### PR TITLE
enabling static compiling exe with mingw under linux

### DIFF
--- a/CMake/options.cmake
+++ b/CMake/options.cmake
@@ -75,6 +75,9 @@ endif (UNIX)
 ##  May be removed once high-DPI support under Windows is complete.
 #######################################################################
 if (WIN32)
+  if(CMAKE_COMPILER_IS_MINGW)
+    set(CMAKE_EXE_LINKER_FLAGS "-static")
+  endif ()
   option(OPTION_HIDPI "build with experimental high-DPI support" OFF)
   if (OPTION_HIDPI)
     add_definitions("-DFLTK_HIDPI_SUPPORT")


### PR DESCRIPTION
This is proposed solution.

Otherwise you will get error: 
> This application has failed to start because **libgcc_s_sjlj-1.dll** was not found. Re-installing the application may fix this problem.