### PR TITLE
save fl_file_chooser directory on cancel (STR3225)

### DIFF
--- a/src/fl_file_dir.cxx
+++ b/src/fl_file_dir.cxx
@@ -138,8 +138,15 @@ fl_file_chooser(const char *message,    // I - Message in titlebar
         *retname = 0;
       const char *n = fl_filename_name(retname);
       if (n) *((char*)n) = 0;
-      fc->value("");
-      fc->directory(retname);
+      if (*retname) {
+        fc->value("");
+        fc->directory(retname);
+      } else {
+        char dirsave[FL_PATH_MAX];
+        strlcpy(dirsave, fc->directory(), sizeof(dirsave));
+        fc->value("");          // also resets directory to "system default"
+        fc->directory(dirsave); // so reset directory back where we were
+      }
     } else {
        fc->value(fname);
     }


### PR DESCRIPTION
by default, the fl_file_chooser() starts in the current directory
if no filename is given, but the directory is reset to the "system
directory" if the dialog is cancelled without choosing a file.
This patch saves and restores the directory if no file is chosen.

See also https://www.fltk.org/str.php?L3225