### PR TITLE
#319: Fixed Live Resize Mode in Fluid

### DIFF
--- a/fluid/Fl_Widget_Type.cxx
+++ b/fluid/Fl_Widget_Type.cxx
@@ -1846,7 +1846,7 @@ void live_mode_cb(Fl_Button*o,void *) {
         Fl_Group::current(0);
         int w = live_widget->w();
         int h = live_widget->h();
-        live_window = new Fl_Double_Window(w+20, h+55, "Fluid Live Mode Widget");
+        live_window = new Fl_Double_Window(w+20, h+55, "Fluid Live Resize");
         live_window->box(FL_FLAT_BOX);
         live_window->color(FL_GREEN);
         Fl_Group *rsz = new Fl_Group(0, h+20, 130, 35);
@@ -1854,7 +1854,7 @@ void live_mode_cb(Fl_Button*o,void *) {
         Fl_Box *rsz_dummy = new Fl_Box(110, h+20, 1, 25);
         rsz_dummy->box(FL_NO_BOX);
         rsz->resizable(rsz_dummy);
-        Fl_Button *btn = new Fl_Button(10, h+20, 100, 25, "Exit Live Mode");
+        Fl_Button *btn = new Fl_Button(10, h+20, 100, 25, "Exit Live Resize");
         btn->labelsize(12);
         btn->callback(leave_live_mode_cb);
         rsz->end();
@@ -1873,6 +1873,7 @@ void live_mode_cb(Fl_Button*o,void *) {
             live_window->size_range(mw, mh, MW, MH);
         }
         live_window->show();
+        live_widget->show();
       } else o->value(0);
     } else o->value(0);
   } else {

--- a/fluid/widget_panel.cxx
+++ b/fluid/widget_panel.cxx
@@ -834,7 +834,7 @@ access the Widget pointer and \'v\' to access the user value.");
         o->callback((Fl_Callback*)revert_cb);
         o->hide();
       } // Fl_Button* o
-      { wLiveMode = new Fl_Button(155, 370, 80, 20, "Live &Mode");
+      { wLiveMode = new Fl_Button(155, 370, 80, 20, "Live &Resize");
         wLiveMode->tooltip("Create a live duplicate of the selected widgets to test resizing and menu beh\
 avior.");
         wLiveMode->type(1);

--- a/fluid/widget_panel.fl
+++ b/fluid/widget_panel.fl
@@ -666,7 +666,7 @@ wCallback->do_callback(wCallback, v);} open
         }
       }
     }
-    Fl_Group {} {
+    Fl_Group {} {open
       xywh {10 370 400 20} labelsize 11
     } {
       Fl_Box {} {
@@ -680,7 +680,7 @@ wCallback->do_callback(wCallback, v);} open
         xywh {90 370 60 20} labelsize 11 hide
       }
       Fl_Button wLiveMode {
-        label {Live &Mode}
+        label {Live &Resize}
         callback live_mode_cb
         tooltip {Create a live duplicate of the selected widgets to test resizing and menu behavior.} xywh {155 370 80 20} type Toggle labelsize 11
       }


### PR DESCRIPTION
#319, it seems that windows inside windows need to be shown separately if created before the main window.