### PR TITLE
Fluid: "Widget Class" subclasses Group but incorrectly shows Window subtypes.

### DIFF
--- a/fluid/Fl_Widget_Type.cxx
+++ b/fluid/Fl_Widget_Type.cxx
@@ -2442,7 +2442,7 @@ void Fl_Widget_Type::write_properties() {
   if (is_spinner() && ((Fl_Spinner*)o)->type() != ((Fl_Spinner*)tplate)->type()) {
     write_string("type");
     write_word(item_name(subtypes(), ((Fl_Spinner*)o)->type()));
-  } else if (o->type() != tplate->type() || is_window()) {
+  } else if (subtypes() && (o->type() != tplate->type() || is_window())) {
     write_string("type");
     write_word(item_name(subtypes(), o->type()));
   }

--- a/fluid/Fl_Window_Type.h
+++ b/fluid/Fl_Window_Type.h
@@ -99,6 +99,9 @@ public:
 };
 
 class Fl_Widget_Class_Type : private Fl_Window_Type {
+protected:
+  Fl_Menu_Item* subtypes() {return 0;}
+
 public:
   Fl_Widget_Class_Type() {
     write_public_state = 0;


### PR DESCRIPTION
In Fluid, if you select New>Code>Widget Class, the resulting entry shows subtypes for Fl_Window but the generated code subclasses Fl_Group (i.e., the selected subtype is ignored).