### PR TITLE
Fix use of variable out-of-scope

### DIFF
--- a/src/Fl_File_Chooser2.cxx
+++ b/src/Fl_File_Chooser2.cxx
@@ -1491,9 +1491,9 @@ Fl_File_Chooser::value(const char *filename)
     return;
   }
 
+  char fixpath[FL_PATH_MAX];                   // Path with slashes converted
   if (Fl::system_driver()->backslash_as_slash()) {
     // See if the filename contains backslashes...
-    char        fixpath[FL_PATH_MAX];                   // Path with slashes converted
     if (strchr(filename, '\\')) {
       // Convert backslashes to slashes...
       strlcpy(fixpath, filename, sizeof(fixpath));


### PR DESCRIPTION
fixpath goes out-of-scope but is subsequently used as `filename`.

Note: the issue was reported using a Linux build, but would manifest on Windows [backslashes in path].

Source:
Coverity Scan: Linux build (gcc 9.3.0)
