### PR TITLE
GitHub #326: browser scrolling should be much improved

### DIFF
--- a/fluid/Fl_Group_Type.cxx
+++ b/fluid/Fl_Group_Type.cxx
@@ -23,6 +23,7 @@
 #include "fluid.h"
 #include "file.h"
 #include "code.h"
+#include "widget_browser.h"
 
 #include <FL/Fl.H>
 #include <FL/Fl_Group.H>
@@ -90,6 +91,7 @@ void group_cb(Fl_Widget *, void *) {
     t = nxt;
   }
   fix_group_size(n);
+  widget_browser->rebuild();
 }
 
 void ungroup_cb(Fl_Widget *, void *) {
@@ -114,6 +116,7 @@ void ungroup_cb(Fl_Widget *, void *) {
     n = nxt;
   }
   delete q;
+  widget_browser->rebuild();
 }
 
 ////////////////////////////////////////////////////////////////

--- a/fluid/Fl_Window_Type.cxx
+++ b/fluid/Fl_Window_Type.cxx
@@ -1239,6 +1239,8 @@ int Fl_Window_Type::handle(int event) {
       popupx = 0x7FFFFFFF;
       popupy = 0x7FFFFFFF; // mark as invalid (MAXINT)
       in_this_only = NULL;
+      widget_browser->display(Fl_Type::current);
+      widget_browser->rebuild();
       return 1;
     }
   case FL_PUSH:

--- a/fluid/Shortcut_Button.cxx
+++ b/fluid/Shortcut_Button.cxx
@@ -37,6 +37,7 @@ copied or otherwise examined.
 #include "Fl_Window_Type.h"
 #include "factory.h"
 #include "widget_panel.h"
+#include "widget_browser.h"
 
 #include <FL/platform.H>
 #include <FL/Fl_Button.H>
@@ -185,6 +186,8 @@ int Widget_Bin_Window_Button::handle(int inEvent)
             w->position(Fl::event_x_root(), Fl::event_y_root());
           }
         }
+        widget_browser->display(Fl_Type::current);
+        widget_browser->rebuild();
       }
       return Fl_Button::handle(inEvent);
   }

