### PR TITLE
Fix JIS Keyboard dead keys

### DIFF
--- a/src/drivers/Cocoa/Fl_Cocoa_Screen_Driver.cxx
+++ b/src/drivers/Cocoa/Fl_Cocoa_Screen_Driver.cxx
@@ -249,6 +249,7 @@ void Fl_Cocoa_Screen_Driver::insertion_point_location(int x, int y, int height) 
 int Fl_Cocoa_Screen_Driver::compose(int &del) {
   int condition;
   int has_text_key = Fl::compose_state || Fl::e_keysym <= '~' || Fl::e_keysym == FL_Iso_Key ||
+  Fl::e_keysym == FL_JIS_Underscore || Fl::e_keysym == FL_Yen ||
   (Fl::e_keysym >= FL_KP && Fl::e_keysym <= FL_KP_Last && Fl::e_keysym != FL_KP_Enter);
   condition = Fl::e_state&(FL_META | FL_CTRL) ||
   (Fl::e_keysym >= FL_Shift_L && Fl::e_keysym <= FL_Alt_R) || // called from flagsChanged


### PR DESCRIPTION
Underscore key and Yen key do not work properly in Japanese keyboard. This patch fixes the problem.