### PR TITLE
Convert Fl_Group::array_ to union to better represent its behavior

### DIFF
--- a/FL/Fl_Group.H
+++ b/FL/Fl_Group.H
@@ -41,7 +41,10 @@ class Fl_Rect;
 */
 class FL_EXPORT Fl_Group : public Fl_Widget {
 
-  Fl_Widget** array_;
+  union {
+    Fl_Widget** arrayN_;
+    Fl_Widget* array1_;
+  };
   Fl_Widget* savedfocus_;
   Fl_Widget* resizable_;
   int children_;


### PR DESCRIPTION
While using b0e0c355edaa2e23148cb0260ada907aec930f05 with Visual Studio 2019, I encountered crashes in Release that would not reproduce during Debug. While debugging the crash in release mode, I saw that `Fl_Group::array_` had unexpected invalid pointer values. Based on things not reproducing in Debug, I assumed the crash to be related to some undefined behavior.

Reading through the code, I noticed the re-use of `array_` to sometimes be of type `Fl_Widget*`, but sometimes as `Fl_Widget**`. This is a common source of UB pitfalls, so I rewrote it using a union to make things clearer (similar to other parts of the code). This rewrite fixed the crashes I experienced.

My code that caused the crashes was quite innocuous:
```cpp
struct MyWidget : Fl_Group
{
  MyWidget(int x, int y, int w, int h, const char* label = 0)
    : Fl_Group(x, y, w, h, label)
    , inner_widget(x, y, w, h) // crashes during inner_widget's constructor while adding to the superclass' group
  { this->end(); }

  Fl_Output inner_widget;
};
```

Specific OS/Platform details:
- Visual Studio Community 2019 Version 16.6.3
- MSVC 19.26.28806 Native x64 -> x64 Tools
- Windows 10.0.18363