### PR TITLE
Fluid: when linking include LDFLAGS last

### DIFF
--- a/fluid/Makefile
+++ b/fluid/Makefile
@@ -55,7 +55,7 @@ all:	$(FLUID) fluid$(EXEEXT)
 fluid$(EXEEXT):		$(OBJECTS) $(LIBNAME) $(FLLIBNAME) \
 			$(IMGLIBNAME)
 	echo Linking $@...
-	$(CXX) $(ARCHFLAGS) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECTS) $(LINKFLTKFORMS) $(LINKFLTKIMG) $(LDLIBS)
+	$(CXX) $(ARCHFLAGS) $(CXXFLAGS) -o $@ $(OBJECTS) $(LINKFLTKFORMS) $(LINKFLTKIMG) $(LDFLAGS) $(LDLIBS)
 	$(OSX_ONLY) $(RM) -r -f fluid.app/Contents/MacOS
 	$(OSX_ONLY) mkdir fluid.app/Contents/MacOS
 	$(OSX_ONLY) $(INSTALL_BIN) fluid fluid.app/Contents/MacOS
@@ -63,7 +63,7 @@ fluid$(EXEEXT):		$(OBJECTS) $(LIBNAME) $(FLLIBNAME) \
 fluid-shared$(EXEEXT):	$(OBJECTS) ../src/$(DSONAME) ../src/$(FLDSONAME) \
 			../src/$(IMGDSONAME)
 	echo Linking $@...
-	$(CXX) $(ARCHFLAGS) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECTS) $(LINKSHARED) $(LDLIBS)
+	$(CXX) $(ARCHFLAGS) $(CXXFLAGS) -o $@ $(OBJECTS) $(LINKSHARED) $(LDFLAGS) $(LDLIBS)
 
 clean:
 	-$(RM) *.o core.* *~ *.bck *.bak


### PR DESCRIPTION
LDFLAGS often contains "-L*" flags to tell the linker where to search for libraries. If these are included -before- the ones used for internal linkage, and FLTK is already installed on the system, then the already-installed FLTK libraries can be found before those internal to the build. Moving the LDFLAGS to the end generally solves this issue. Worst case the move won't hurt linking since all of the flags are still included in the link command.