### PR TITLE
Background color attribute for Fl_Text_Display.

### DIFF
--- a/FL/Fl_Text_Display.H
+++ b/FL/Fl_Text_Display.H
@@ -156,12 +156,11 @@ public:
     ATTR_BGCOLOR        = 0x0001, ///< use the background color
     ATTR_BGCOLOR_EXT_   = 0x0002, ///< internal use
     ATTR_BGCOLOR_EXT    = 0x0003, ///< extend background color to the end of the line
-    ATTR_UNDERLINE      = 0x0004, ///< a single underline, underline types ar mutually exclusive
+    ATTR_UNDERLINE      = 0x0004, ///< a single underline, underline types are mutually exclusive
     ATTR_GRAMMAR        = 0x0008, ///< grammar suggestion (blue dotted underline)
     ATTR_SPELLING       = 0x000C, ///< spelling suggestion (red dotted underline)
     ATTR_STRIKE_THROUGH = 0x0010, ///< line through the middle of the text
     ATTR_LINES_MASK     = 0x001C, ///< all underline and strike through types combined
-    // how about underscore, strikethrough, undersquigle(color)?
   };
 
   Fl_Text_Display(int X, int Y, int W, int H, const char *l = 0);

--- a/FL/Fl_Text_Display.H
+++ b/FL/Fl_Text_Display.H
@@ -146,6 +146,17 @@ public:
     Fl_Font     font;   ///< text font
     Fl_Fontsize size;   ///< text font size
     unsigned    attr;   ///< currently unused (this may be changed in the future)
+    Fl_Color    bgcolor;///< text background color if ATTR_BGCOLOR or ATTR_BGCOLOR_EXT is set
+  };
+
+  /**
+   attribute flags
+   */
+  enum {
+    ATTR_BGCOLOR      = 0x0001, ///< use the background color
+    ATTR_BGCOLOR_EXT_ = 0x0002, ///< internal use
+    ATTR_BGCOLOR_EXT  = 0x0003  ///< extend background color to the end of the line
+    // how about underscore, strikethrough, undersquigle(color)?
   };
 
   Fl_Text_Display(int X, int Y, int W, int H, const char *l = 0);

--- a/FL/Fl_Text_Display.H
+++ b/FL/Fl_Text_Display.H
@@ -153,9 +153,13 @@ public:
    attribute flags
    */
   enum {
-    ATTR_BGCOLOR      = 0x0001, ///< use the background color
-    ATTR_BGCOLOR_EXT_ = 0x0002, ///< internal use
-    ATTR_BGCOLOR_EXT  = 0x0003  ///< extend background color to the end of the line
+    ATTR_BGCOLOR        = 0x0001, ///< use the background color
+    ATTR_BGCOLOR_EXT_   = 0x0002, ///< internal use
+    ATTR_BGCOLOR_EXT    = 0x0003, ///< extend background color to the end of the line
+    ATTR_UNDERLINE      = 0x0004, ///< a single underline, underline types ar mutually exclusive
+    ATTR_GRAMMAR        = 0x0008, ///< grammar suggestion (blue dotted underline)
+    ATTR_SPELLING       = 0x000C, ///< spelling suggestion (red dotted underline)
+    ATTR_STRIKE_THROUGH = 0x0010  ///< line through the middle of the text
     // how about underscore, strikethrough, undersquigle(color)?
   };
 

