### PR TITLE
Travis implementation supporting  build and doc generation of  four targets 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+sudo: required
+dist: trusty
+cache: ccache
+
+language:
+  - c++
+# - objective-c
+
+os:
+  - linux
+  - osx
+  
+compiler:
+  - gcc
+  - clang
+
+branches:
+  only:
+  - master
+  - /^feature.*$/
+
+before_script:
+  - |
+    if [ $TRAVIS_OS_NAME == linux ]; then
+       sudo apt-get update -q
+       sudo apt-get install -y libxinerama-dev libxcursor-dev libasound2-dev
+       sudo apt-get install -y doxygen 
+    elif [ $TRAVIS_OS_NAME == osx ]; then
+      brew install ccache # need to install on OSX
+      export PATH="/usr/local/opt/ccache/libexec:$PATH"
+      brew install doxygen
+    fi
+
+script:
+  - |
+    autoconf
+    ./configure
+    make
+
+after_success:
+  - |
+    if [ $TRAVIS_OS_NAME == linux ]; then
+      doxygen --version
+      cd documentation
+      make html
+      cd -
+    fi
+
+notifications:
+  email:
+    recipients:
+      - fabien@onepost.net
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,17 @@ compiler:
   - gcc
   - clang
 
+env:
+  - |
+    ANALYZE=false
+    DOC=false
+
+matrix:
+  include:
+    os: linux
+    compiler: clang
+    env: ANALYZE=true DOC=true
+
 branches:
   only:
   - master
@@ -33,13 +44,23 @@ before_script:
 
 script:
   - |
-    autoconf
-    ./configure
-    make
+   if [ $ANALYZE = "false" ]; then
+     autoconf
+     ./configure
+     make
+     mkdir cmake-build
+     cmake -G "Unix Makefiles" -S .  -B"./cmake-build"
+     cd cmake-build
+     make
+   else
+     scan-build cmake -G "Unix Makefiles"
+     scan-build --status-bugs -v
+     make
+   fi
 
 after_success:
   - |
-    if [ $TRAVIS_OS_NAME == linux ]; then
+    if [ $DOC = "true" ]; then
       doxygen --version
       cd documentation
       make html
@@ -50,4 +71,4 @@ notifications:
   email:
     recipients:
       - fabien@onepost.net
-
+      


### PR DESCRIPTION
This implementation differs from existing fltk-test and also gitlab implementations :
 - minimum, fast light implementation: stripped all unused constructions compared to other implementations
 - supports successful builds of four targets (linux, osx and then gcc and clang for each of them)
- uses before_script instead of before_install
- uses after_success for building documentation, instead of building always if error
- only builds documentation on linux targets for now (can easily change in future)
As I don't have access to travis on this branch one can check the results on my other fork [here](https://travis-ci.org/fab672000/fltk)