### PR TITLE
Eliminate -Wunknown-pragmas and -Wsign-compare warnings on GCC

### DIFF
--- a/src/Fl_Native_File_Chooser_GTK.cxx
+++ b/src/Fl_Native_File_Chooser_GTK.cxx
@@ -519,7 +519,7 @@ static char *text_file_preview(const char *fname) {
   int len = fread(text, 1, 4010, in);
   fclose(in);
   text[len] = 0;
-  if (strlen(text) < len) text[0] = 0; // presence of null byte in file --> not text
+  if ((int)strlen(text) < len) text[0] = 0; // presence of null byte in file --> not text
   char *p = text;
   int count = 0;
   const char *end = text + strlen(text);

--- a/src/Fl_x.cxx
+++ b/src/Fl_x.cxx
@@ -1268,8 +1268,10 @@ static long getIncrData(uchar* &data, const XSelectionEvent& selevent, long lowe
   Note: '#pragma GCC diagnostic push' needs at least GCC 4.6.
 */
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 #if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 5))
 #pragma GCC diagnostic push
@@ -1284,7 +1286,9 @@ static KeySym fl_KeycodeToKeysym(Display *d, KeyCode k, unsigned i) {
 #pragma GCC diagnostic pop
 #endif
 
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 #if USE_XRANDR
 static void react_to_screen_reconfiguration() {


### PR DESCRIPTION
Those are the warnings I currently get using `-Wall -O3`:
```
fltk/src/Fl_x.cxx:1271:0: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
 #pragma clang diagnostic push
 
fltk/src/Fl_x.cxx:1272:0: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
fltk/src/Fl_x.cxx:1287:0: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
 #pragma clang diagnostic pop
 
fltk/src/Fl_Native_File_Chooser_GTK.cxx: In function ‘char* text_file_preview(const char*)’:
fltk/src/Fl_Native_File_Chooser_GTK.cxx:522:20: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (strlen(text) < len) text[0] = 0; // presence of null byte in file --> not text
       ~~~~~~~~~~~~~^~~~~
```