--- a/FL/Fl_Text_Display.H
+++ b/FL/Fl_Text_Display.H
@@ -142,25 +142,25 @@ public:
    \see Fl_Text_Display::highlight_data()
    */
   struct Style_Table_Entry {
-    Fl_Color    color;  ///< text color
-    Fl_Font     font;   ///< text font
-    Fl_Fontsize size;   ///< text font size
-    unsigned    attr;   ///< currently unused (this may be changed in the future)
-    Fl_Color    bgcolor;///< text background color if ATTR_BGCOLOR or ATTR_BGCOLOR_EXT is set
+    Fl_Color    color;    ///< text color
+    Fl_Font     font;     ///< text font
+    Fl_Fontsize size;     ///< text font size
+    unsigned    attr;     ///< further attributes for the text style (see `ATTR_BGCOLOR`, etc.)
+    Fl_Color    bgcolor;  ///< text background color if `ATTR_BGCOLOR` or `ATTR_BGCOLOR_EXT` is set
   };
 
   /**
-   attribute flags
+   attribute flags in `Style_Table_Entry.attr`
    */
   enum {
-    ATTR_BGCOLOR        = 0x0001, ///< use the background color
-    ATTR_BGCOLOR_EXT_   = 0x0002, ///< internal use
+    ATTR_BGCOLOR        = 0x0001, ///< use the background color in the `bgcolor` field
+    ATTR_BGCOLOR_EXT_   = 0x0002, ///< (internal use)
     ATTR_BGCOLOR_EXT    = 0x0003, ///< extend background color to the end of the line
     ATTR_UNDERLINE      = 0x0004, ///< a single underline, underline types are mutually exclusive
     ATTR_GRAMMAR        = 0x0008, ///< grammar suggestion (blue dotted underline)
     ATTR_SPELLING       = 0x000C, ///< spelling suggestion (red dotted underline)
     ATTR_STRIKE_THROUGH = 0x0010, ///< line through the middle of the text
-    ATTR_LINES_MASK     = 0x001C, ///< all underline and strike through types combined
+    ATTR_LINES_MASK     = 0x001C, ///< the mask for all underline and strike through types
   };
 
   Fl_Text_Display(int X, int Y, int W, int H, const char *l = 0);

--- a/FL/Fl_Text_Display.H
+++ b/FL/Fl_Text_Display.H
@@ -159,7 +159,8 @@ public:
     ATTR_UNDERLINE      = 0x0004, ///< a single underline, underline types ar mutually exclusive
     ATTR_GRAMMAR        = 0x0008, ///< grammar suggestion (blue dotted underline)
     ATTR_SPELLING       = 0x000C, ///< spelling suggestion (red dotted underline)
-    ATTR_STRIKE_THROUGH = 0x0010  ///< line through the middle of the text
+    ATTR_STRIKE_THROUGH = 0x0010, ///< line through the middle of the text
+    ATTR_LINES_MASK     = 0x001C, ///< all underline and strike through types combined
     // how about underscore, strikethrough, undersquigle(color)?
   };
 

