### PR TITLE
failure to call pclose

### DIFF
--- a/examples/table-sort.cxx
+++ b/examples/table-sort.cxx
@@ -239,6 +239,7 @@ void MyTable::load_command(const char *cmd) {
     rows((int)rowdata_.size());
     // Auto-calculate widths, with 20 pixel padding
     autowidth(20);
+    pclose(fp);
 }
 
 // Callback whenever someone clicks on different parts of the table


### PR DESCRIPTION
pipe is opened with `popen()` but `pclose()` is not called.

Source:
Coverity Scan: Windows build (VC++ 2019)
Reported as "Resource Leak"