### PR TITLE
Make building fluid optional (ON by default)

### DIFF
--- a/CMake/export.cmake
+++ b/CMake/export.cmake
@@ -33,9 +33,11 @@ if (CMAKE_CROSSCOMPILING)
     PROPERTIES IMPORTED_LOCATION ${FLUID_PATH}
   )
 else ()
-  add_subdirectory(fluid)
-  set (FLTK_FLUID_EXECUTABLE fluid)
-  set (FLUID fluid) # export
+  if(OPTION_BUILD_FLUID)
+    add_subdirectory(fluid)
+    set (FLTK_FLUID_EXECUTABLE fluid)
+    set (FLUID fluid) # export
+  endif(OPTION_BUILD_FLUID)
 endif (CMAKE_CROSSCOMPILING)
 
 add_subdirectory(src)

--- a/CMake/export.cmake
+++ b/CMake/export.cmake
@@ -33,11 +33,11 @@ if (CMAKE_CROSSCOMPILING)
     PROPERTIES IMPORTED_LOCATION ${FLUID_PATH}
   )
 else ()
-  if(OPTION_BUILD_FLUID)
+  if(FLTK_BUILD_FLUID)
     add_subdirectory(fluid)
     set (FLTK_FLUID_EXECUTABLE fluid)
     set (FLUID fluid) # export
-  endif(OPTION_BUILD_FLUID)
+  endif(FLTK_BUILD_FLUID)
 endif (CMAKE_CROSSCOMPILING)
 
 add_subdirectory(src)

--- a/CMake/options.cmake
+++ b/CMake/options.cmake
@@ -115,7 +115,7 @@ option (OPTION_BUILD_SHARED_LIBS
 #######################################################################
 option (OPTION_PRINT_SUPPORT "allow print support" ON)
 option (OPTION_FILESYSTEM_SUPPORT "allow file system support" ON)
-
+option (OPTION_BUILD_FLUID "Build fluid RAD tool" ON)
 option (FLTK_BUILD_TEST     "Build test/demo programs" ON)
 option (FLTK_BUILD_EXAMPLES "Build example programs"   OFF)
 

--- a/CMake/options.cmake
+++ b/CMake/options.cmake
@@ -115,7 +115,7 @@ option (OPTION_BUILD_SHARED_LIBS
 #######################################################################
 option (OPTION_PRINT_SUPPORT "allow print support" ON)
 option (OPTION_FILESYSTEM_SUPPORT "allow file system support" ON)
-option (OPTION_BUILD_FLUID "Build fluid RAD tool" ON)
+option (FLTK_BUILD_FLUID "Build fluid RAD tool" ON)
 option (FLTK_BUILD_TEST     "Build test/demo programs" ON)
 option (FLTK_BUILD_EXAMPLES "Build example programs"   OFF)
 


### PR DESCRIPTION
Hello
Sometimes it doesn't make much sense to build fluid by default, especially when only the library is needed, such as with package managers etc.
I've modified the cmake files to make building fluid optional, and set it to be ON by default as to not break older builds. The build can be turned off using the cmake definition "-DOPTION_BUILD_FLUID=OFF " when invoking cmake from the command line.