### PR TITLE
Backport friend fix from the 1.3 branch.

### DIFF
--- a/fluid/Fl_Type.h
+++ b/fluid/Fl_Type.h
@@ -44,7 +44,7 @@ void set_modflag(int mf);
 class Fl_Type {
 
   friend class Widget_Browser;
-  friend Fl_Widget *make_type_browser(int,int,int,int,const char *l=0);
+  friend Fl_Widget *make_type_browser(int,int,int,int,const char *);
   friend class Fl_Window_Type;
   virtual void setlabel(const char *); // virtual part of label(char*)
 


### PR DESCRIPTION
The l=0 was removed in the 1.3 branch. Also the Debian maintainers did this for FLTK 1.1.