### PR TITLE
Let beep use system default settings

### DIFF
--- a/src/drivers/X11/Fl_X11_Screen_Driver.cxx
+++ b/src/drivers/X11/Fl_X11_Screen_Driver.cxx
@@ -411,17 +411,19 @@ void Fl_X11_Screen_Driver::screen_dpi(float &h, float &v, int n)
 
 void Fl_X11_Screen_Driver::beep(int type)
 {
+
+  int vol;
   switch (type) {
-    case FL_BEEP_DEFAULT :
     case FL_BEEP_ERROR :
-      if (!fl_display) open_display();
-      XBell(fl_display, 0);
+      vol = 100;
       break;
+    case FL_BEEP_DEFAULT :
     default :
-      if (!fl_display) open_display();
-      XBell(fl_display, 50);
+      vol = 0;
       break;
   }
+  if (!fl_display) open_display();
+  XBell(fl_display, vol);
 }
 
 

--- a/src/drivers/X11/Fl_X11_Screen_Driver.cxx
+++ b/src/drivers/X11/Fl_X11_Screen_Driver.cxx
@@ -415,7 +415,7 @@ void Fl_X11_Screen_Driver::beep(int type)
     case FL_BEEP_DEFAULT :
     case FL_BEEP_ERROR :
       if (!fl_display) open_display();
-      XBell(fl_display, 100);
+      XBell(fl_display, 0);
       break;
     default :
       if (!fl_display) open_display();

--- a/src/drivers/X11/Fl_X11_Screen_Driver.cxx
+++ b/src/drivers/X11/Fl_X11_Screen_Driver.cxx
@@ -411,7 +411,6 @@ void Fl_X11_Screen_Driver::screen_dpi(float &h, float &v, int n)
 
 void Fl_X11_Screen_Driver::beep(int type)
 {
-
   int vol;
   switch (type) {
     case FL_BEEP_ERROR :


### PR DESCRIPTION
Please note that the parameter 'percent' of XBell(3).
Given the value of 100, the system defined setting
(normally specified via xset) is ignored and the
percent of 100 is used instead. When calling the
bell from fltk with FL_BEEP_DEFAULT I would expect
to get the default (system specified) percent setting.