### PR TITLE
Simplify, clarify and fix bugs in test/demo.cxx

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,8 +15,8 @@
 #
 #######################################################################
 
-set (EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../bin/examples)
-set (TESTFILE_PATH ${EXECUTABLE_OUTPUT_PATH})
+set (EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../bin)
+set (TESTFILE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../data)
 
 include (../CMake/FLTK-Functions.cmake)
 include (../CMake/fl_create_example.cmake)
@@ -204,13 +204,11 @@ endif (NOT ANDROID)
 
 # We need some support files for the demo programs:
 
-# Note: this is incomplete as of 11 Feb 2015
-# Todo: currently all files are copied, but some of them need configuration:
-# - demo.menu: fluid can't be started (wrong path)
+# Note: this is incomplete as of July 2020
+# Todo: currently all files are copied, but some of them may need configuration:
 # - demo.menu: help_dialog (help_dialog.html) can't find its images (not copied)
-# - maybe more ...
 
-# create data directory for test and demo programs
+# create data directory for test and demo programs if it doesn't exist
 file (MAKE_DIRECTORY ${TESTFILE_PATH})
 
 # copy the test files
@@ -221,12 +219,15 @@ file (COPY
   DESTINATION ${TESTFILE_PATH}
 )
 
+# the main test program 'demo' needs additional hints and configurations
+
+target_compile_definitions (demo PRIVATE GENERATED_BY_CMAKE)
+target_compile_definitions (demo PRIVATE CMAKE_SOURCE_PATH="${CMAKE_CURRENT_SOURCE_DIR}")
+
 # Apple macOS creates bundles instead of executables and needs a little bit
 # more help for demos to run correctly
 
 if (APPLE AND (NOT OPTION_APPLE_X11) AND (NOT OPTION_APPLE_SDL))
-
-  target_compile_definitions (demo PUBLIC USING_XCODE)
 
   # make the menu structure part of the app
   target_sources (demo PRIVATE demo.menu)

--- a/test/demo.menu
+++ b/test/demo.menu
@@ -58,7 +58,7 @@
 	@u:fast && slow widgets:fast_slow
 	@u:inactive:inactive
 
-@main:Fluid\n(UI design tool):../fluid/fluid valuators.fl
+@main:Fluid\n(UI design tool):fluid valuators.fl
 
 @main:Cool\nDemos...:@e
 	@e:X Color\nBrowser:colbrowser


### PR DESCRIPTION
This PR clarifies the special cases in `test/demo.cxx` regarding different build systems and platform specific code.

**The goal is to de-duplicate code and to reduce platform specific code to a minimum.**

I also added a big comment describing the different directory layouts of the different build systems for future development. See [test/demo.cxx](https://github.com/Albrecht-S/fltk/blob/b482fcd0e058106a7837f60ca84b9be859a3532d/test/demo.cxx#L20).

Before this commit some of the `test/demo` programs could not be started in some builds (e.g. `Visual Studio`) because the paths differ between the classic (`autoconf/make`) and the new `CMake` generated build systems.

This should all be fixed now. I could test successfully under Windows and Linux but I'd like to see confirmations from others (see also the commit comments).

Summary of important changes:
- For `CMake` builds I removed the '`/examples`' folder so all executable (fluid and test/demo) programs are now directly in the `/bin` folder of the build root.
- I also added a new folder `/data` in the build root (same level as `/bin`). All test support (data) files including `demo.menu` are now in this folder to keep them apart from the executables.
- [Edit] There's no longer an executable path `../fluid` in `demo.menu` - this is handled in the demo program depending on the build system (**bug fix**). [/Edit]

For all other changes please refer to the source file `test/demo.cxx`.