### PR TITLE
Backport fix from the 1.3 branch to resolve issues an issue with _strdup not being defined.

### DIFF
--- a/src/flstring.h
+++ b/src/flstring.h
@@ -48,7 +48,7 @@
 #    undef index
 #  endif /* index */
 
-#  if defined(WIN32) && !defined(__CYGWIN__)
+#  if defined(WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__)
 #    define strcasecmp(s,t)	_stricmp((s), (t))
 #    define strncasecmp(s,t,n)	_strnicmp((s), (t), (n))
 // Visual C++ 2005 incorrectly displays a warning about the use of POSIX APIs


### PR DESCRIPTION
This resolves an issue when trying to compile FLTK 1.1 with MinGW because _strdup doesn't exist but the regular strdup function does.

The change was a direct copy and paste from flstring.h from the 1.3 branch.