### PR TITLE
Only use macOS sheet modals when compiler supports blocks

### DIFF
--- a/src/Fl_Native_File_Chooser_MAC.mm
+++ b/src/Fl_Native_File_Chooser_MAC.mm
@@ -602,7 +602,7 @@ int Fl_Quartz_Native_File_Chooser_Driver::runmodal()
     fname = [preset lastPathComponent];
   }
   if (_directory && !dir) dir = [[NSString alloc] initWithUTF8String:_directory];
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6 && defined(__BLOCKS__)
   if (fl_mac_os_version >= 100600) {
     bool usepath = false;
     NSString *path = nil;


### PR DESCRIPTION
Blocks are a non-standard extension and are not supported by GCC. Sheet
modals require blocks, so let's fall back on a regular modal when blocks
are not supported.

See GCC discussion about block support: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78352
