### PR TITLE
Fix issue with Fl_Tiled_Image: does not correctly draw to widget sub-region

### DIFF
--- a/src/Fl_Tiled_Image.cxx
+++ b/src/Fl_Tiled_Image.cxx
@@ -182,12 +182,12 @@ Fl_Tiled_Image::draw(int X,     // I - Starting X position
   if (cx > 0) iw -= cx;         // crop image
   if (cy > 0) ih -= cy;
 
-  for (int yy = Y; yy < H; yy += ih) {
+  for (int yy = Y; yy < Y+H; yy += ih) {
     if (fl_not_clipped(X,yy,W,ih)) {
-      for (int xx = X; xx < W; xx += iw) {
-        if (fl_not_clipped(xx,yy,iw,ih)) {
-          image_->draw(xx,yy,iw,ih,cx,cy);
-        }
+      for (int xx = X; xx < X+W; xx += iw) {
+	if (fl_not_clipped(xx,yy,iw,ih)) {
+	  image_->draw(xx,yy,iw,ih,cx,cy);
+	}
       }
     }
   }

--- a/test/unittest_images.cxx
+++ b/test/unittest_images.cxx
@@ -20,6 +20,36 @@
 #include <FL/Fl_Check_Button.H>
 #include <FL/fl_draw.H>
 
+#ifdef TILE_IMAGE
+#include <FL/Fl_Tiled_Image.H>
+
+// A grey+white pixmap to use as a checker board background
+static const char *const checker_xpm[] = {"20 20 2 1",
+                                          " 	c #CCCCCCCCCCCC",
+                                          ".	c #FFFFFFFFFFFF",
+                                          "          ..........",
+                                          "          ..........",
+                                          "          ..........",
+                                          "          ..........",
+                                          "          ..........",
+                                          "          ..........",
+                                          "          ..........",
+                                          "          ..........",
+                                          "          ..........",
+                                          "          ..........",
+                                          "..........          ",
+                                          "..........          ",
+                                          "..........          ",
+                                          "..........          ",
+                                          "..........          ",
+                                          "..........          ",
+                                          "..........          ",
+                                          "..........          ",
+                                          "..........          ",
+                                          "..........          "};
+
+#endif
+
 // Note: currently (March 2010) fl_draw_image() supports transparency with
 //       alpha channel only on Apple (Mac OS X), but Fl_RGB_Image->draw()
 //       supports transparency on all platforms !
@@ -154,6 +184,10 @@ public:
   Fl_Radio_Button *rb_LXp1;
   Fl_Button *refresh;
 
+#ifdef TILE_IMAGE
+  Fl_Tiled_Image *checkerBoard;
+#endif
+
   ImageTest(int x, int y, int w, int h) : Fl_Group(x, y, w, h) {
     label("Testing Image Drawing\n\n"
         "This test renders four images, two of them with a checker board\n"
@@ -193,6 +227,10 @@ public:
     ctr_grp->box(FL_BORDER_BOX);
     ctr_grp->end();
     end(); // make sure this ImageTest group is closed
+
+#ifdef TILE_IMAGE
+    checkerBoard = new Fl_Tiled_Image(new Fl_Pixmap((const char *const *)checker_xpm));
+#endif
   } // constructor ends
 
   void draw() {
@@ -221,8 +259,12 @@ public:
     fl_color(FL_BLACK); fl_rect(xx, yy, 130, 130);      // black frame
     fl_color(FL_WHITE); fl_rectf(xx+1, yy+1, 128, 128); // white background
     if (CB) { // checker board
+#ifdef TILE_IMAGE
+      checkerBoard->draw(xx+1, yy+1, 128, 128);
+#else
       fl_color(FL_BLACK); fl_rectf(xx+65, yy+1, 64, 64);
       fl_color(FL_BLACK); fl_rectf(xx+1, yy+65, 64, 64);
+#endif
     }
     if (IMG) {
       i_rgba->draw(xx+1,yy+1);
@@ -260,8 +302,12 @@ public:
     fl_color(FL_BLACK); fl_rect(xx, yy, 130, 130);      // black frame
     fl_color(FL_WHITE); fl_rectf(xx+1, yy+1, 128, 128); // white background
     if (CB) { // checker board
+#ifdef TILE_IMAGE
+      checkerBoard->draw(xx+1, yy+1, 128, 128);
+#else
       fl_color(FL_BLACK); fl_rectf(xx+65, yy+1, 64, 64);
       fl_color(FL_BLACK); fl_rectf(xx+1, yy+65, 64, 64);
+#endif
     }
     if (IMG) {
       i_ga->draw(xx+1,yy+1);


### PR DESCRIPTION
Discovered while trying to use Fl_Tiled_Image into a sub-region of my window that it does not draw correctly.

Fl_Tiled_Image/draw() is written as if the W / H parameters are "rect right" / "rect bottom" instead of width/height.

To demonstrate, I've included a modified version of unittest_images.cxx. If the unittests project is built with TILE_IMAGE defined, the "drawing images" unit test will use a pixmap and  Fl_Tiled_Image to draw the "checker board" background behind the images.

Without the fix, you will not see the checker board. With the fix, the checker board is shown.
The other test program, tiled_image, is unaffected.
