### PR TITLE
Fix min not defined compiler error (without using std::min) by using the same method the Debian maintainers did by moving it down

### DIFF
--- a/src/fl_draw.cxx
+++ b/src/fl_draw.cxx
@@ -39,6 +39,7 @@
 #include <ctype.h>
 #include <math.h>
 
+#undef min
 #define min(a,b) ((a)<(b)?(a):(b))
 #define MAXBUF 1024
 

--- a/src/fl_draw.cxx
+++ b/src/fl_draw.cxx
@@ -32,7 +32,6 @@
 // Expands all unprintable characters to ^X or \nnn notation
 // Aligns them against the inside of the box.
 
-#define min(a,b) ((a)<(b)?(a):(b))
 #include <FL/fl_draw.H>
 #include <FL/Fl_Image.H>
 
@@ -40,6 +39,7 @@
 #include <ctype.h>
 #include <math.h>
 
+#define min(a,b) ((a)<(b)?(a):(b))
 #define MAXBUF 1024
 
 char fl_draw_shortcut;	// set by fl_labeltypes.cxx


### PR DESCRIPTION
This accomplishes the same goal as my previous pull request except it doesn't use std:: which is not acceptable per the FLTK CMP as discussed here: https://github.com/fltk/fltk/pull/169