### PR TITLE
Fix "misleading indentation" in Fl_Text_Buffer.cxx

### DIFF
--- a/src/Fl_Text_Buffer.cxx
+++ b/src/Fl_Text_Buffer.cxx
@@ -1373,7 +1373,7 @@ void Fl_Text_Buffer::replace_selection_(Fl_Text_Selection * sel,
     return;
   
   /* Do the appropriate type of replace */
-    replace(start, end, text);
+  replace(start, end, text);
   
   /* Unselect (happens automatically in BufReplace, but BufReplaceRect
    can't detect when the contents of a selection goes away) */


### PR DESCRIPTION
Compiling with clang produced the following warning on this line:

src/Fl_Text_Buffer.cxx:1292:5: warning: misleading indentation; statement is not part of the previous 'if' [-Wmisleading-indentation]
    replace(start, end, text);
    ^
src/Fl_Text_Buffer.cxx:1288:3: note: previous statement is here
  if (!sel->position(&start, &end))
  ^