### PR TITLE
fltk-config: Don't use "-luuid" in shared linking flags on Windows.

### DIFF
--- a/fltk-config.in
+++ b/fltk-config.in
@@ -233,8 +233,18 @@ else
 fi
 
 # Calculate needed libraries
+if test "$OSTYPE" = "msys" -o "$OSTYPE" = "cygwin"; then
+    # Remove "-luuid" from shared linker flags.
+    for lib in $LDLIBS; do
+        if test "$lib" != "-luuid"; then
+            LDSHAREDLIBS="$LDSHAREDLIBS $lib"
+        fi
+    done
+else
+    LDSHAREDLIBS="$LDLIBS"
+fi
 LDSTATIC="$libdir/libfltk.a $LDLIBS"
-LDLIBS="-lfltk$SHAREDSUFFIX $LDLIBS"
+LDLIBS="-lfltk$SHAREDSUFFIX $LDSHAREDLIBS"
 
 if test x$use_forms = xyes; then
     LDLIBS="-lfltk_forms$SHAREDSUFFIX $LDLIBS"


### PR DESCRIPTION
The uuid library just exports various GUIDs. There is no actual shared library with that name on Windows.
The necessary symbols are already (statically) linked into the shared FLTK library. No need to link to it again when linking to the shared FLTK library. It can actually be harmful to link with "-luuid" when (libtool?) projects try to link a shared library with the shared FLTK library.

Remove "-luuid" from the LDFLAGS for "fltk-config --ldflags". But keep it for "fltk-config --ldstaticflags".