### PR TITLE
STR 3355: allow Unicode UTF-8 in source code

### DIFF
--- a/fluid/Fl_Type.cxx
+++ b/fluid/Fl_Type.cxx
@@ -181,6 +181,7 @@ void delete_all(int selected_only) {
   if(!selected_only) {
     include_H_from_C=1;
     use_FL_COMMAND=0;
+    utf8_in_src = 0;
     // reset the setting for the external shell command
     shell_prefs_get();
     shell_settings_write();

--- a/fluid/Fl_Window_Type.cxx
+++ b/fluid/Fl_Window_Type.cxx
@@ -44,6 +44,7 @@
 
 int include_H_from_C = 1;
 int use_FL_COMMAND = 0;
+int utf8_in_src = 0;
 extern int i18n_type;
 extern const char* i18n_include;
 extern const char* i18n_function;
@@ -181,6 +182,7 @@ void show_project_cb(Fl_Widget *, void *) {
   if(project_window==0) make_project_window();
   include_H_from_C_button->value(include_H_from_C);
   use_FL_COMMAND_button->value(use_FL_COMMAND);
+  utf8_in_src_button->value(utf8_in_src);
   header_file_input->value(header_file_name);
   code_file_input->value(code_file_name);
   i18n_type_chooser->value(i18n_type);
@@ -261,6 +263,13 @@ void use_FL_COMMAND_button_cb(Fl_Check_Button* b, void*) {
   if (use_FL_COMMAND != b->value()) {
     set_modflag(1);
     use_FL_COMMAND = b->value();
+  }
+}
+
+void utf8_in_src_cb(Fl_Check_Button *b, void*) {
+  if (utf8_in_src != b->value()) {
+    set_modflag(1);
+    utf8_in_src = b->value();
   }
 }
 

--- a/fluid/Fl_Window_Type.h
+++ b/fluid/Fl_Window_Type.h
@@ -27,6 +27,7 @@ class Fl_Widget_Class_Type;
 
 extern int include_H_from_C;
 extern int use_FL_COMMAND;
+extern int utf8_in_src;
 
 extern Fl_Menu_Item window_type_menu[];
 extern Fl_Widget_Class_Type *current_widget_class;

--- a/fluid/alignment_panel.cxx
+++ b/fluid/alignment_panel.cxx
@@ -36,6 +36,8 @@ Fl_Check_Button *include_H_from_C_button=(Fl_Check_Button *)0;
 
 Fl_Check_Button *use_FL_COMMAND_button=(Fl_Check_Button *)0;
 
+Fl_Check_Button *utf8_in_src_button=(Fl_Check_Button *)0;
+
 Fl_Choice *i18n_type_chooser=(Fl_Choice *)0;
 
 Fl_Menu_Item menu_i18n_type_chooser[] = {
@@ -54,14 +56,14 @@ Fl_Int_Input *i18n_set_input=(Fl_Int_Input *)0;
 Fl_Input *i18n_function_input=(Fl_Input *)0;
 
 Fl_Double_Window* make_project_window() {
-  { project_window = new Fl_Double_Window(399, 252, "Project Settings");
-    { Fl_Button* o = new Fl_Button(328, 216, 60, 25, "Close");
+  { project_window = new Fl_Double_Window(399, 275, "Project Settings");
+    { Fl_Button* o = new Fl_Button(328, 239, 60, 25, "Close");
       o->tooltip("Close this dialog.");
       o->callback((Fl_Callback*)cb_Close);
     } // Fl_Button* o
-    { Fl_Tabs* o = new Fl_Tabs(10, 10, 378, 195);
+    { Fl_Tabs* o = new Fl_Tabs(10, 10, 378, 218);
       o->selection_color((Fl_Color)12);
-      { Fl_Group* o = new Fl_Group(10, 36, 378, 169, "Output");
+      { Fl_Group* o = new Fl_Group(10, 36, 378, 192, "Output");
         { Fl_Box* o = new Fl_Box(20, 49, 340, 49, "Use \"name.ext\" to set a file name or just \".ext\" to set extension.");
           o->align(Fl_Align(132|FL_ALIGN_INSIDE));
         } // Fl_Box* o
@@ -91,9 +93,16 @@ Fl_Double_Window* make_project_window() {
           use_FL_COMMAND_button->down_box(FL_DOWN_BOX);
           use_FL_COMMAND_button->callback((Fl_Callback*)use_FL_COMMAND_button_cb);
         } // Fl_Check_Button* use_FL_COMMAND_button
+        { utf8_in_src_button = new Fl_Check_Button(117, 199, 272, 20, "allow Unicode UTF-8 in source code");
+          utf8_in_src_button->tooltip("For older compilers, characters outside of the printable ASCII range are esca\
+ped using octal notation `\\0123`. If this option is checked, Fluid will write\
+ UFT-8 characters unchanged.");
+          utf8_in_src_button->down_box(FL_DOWN_BOX);
+          utf8_in_src_button->callback((Fl_Callback*)utf8_in_src_cb);
+        } // Fl_Check_Button* utf8_in_src_button
         o->end();
       } // Fl_Group* o
-      { Fl_Group* o = new Fl_Group(10, 36, 378, 169, "Internationalization");
+      { Fl_Group* o = new Fl_Group(10, 36, 378, 192, "Internationalization");
         o->hide();
         { i18n_type_chooser = new Fl_Choice(100, 48, 136, 25, "Use:");
           i18n_type_chooser->tooltip("Type of internationalization to use.");

--- a/fluid/alignment_panel.fl
+++ b/fluid/alignment_panel.fl
@@ -2,8 +2,6 @@
 version 1.0400
 header_name {.h}
 code_name {.cxx}
-mac_shell_cmd {echo "I love Fluid"}
-mac_shell_flags 3
 comment {//
 // Setting and shell dialogs for the Fast Light Tool Kit (FLTK).
 //
@@ -56,7 +54,7 @@ Function {make_project_window()} {open
 } {
   Fl_Window project_window {
     label {Project Settings} open
-    xywh {473 246 399 252} type Double
+    xywh {473 246 399 275} type Double
     code0 {\#include <FL/Fl_Preferences.H>}
     code1 {\#include <FL/Fl_Tooltip.H>} modal visible
   } {
@@ -64,14 +62,14 @@ Function {make_project_window()} {open
       label Close
       callback {project_window->hide();
 set_modflag(-1, -1);}
-      tooltip {Close this dialog.} xywh {328 216 60 25}
+      tooltip {Close this dialog.} xywh {328 239 60 25}
     }
     Fl_Tabs {} {open
-      xywh {10 10 378 195} selection_color 12
+      xywh {10 10 378 218} selection_color 12
     } {
       Fl_Group {} {
         label Output open
-        xywh {10 36 378 169}
+        xywh {10 36 378 192}
       } {
         Fl_Box {} {
           label {Use "name.ext" to set a file name or just ".ext" to set extension.}
@@ -86,7 +84,7 @@ set_modflag(-1, -1);}
         Fl_Input code_file_input {
           label {Code File:}
           user_data 1 user_data_type {void*}
-          callback code_input_cb selected
+          callback code_input_cb
           tooltip {The name of the generated code file.} xywh {119 128 252 20} box THIN_DOWN_BOX labelfont 1 when 1 textfont 4
         }
         Fl_Check_Button include_H_from_C_button {
@@ -99,10 +97,15 @@ set_modflag(-1, -1);}
           callback use_FL_COMMAND_button_cb
           tooltip {Replace FL_CTRL with FL_COMMAND when generating menu shortcut code.} xywh {117 176 272 20} down_box DOWN_BOX
         }
+        Fl_Check_Button utf8_in_src_button {
+          label {allow Unicode UTF-8 in source code}
+          callback utf8_in_src_cb selected
+          tooltip {For older compilers, characters outside of the printable ASCII range are escaped using octal notation `\\0123`. If this option is checked, Fluid will write UFT-8 characters unchanged.} xywh {117 199 272 20} down_box DOWN_BOX
+        }
       }
       Fl_Group {} {
         label Internationalization open
-        xywh {10 36 378 169} hide
+        xywh {10 36 378 192} hide
       } {
         Fl_Choice i18n_type_chooser {
           label {Use:}
@@ -291,7 +294,7 @@ Function {make_shell_window()} {open
 } {
   Fl_Window shell_window {
     label {Shell Command} open
-    xywh {287 318 365 200} type Double modal size_range {365 200 365 200} visible
+    xywh {544 751 365 200} type Double modal size_range {365 200 365 200} visible
   } {
     Fl_Group {} {open
       xywh {0 0 365 165}
@@ -385,7 +388,7 @@ Function {make_layout_window()} {open
 } {
   Fl_Window grid_window {
     label {Layout Settings}
-    xywh {545 376 310 245} type Double non_modal visible
+    xywh {885 274 310 245} type Double non_modal visible
   } {
     Fl_Input horizontal_input {
       label x

--- a/fluid/alignment_panel.h
+++ b/fluid/alignment_panel.h
@@ -44,6 +44,8 @@ extern void include_H_from_C_button_cb(Fl_Check_Button*, void*);
 extern Fl_Check_Button *include_H_from_C_button;
 extern void use_FL_COMMAND_button_cb(Fl_Check_Button*, void*);
 extern Fl_Check_Button *use_FL_COMMAND_button;
+extern void utf8_in_src_cb(Fl_Check_Button*, void*);
+extern Fl_Check_Button *utf8_in_src_button;
 #include <FL/Fl_Choice.H>
 extern void i18n_type_cb(Fl_Choice*, void*);
 extern Fl_Choice *i18n_type_chooser;

--- a/fluid/code.cxx
+++ b/fluid/code.cxx
@@ -269,6 +269,18 @@ void write_cstring(const char *s, int length) {
         linelength++;
         break;
       }
+      // if the UTF-8 option is checked, write unicode characters verbatim
+        if (utf8_in_src && (c&0x80)) {
+          if ((c&0x40)) {
+            // This is the first character in a utf-8 sequence (0b11......).
+            // A line break would be ok here. Do not put linebreak in front of
+            // following characters (0b10......)
+            if (linelength >= 78) {fputs("\\\n",code_file); linelength = 0;}
+          }
+          putc(c, code_file);
+          linelength++;
+          break;
+        }
       // otherwise we must print it as an octal constant:
       c &= 255;
       if (c < 8) {

--- a/fluid/file.cxx
+++ b/fluid/file.cxx
@@ -381,6 +381,8 @@ int write_file(const char *filename, int selected_only) {
     write_string("\ndo_not_include_H_from_C");
   if(use_FL_COMMAND)
     write_string("\nuse_FL_COMMAND");
+  if (utf8_in_src)
+    write_string("\nutf8_in_src");
   if (i18n_type) {
     write_string("\ni18n_type %d", i18n_type);
     write_string("\ni18n_include %s", i18n_include);
@@ -491,6 +493,10 @@ static void read_children(Fl_Type *p, int paste, Strategy strategy, char skip_op
       }
       if (!strcmp(c,"use_FL_COMMAND")) {
         use_FL_COMMAND=1;
+        goto CONTINUE;
+      }
+      if (!strcmp(c,"utf8_in_src")) {
+        utf8_in_src=1;
         goto CONTINUE;
       }
       if (!strcmp(c,"i18n_type")) {


### PR DESCRIPTION
This includes changes in the UI in Project Settings.
Lines will wrap correctly without interrupting utf8 sequences.