--- a/src/Fl_Text_Display.cxx
+++ b/src/Fl_Text_Display.cxx
@@ -2352,7 +2352,7 @@ void Fl_Text_Display::draw_string(int style,
     // Make sure antialiased ÄÖÜ do not leak on line above:
     // on X11+Xft the antialiased part of characters such as ÄÖÜ leak on the bottom pixel of the line above
     static int can_leak = Fl::screen_driver()->text_display_can_leak();
-    // Clip top an bottom only. Add margin to avoid clipping horizontally
+    // Clip top and bottom only. Add margin to avoid clipping horizontally
     if (can_leak) fl_push_clip(x(), Y, w(), mMaxsize);
     fl_draw( string, nChars, X, baseline);
     if (styleRec) {

--- a/src/Fl_Text_Display.cxx
+++ b/src/Fl_Text_Display.cxx
@@ -2351,7 +2351,8 @@ void Fl_Text_Display::draw_string(int style,
     // Make sure antialiased ÄÖÜ do not leak on line above:
     // on X11+Xft the antialiased part of characters such as ÄÖÜ leak on the bottom pixel of the line above
     static int can_leak = Fl::screen_driver()->text_display_can_leak();
-    if (can_leak) fl_push_clip(X, Y, toX - X, mMaxsize);
+    // Clip top an bottom only. Add margin to avoid clipping horizontally
+    if (can_leak) fl_push_clip(x(), Y, w(), mMaxsize);
     fl_draw( string, nChars, X, Y + mMaxsize - fl_descent());
     if (Fl::screen_driver()->has_marked_text() && Fl::compose_state && (style & PRIMARY_MASK)) {
       fl_color( fl_color_average(foreground, background, 0.6f) );

--- a/src/Fl_Text_Display.cxx
+++ b/src/Fl_Text_Display.cxx
@@ -2348,12 +2348,13 @@ void Fl_Text_Display::draw_string(int style,
   if (!(style & BG_ONLY_MASK)) {
     fl_color( foreground );
     fl_font( font, fsize );
+    int baseline = Y + mMaxsize - fl_descent();
     // Make sure antialiased ÄÖÜ do not leak on line above:
     // on X11+Xft the antialiased part of characters such as ÄÖÜ leak on the bottom pixel of the line above
     static int can_leak = Fl::screen_driver()->text_display_can_leak();
     // Clip top an bottom only. Add margin to avoid clipping horizontally
     if (can_leak) fl_push_clip(x(), Y, w(), mMaxsize);
-    fl_draw( string, nChars, X, Y + mMaxsize - fl_descent());
+    fl_draw( string, nChars, X, baseline);
     if (styleRec) {
       if (styleRec->attr & ATTR_LINES_MASK) {
         int pitch = fsize/7;
@@ -2373,12 +2374,12 @@ void Fl_Text_Display::draw_string(int style,
           DRAW_DOTTED_UNDERLINE:
             fl_line_style(FL_DOT, pitch);
           DRAW_UNDERLINE:
-            fl_xyline(X, Y + mMaxsize - fl_descent()/2, toX);
+            fl_xyline(X, baseline + fl_descent()/2, toX);
             break;
           case ATTR_STRIKE_THROUGH:
             fl_color(foreground);
             fl_line_style(FL_SOLID, pitch);
-            fl_xyline(X, Y + mMaxsize-2*fl_descent(), toX);
+            fl_xyline(X, baseline - (fl_height()-fl_descent())/3, toX);
             break;
         }
         fl_line_style(FL_SOLID, 1);

--- a/test/editor.cxx
+++ b/test/editor.cxx
@@ -58,8 +58,8 @@ Fl_Text_Buffer     *stylebuf = 0;
 Fl_Text_Display::Style_Table_Entry
                    styletable[] = {     // Style table
                      { FL_BLACK,      FL_COURIER,           TS }, // A - Plain
-                     { FL_DARK_GREEN, FL_HELVETICA_ITALIC,  TS }, // B - Line comments
-                     { FL_DARK_GREEN, FL_HELVETICA_ITALIC,  TS }, // C - Block comments
+                     { FL_DARK_GREEN, FL_HELVETICA_ITALIC,  TS, Fl_Text_Display::ATTR_BGCOLOR, FL_LIGHT2  }, // B - Line comments
+                     { FL_DARK_GREEN, FL_HELVETICA_ITALIC,  TS, Fl_Text_Display::ATTR_BGCOLOR_EXT, FL_LIGHT2 }, // C - Block comments
                      { FL_BLUE,       FL_COURIER,           TS }, // D - Strings
                      { FL_DARK_RED,   FL_COURIER,           TS }, // E - Directives
                      { FL_DARK_RED,   FL_COURIER_BOLD,      TS }, // F - Types
@@ -188,7 +188,6 @@ style_parse(const char *text,
       } else if (strncmp(text, "//", 2) == 0) {
         current = 'B';
         for (; length > 0 && *text != '\n'; length --, text ++) *style++ = 'B';
-
         if (length == 0) break;
       } else if (strncmp(text, "/*", 2) == 0) {
         current = 'C';

--- a/test/editor.cxx
+++ b/test/editor.cxx
@@ -57,13 +57,23 @@ const int line_num_width = 75;
 Fl_Text_Buffer     *stylebuf = 0;
 Fl_Text_Display::Style_Table_Entry
                    styletable[] = {     // Style table
+#ifdef TESTING_ATTRIBUTES
                      { FL_BLACK,      FL_COURIER,           TS }, // A - Plain
                      { FL_DARK_GREEN, FL_HELVETICA_ITALIC,  TS, Fl_Text_Display::ATTR_BGCOLOR, FL_LIGHT2  }, // B - Line comments
                      { FL_DARK_GREEN, FL_HELVETICA_ITALIC,  TS, Fl_Text_Display::ATTR_BGCOLOR_EXT, FL_LIGHT2 }, // C - Block comments
-                     { FL_BLUE,       FL_COURIER,           TS }, // D - Strings
+                     { FL_BLUE,       FL_COURIER,           TS, Fl_Text_Display::ATTR_UNDERLINE }, // D - Strings
                      { FL_DARK_RED,   FL_COURIER,           TS, Fl_Text_Display::ATTR_GRAMMAR }, // E - Directives
                      { FL_DARK_RED,   FL_COURIER_BOLD,      TS, Fl_Text_Display::ATTR_STRIKE_THROUGH }, // F - Types
                      { FL_BLUE,       FL_COURIER_BOLD,      TS, Fl_Text_Display::ATTR_SPELLING }, // G - Keywords
+#else
+                     { FL_BLACK,      FL_COURIER,           TS }, // A - Plain
+                     { FL_DARK_GREEN, FL_HELVETICA_ITALIC,  TS }, // B - Line comments
+                     { FL_DARK_GREEN, FL_HELVETICA_ITALIC,  TS }, // C - Block comments
+                     { FL_BLUE,       FL_COURIER,           TS }, // D - Strings
+                     { FL_DARK_RED,   FL_COURIER,           TS }, // E - Directives
+                     { FL_DARK_RED,   FL_COURIER_BOLD,      TS }, // F - Types
+                     { FL_BLUE,       FL_COURIER_BOLD,      TS }, // G - Keywords
+#endif
                    };
 const char         *code_keywords[] = { // List of known C/C++ keywords...
                      "and",

--- a/test/editor.cxx
+++ b/test/editor.cxx
@@ -61,9 +61,9 @@ Fl_Text_Display::Style_Table_Entry
                      { FL_DARK_GREEN, FL_HELVETICA_ITALIC,  TS, Fl_Text_Display::ATTR_BGCOLOR, FL_LIGHT2  }, // B - Line comments
                      { FL_DARK_GREEN, FL_HELVETICA_ITALIC,  TS, Fl_Text_Display::ATTR_BGCOLOR_EXT, FL_LIGHT2 }, // C - Block comments
                      { FL_BLUE,       FL_COURIER,           TS }, // D - Strings
-                     { FL_DARK_RED,   FL_COURIER,           TS }, // E - Directives
-                     { FL_DARK_RED,   FL_COURIER_BOLD,      TS }, // F - Types
-                     { FL_BLUE,       FL_COURIER_BOLD,      TS }, // G - Keywords
+                     { FL_DARK_RED,   FL_COURIER,           TS, Fl_Text_Display::ATTR_GRAMMAR }, // E - Directives
+                     { FL_DARK_RED,   FL_COURIER_BOLD,      TS, Fl_Text_Display::ATTR_STRIKE_THROUGH }, // F - Types
+                     { FL_BLUE,       FL_COURIER_BOLD,      TS, Fl_Text_Display::ATTR_SPELLING }, // G - Keywords
                    };
 const char         *code_keywords[] = { // List of known C/C++ keywords...
                      "and",


### PR DESCRIPTION
The implementation stays source code compatible with older versions of `Style_Table_Entry`. The background color field was added which can stay the default value 0. The previously existing `attr` field now supports two flags, `ATTR_BGCOLOR` and `ATTR_BGCOLOR_EXT`. The first version changes the background of text with this attribute. The _ext version expands the background color to the end of the line if the line end or breaks.

I also fixed the clipping at the end of tile changes and at the end of the line. This was very visible with italicised characters that may bleed into the next attribute.