### PR TITLE
Fix stack corruption when loading GIF

### DIFF
--- a/src/Fl_GIF_Image.cxx
+++ b/src/Fl_GIF_Image.cxx
@@ -337,7 +337,7 @@ void Fl_GIF_Image::load_gif_(Fl_Image_Reader &rdr)
 
     if (CurCode == EOFCode) break;
 
-    uchar OutCode[1025]; // temporary array for reversing codes
+    uchar OutCode[4097]; // temporary array for reversing codes
     uchar *tp = OutCode;
     int i;
     if (CurCode < FreeCode) i = CurCode;


### PR DESCRIPTION

I have a GIF image which repeatedly causes a "Stack corruption around OutCode" error in Fl_GIF_Image.cxx while running in Visual Studio.

After examining several GIF decode implementations, including one also derived from gif2ras
[see(https://www.unf.edu/public/cap6400/ychua/xv-2.21/xvgif.c)] I've determined that OutCode needs to be at least 4096, not the current 1024.

After changing the array size to 4097, the stack corruption no longer happens for the GIF image in question.

The GIF image which causes the error is attached in this ZIP [yes, it's SFW].

[animu.ru-clannad-(2560x1920)-wallpaper-001.gif.zip](https://github.com/fltk/fltk/files/6118016/animu.ru-clannad-.2560x1920.-wallpaper-001.gif.zip)
