### PR TITLE
read_win_rectangle_unscaled: Fix a memory leak and …

### DIFF
--- a/src/drivers/WinAPI/Fl_WinAPI_Screen_Driver.cxx
+++ b/src/drivers/WinAPI/Fl_WinAPI_Screen_Driver.cxx
@@ -504,13 +504,7 @@ Fl_WinAPI_Screen_Driver::read_win_rectangle(
 Fl_RGB_Image *Fl_WinAPI_Screen_Driver::read_win_rectangle_unscaled(int X, int Y, int w, int h, Fl_Window *win)
 {
   int   d = 3;                  // Depth of image
-  int alpha = 0; uchar *p = NULL;
-  // Allocate the image data array as needed...
-  const uchar *oldp = p;
-  if (!p) p = new uchar[w * h * d];
-
-  // Initialize the default colors/alpha in the whole image...
-  memset(p, alpha, w * h * d);
+  int alpha = 0; 
 
   // Grab all of the pixels in the image...
 
@@ -534,7 +528,12 @@ Fl_RGB_Image *Fl_WinAPI_Screen_Driver::read_win_rectangle_unscaled(int X, int Y,
     Y = 0;
   }
 
-  if (h < 1 || w < 1) return 0/*p*/;            // nothing to copy
+  if (h < 1 || w < 1) return 0;		// nothing to copy
+
+  // Allocate and initialize the image data array
+  size_t arraySize = (size_t)d * w * h;
+  uchar *p = new uchar[arraySize];
+  memset(p, alpha, arraySize);
 
   int line_size = ((3*w+3)/4) * 4;      // each line is aligned on a DWORD (4 bytes)
   uchar *dib = new uchar[line_size*h];  // create temporary buffer to read DIB
@@ -592,7 +591,7 @@ Fl_RGB_Image *Fl_WinAPI_Screen_Driver::read_win_rectangle_unscaled(int X, int Y,
   delete[] dib;         // delete DIB temporary buffer
 
   Fl_RGB_Image *rgb = new Fl_RGB_Image(p, w, h, d);
-  if (!oldp) rgb->alloc_array = 1;
+  rgb->alloc_array = 1;
   return rgb;
 }
 


### PR DESCRIPTION
…awkward code from the drivers conversion.

In FLTK 1.3, the `p` array could be passed in, thus the usage of `oldp` construct. In FLTK 1.4, the code _always_ allocates the array, allowing the suggested changes.

The memory leak occurs in the very unusual situation that there is "nothing to copy" and is fixed by allocating after that check.

[Discovered via cppcheck 2.2]