--- a/fluid/fluid.cxx
+++ b/fluid/fluid.cxx
@@ -517,9 +517,11 @@ void revert_cb(Fl_Widget *,void *) {
   undo_suspend();
   if (!read_file(filename, 0)) {
     undo_resume();
+    widget_browser->rebuild();
     fl_message("Can't read %s: %s", filename, strerror(errno));
     return;
   }
+  widget_browser->rebuild();
   undo_resume();
   set_modflag(0, 0);
   undo_clear();
@@ -652,6 +654,7 @@ void open_cb(Fl_Widget *, void *v) {
   undo_suspend();
   if (!read_file(c, v!=0)) {
     undo_resume();
+    widget_browser->rebuild();
     fl_message("Can't read %s: %s", c, strerror(errno));
     free((void *)filename);
     filename = oldfilename;
@@ -659,6 +662,7 @@ void open_cb(Fl_Widget *, void *v) {
     return;
   }
   undo_resume();
+  widget_browser->rebuild();
   if (v) {
     // Inserting a file; restore the original filename...
     free((void *)filename);
@@ -697,6 +701,7 @@ void open_history_cb(Fl_Widget *, void *v) {
   if (!read_file(filename, 0)) {
     undo_resume();
     undo_clear();
+    widget_browser->rebuild();
     fl_message("Can't read %s: %s", filename, strerror(errno));
     free((void *)filename);
     filename = oldfilename;
@@ -706,6 +711,7 @@ void open_history_cb(Fl_Widget *, void *v) {
   set_modflag(0, 0);
   undo_resume();
   undo_clear();
+  widget_browser->rebuild();
   if (oldfilename) {
     free((void *)oldfilename);
     oldfilename = 0L;
@@ -737,6 +743,7 @@ void new_cb(Fl_Widget *, void *v) {
   delete_all();
   set_filename(NULL);
   set_modflag(0, 0);
+  widget_browser->rebuild();
 }
 
 /**
@@ -836,6 +843,7 @@ void new_from_template_cb(Fl_Widget *w, void *v) {
     }
   }
 
+  widget_browser->rebuild();
   set_modflag(0);
   undo_clear();
 }
@@ -975,7 +983,7 @@ void cut_cb(Fl_Widget *, void *) {
   while (p && p->selected) p = p->parent;
   delete_all(1);
   if (p) select_only(p);
-  //widget_browser->redraw_lines();
+  widget_browser->rebuild();
 }
 
 /**
@@ -993,6 +1001,7 @@ void delete_cb(Fl_Widget *, void *) {
   while (p && p->selected) p = p->parent;
   delete_all(1);
   if (p) select_only(p);
+  widget_browser->rebuild();
 }
 
 /**
@@ -1011,9 +1020,12 @@ void paste_cb(Fl_Widget*, void*) {
   if (Fl_Type::current && Fl_Type::current->is_group())
     strategy = kAddAsLastChild;
   if (!read_file(cutfname(), 1, strategy)) {
+    widget_browser->rebuild();
     fl_message("Can't read %s: %s", cutfname(), strerror(errno));
   }
   undo_resume();
+  widget_browser->display(Fl_Type::current);
+  widget_browser->rebuild();
   pasteoffset = 0;
   ipasteoffset += 10;
   force_parent = 0;
@@ -1042,6 +1054,8 @@ void duplicate_cb(Fl_Widget*, void*) {
     fl_message("Can't read %s: %s", cutfname(1), strerror(errno));
   }
   fl_unlink(cutfname(1));
+  widget_browser->display(Fl_Type::current);
+  widget_browser->rebuild();
   undo_resume();
 
   force_parent = 0;
@@ -1052,6 +1066,7 @@ void duplicate_cb(Fl_Widget*, void*) {
  */
 static void sort_cb(Fl_Widget *,void *) {
   sort((Fl_Type*)NULL);
+  widget_browser->rebuild();
 }
 
 /**

--- a/fluid/undo.cxx
+++ b/fluid/undo.cxx
@@ -82,6 +82,7 @@ void redo_cb(Fl_Widget *, void *) {
   undo_suspend();
   if (!read_file(undo_filename(undo_current + 1), 0)) {
     // Unable to read checkpoint file, don't redo...
+    widget_browser->rebuild();
     undo_resume();
     return;
   }
@@ -90,6 +91,7 @@ void redo_cb(Fl_Widget *, void *) {
 
   // Update modified flag...
   set_modflag(undo_current != undo_save);
+  widget_browser->rebuild();
 
   // Update undo/redo menu items...
   if (undo_current >= undo_last) Main_Menu[redo_item].deactivate();
@@ -109,18 +111,17 @@ void undo_cb(Fl_Widget *, void *) {
 
   undo_suspend();
   // Undo first deletes all widgets which resets the widget_tree browser.
-  // Save the current scroll position, so we don;t scroll back to 0 at undo.
-  int x = widget_browser->hposition();
-  int y = widget_browser->position();
+  // Save the current scroll position, so we don't scroll back to 0 at undo.
+  if (widget_browser) widget_browser->save_scroll_position();
   if (!read_file(undo_filename(undo_current - 1), 0)) {
     // Unable to read checkpoint file, don't undo...
+    widget_browser->rebuild();
     undo_resume();
     return;
   }
   // Restore old browser position.
   // Ideally, we would save the browser position insied the undo file.
-  widget_browser->hposition(x);
-  widget_browser->position(y);
+  if (widget_browser) widget_browser->restore_scroll_position();
 
   undo_current --;
 
@@ -130,6 +131,7 @@ void undo_cb(Fl_Widget *, void *) {
   // Update undo/redo menu items...
   if (undo_current <= 0) Main_Menu[undo_item].deactivate();
   Main_Menu[redo_item].activate();
+  widget_browser->rebuild();
   undo_resume();
 }
 

--- a/fluid/widget_browser.h
+++ b/fluid/widget_browser.h
@@ -41,6 +41,8 @@ class Widget_Browser : public Fl_Browser_
   }
 
   Fl_Type* pushedtitle;
+  int saved_h_scroll_;
+  int saved_v_scroll_;
 
   // required routines for Fl_Browser_ subclass:
   void *item_first() const ;
@@ -57,7 +59,10 @@ public:
   Widget_Browser(int,int,int,int,const char * =NULL);
   int handle(int);
   void callback();
-  void deleting(Fl_Type *inType) { Fl_Browser_::deleting((void*)inType); }
+  void save_scroll_position();
+  void restore_scroll_position();
+  void rebuild();
+  void display(Fl_Type *);
 };
 
 #endif // _FLUID_WIDGET_BROWSER_H


### PR DESCRIPTION
Code now convinces browser to rebuild when the tree changes by UI.
When widgets are move, the current widget should always be visible.
It's the responsibility of the UI callback to update the browser.