### PR TITLE
GitHub #327: menu buttons will no longer grab arrow keys.

### DIFF
--- a/fluid/Fl_Menu_Type.cxx
+++ b/fluid/Fl_Menu_Type.cxx
@@ -485,6 +485,7 @@ Fl_Type* Fl_Menu_Type::click_test(int, int) {
   w->value((Fl_Menu_Item*)0);
   Fl::pushed(w);
   w->handle(FL_PUSH);
+  Fl::focus(NULL);
   const Fl_Menu_Item* m = w->mvalue();
   if (m) {
     // restore the settings of toggles & radio items:
@@ -586,6 +587,7 @@ Fl_Type* Fl_Input_Choice_Type::click_test(int, int) {
   w->value((Fl_Menu_Item*)0);
   Fl::pushed(w);
   w->handle(FL_PUSH);
+  Fl::focus(NULL);
   const Fl_Menu_Item* m = w->mvalue();
   if (m) {
     // restore the settings of toggles & radio items:

--- a/test/preferences.fl
+++ b/test/preferences.fl
@@ -45,7 +45,7 @@ Function {} {open return_type int
   Fl_Window myWindow {
     label {My Preferences}
     callback closeWindowCB open
-    xywh {408 202 298 311} type Double hide
+    xywh {586 277 298 311} type Double visible
   } {
     Fl_Button {} {
       label Cancel
@@ -62,7 +62,7 @@ Function {} {open return_type int
       xywh {20 30 115 225} box ENGRAVED_FRAME align 5
     } {
       Fl_Input wAlarm {
-        label {Alarm at:}
+        label {Alarm at:} selected
         xywh {25 55 45 20} align 5
       }
       Fl_Choice wAmPm {open
@@ -268,8 +268,7 @@ Fl_Preferences app( Fl_Preferences::USER, project, application );
     eat.get( "binFoo", (void*)&hex, 0, 0, sizeof( unsigned int ) );
     void *data;
     eat.get( "binFoo2", data, 0, 0 );
-  **/} {selected
-  }
+  **/} {}
 }
 
 Function {writePrefs()} {open return_type void


### PR DESCRIPTION
In Fluid, selecting a menu button, and selecting it again to make it
movable would also grab the text input focus, which would prevent
the enclosing window from using arrow key events to manipulate
the selected widget.