### PR TITLE
Fix fullscreen window level corner cases on macOS

### DIFF
--- a/src/Fl_cocoa.mm
+++ b/src/Fl_cocoa.mm
@@ -3086,7 +3086,9 @@ void Fl_Window::fullscreen_x() {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6
     [i->xid setStyleMask:NSBorderlessWindowMask]; //10.6
 #endif
-    [i->xid setLevel:NSStatusWindowLevel];
+    if ([i->xid level] != NSStatusWindowLevel) {
+      [i->xid setLevel:NSStatusWindowLevel];
+    }
     int sx, sy, sw, sh, X, Y, W, H;
     int top = fullscreen_screen_top;
     int bottom = fullscreen_screen_bottom;

--- a/src/Fl_cocoa.mm
+++ b/src/Fl_cocoa.mm
@@ -3086,8 +3086,12 @@ void Fl_Window::fullscreen_x() {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6
     [i->xid setStyleMask:NSBorderlessWindowMask]; //10.6
 #endif
-    if ([i->xid level] != NSStatusWindowLevel) {
-      [i->xid setLevel:NSStatusWindowLevel];
+    if ([i->xid isKeyWindow]) {
+      if ([i->xid level] != NSStatusWindowLevel) {
+        [i->xid setLevel:NSStatusWindowLevel];
+      }
+    } else if([i->xid level] != NSNormalWindowLevel) {
+      [i->xid setLevel:NSNormalWindowLevel];
     }
     int sx, sy, sw, sh, X, Y, W, H;
     int top = fullscreen_screen_top;

--- a/src/Fl_cocoa.mm
+++ b/src/Fl_cocoa.mm
@@ -3089,9 +3089,11 @@ void Fl_Window::fullscreen_x() {
     if ([i->xid isKeyWindow]) {
       if ([i->xid level] != NSStatusWindowLevel) {
         [i->xid setLevel:NSStatusWindowLevel];
+        fixup_window_levels();
       }
     } else if([i->xid level] != NSNormalWindowLevel) {
       [i->xid setLevel:NSNormalWindowLevel];
+      fixup_window_levels();
     }
     int sx, sy, sw, sh, X, Y, W, H;
     int top = fullscreen_screen_top;


### PR DESCRIPTION
I'll begin with my understanding of the intended window levels from the `windowDidResignKey` and `windowDidBecomeKey` functions:

* Fullscreen non keyWindow = `NSNormalWindowLevel`
* Fullscreen keyWindow = `NSStatusWindowLevel`

Our application listens to `FL_SCREEN_CONFIGURATION_CHANGED` to be able to handle when a new monitor has been added while the window is in fullscreen. When this happens we need to call FLTK's `fullscreen_x()` to enable fullscreen on the new monitor as well. The function needs to be called while the window already is in fullscreen.

It's possible that this happens when the fullscreen window isn't keyWindow, and in this case the proper level seems to be `NSNormalWindowLevel` instead of `NSStatusWindowLevel`.

We also want to avoid re-stacking windows within the same level, this happens when setting level to the same value again. The window who's level was re-set will appear in front. This was already mentioned in a comment in `fixup_window_levels()`.

Lastly, when the level of a window changes we should make sure the stacking is correct for modal and non-modal windows, this is done using `fixup_window_levels()` on other places in the code, we should do the same in `fullscreen_x()`.