### PR TITLE
Fluid: fixed subtype menu to clear the menu when deactivated.

### DIFF
--- a/fluid/Fl_Widget_Type.cxx
+++ b/fluid/Fl_Widget_Type.cxx
@@ -1728,7 +1728,11 @@ Fl_Menu_Item *Fl_Widget_Type::subtypes() {return 0;}
 void subtype_cb(Fl_Choice* i, void* v) {
   if (v == LOAD) {
     Fl_Menu_Item* m = current_widget->subtypes();
-    if (!m) {i->deactivate(); return;}
+    if (!m) {
+      i->clear();
+      i->deactivate();
+      return;
+    }
     i->menu(m);
     int j;
     for (j = 0;; j++) {


### PR DESCRIPTION
If the subtype menu is disabled because there are no subtypes, the deactivated menu will still display the subtype of the last widget that had a subtype value.  Clearing the menu when there are no subtypes fixes this minor inconsistency.