### PR TITLE
Quick fix for inability to link with pango from fltk-config

### DIFF
--- a/CMake/options.cmake
+++ b/CMake/options.cmake
@@ -469,6 +469,7 @@ if(X11_Xft_FOUND AND OPTION_USE_PANGO)
     find_library(HAVE_LIB_PANGO pango-1.0 ${CMAKE_LIBRARY_PATH})
     find_library(HAVE_LIB_PANGOXFT pangoxft-1.0 ${CMAKE_LIBRARY_PATH})
     set(USE_PANGO TRUE)
+    list(APPEND FLTK_LDLIBS -lpango-1.0 -lpangoxft-1.0 -lgobject-2.0)
   else(PANGOXFT_FOUND)
   
 #this covers Debian, Ubuntu, FreeBSD, NetBSD, Darwin


### PR DESCRIPTION
Commit 6fe226cb804d000b29ea53e08acc505267fd44de introduced use of pkg-config which broke linking from fltk-config if FLTK was configured to use pango library.

This patch duplicates line from another if branch that just adds libraries assuming that if pkg-config found pangoxft that there are present all it's requirements.