### PR TITLE
Fix potential memory leak

### DIFF
--- a/src/drivers/WinAPI/Fl_WinAPI_Window_Driver.cxx
+++ b/src/drivers/WinAPI/Fl_WinAPI_Window_Driver.cxx
@@ -475,7 +475,10 @@ void Fl_WinAPI_Window_Driver::hide() {
     }
   }
 
-  if (hide_common()) return;
+  if (hide_common()) {
+    delete[] doit; // note: `count` and `doit` may be NULL (see PR #241)
+    return;
+  }
 
   // make sure any custom icons get freed
 //  icons(NULL, 0); // free_icons() is called by the Fl_Window destructor


### PR DESCRIPTION
Allocated object not freed on return from successful `hide_common` call.

Source: 
Coverity Scan : Windows build (VC++ 2019)
