### PR TITLE
github #328: temporarily disabling new project flags

### DIFF
--- a/fluid/file.cxx
+++ b/fluid/file.cxx
@@ -394,11 +394,15 @@ int write_file(const char *filename, int selected_only) {
         break;
     }
   }
-  shell_settings_write();
+
   if (!selected_only) {
     write_string("\nheader_name"); write_word(header_file_name);
     write_string("\ncode_name"); write_word(code_file_name);
 
+#if 0
+    // https://github.com/fltk/fltk/issues/328
+    // Project wide settings require a redesign.
+    shell_settings_write();
     if (shell_settings_windows.command) {
       write_string("\nwin_shell_cmd"); write_word(shell_settings_windows.command);
       write_string("\nwin_shell_flags"); write_string("%d", shell_settings_windows.flags);
@@ -411,7 +415,9 @@ int write_file(const char *filename, int selected_only) {
       write_string("\nmac_shell_cmd"); write_word(shell_settings_macos.command);
       write_string("\nmac_shell_flags"); write_string("%d", shell_settings_macos.flags);
     }
+#endif
   }
+
   for (Fl_Type *p = Fl_Type::first; p;) {
     if (!selected_only || p->selected) {
       p->write();

--- a/fluid/print_panel.fl
+++ b/fluid/print_panel.fl
@@ -2,8 +2,6 @@
 version 1.0400
 header_name {.h}
 code_name {.cxx}
-mac_shell_cmd {echo "Fluid is nice"}
-mac_shell_flags 3
 comment {//
 // FLUID print panel for the Fast Light Tool Kit (FLTK).
 //
@@ -214,7 +212,7 @@ print_collate_group[1 - i]->hide();}
   Fl_Window print_properties_panel {
     label {Printer Properties}
     callback {print_properties_panel->hide();
-print_update_status();} selected
+print_update_status();}
     xywh {462 486 290 130} type Double modal visible
   } {
     Fl_Choice print_page_size {
@@ -330,7 +328,7 @@ if (defname[0]) {
 print_update_status();} {}
 }
 
-Function {print_update_status()} {open return_type void
+Function {print_update_status()} {open selected return_type void
 } {
   code {FILE *lpstat;
 char command[1024];


### PR DESCRIPTION
Project wide settings require a redesign.
Temporarily disabled until I find a satisfying solution.