### PR TITLE
Update Fl_Check_Browser.cxx

### DIFF
--- a/src/Fl_Check_Browser.cxx
+++ b/src/Fl_Check_Browser.cxx
@@ -186,7 +186,7 @@ void Fl_Check_Browser::item_draw(void *v, int X, int Y, int, int) const {
 	int cy = Y + (tsize + 1 - CHECK_SIZE) / 2;
 	X += 2;
 
-	fl_color(active_r() ? FL_FOREGROUND_COLOR : fl_inactive(FL_FOREGROUND_COLOR));
+	fl_color(active_r() ? textcolor() : fl_inactive(textcolor()));
 	fl_loop(X, cy, X, cy + CHECK_SIZE,
 	        X + CHECK_SIZE, cy + CHECK_SIZE, X + CHECK_SIZE, cy);
 	if (i->checked) {


### PR DESCRIPTION
Better to use a parameterized  color (Fl_Browser_::textcolor()) rather than a fixed color (FL_FOREGROUND_COLOR).
Useful when theming the widgets using custom background/foreground colors.