### PR TITLE
Fluid: no grid on window resizing.

### DIFF
--- a/fluid/Fl_Widget_Type.cxx
+++ b/fluid/Fl_Widget_Type.cxx
@@ -674,10 +674,6 @@ void x_cb(Fluid_Coord_Input *i, void *v) {
         i->variables(widget_vars, o);
         w->resize((int)i->value(), w->y(), w->w(), w->h());
         if (w->window()) w->window()->redraw();
-        if (o->is_window()) {
-          ((Fl_Window *)w)->size_range(gridx, gridy, Fl::w(), Fl::h(),
-                                       gridx, gridy, 0);
-        }
         widget_i++;
         mod = 1;
       }
@@ -702,10 +698,6 @@ void y_cb(Fluid_Coord_Input *i, void *v) {
         i->variables(widget_vars, o);
         w->resize(w->x(), (int)i->value(), w->w(), w->h());
         if (w->window()) w->window()->redraw();
-        if (o->is_window()) {
-          ((Fl_Window *)w)->size_range(gridx, gridy, Fl::w(), Fl::h(),
-                                       gridx, gridy, 0);
-        }
         widget_i++;
         mod = 1;
       }
@@ -730,10 +722,6 @@ void w_cb(Fluid_Coord_Input *i, void *v) {
         i->variables(widget_vars, o);
         w->resize(w->x(), w->y(), (int)i->value(), w->h());
         if (w->window()) w->window()->redraw();
-        if (o->is_window()) {
-          ((Fl_Window *)w)->size_range(gridx, gridy, Fl::w(), Fl::h(),
-                                       gridx, gridy, 0);
-        }
         widget_i++;
         mod = 1;
       }
@@ -758,10 +746,6 @@ void h_cb(Fluid_Coord_Input *i, void *v) {
         i->variables(widget_vars, o);
         w->resize(w->x(), w->y(), w->w(), (int)i->value());
         if (w->window()) w->window()->redraw();
-        if (o->is_window()) {
-          ((Fl_Window *)w)->size_range(gridx, gridy, Fl::w(), Fl::h(),
-                                       gridx, gridy, 0);
-        }
         widget_i++;
         mod = 1;
       }

--- a/fluid/Fl_Window_Type.cxx
+++ b/fluid/Fl_Window_Type.cxx
@@ -99,9 +99,7 @@ void grid_cb(Fl_Int_Input *i, long v) {
   for (p = Fl_Type::first; p; p = p->next) {
     if (p->is_window()) {
       w = (Fl_Window_Type *)p;
-      ((Fl_Window *)(w->o))->size_range(gridx, gridy,
-                                        Fl::w(), Fl::h(),
-                                        gridx, gridy, 0);
+      ((Fl_Window *)(w->o))->size_range(gridx, gridy, Fl::w(), Fl::h());
     }
   }
 }
@@ -406,9 +404,7 @@ Fl_Type *Fl_Window_Type::make(Strategy strategy) {
   }
   // Set the size ranges for this window; in order to avoid opening the
   // X display we use an arbitrary maximum size...
-  ((Fl_Window *)(this->o))->size_range(gridx, gridy,
-                                       3072, 2048,
-                                       gridx, gridy, 0);
+  ((Fl_Window *)(this->o))->size_range(gridx, gridy, 6144, 4096);
   myo->factory = this;
   myo->drag = 0;
   myo->numselected = 0;
@@ -460,7 +456,7 @@ void Fl_Window_Type::open() {
   }
 
   w->image(Fl::scheme_bg_);
-  w->size_range(gridx, gridy, Fl::w(), Fl::h(), gridx, gridy, 0);
+  w->size_range(gridx, gridy, Fl::w(), Fl::h());
 }
 
 // Read an image of the window
@@ -1553,9 +1549,7 @@ Fl_Type *Fl_Widget_Class_Type::make(Strategy strategy) {
   }
   // Set the size ranges for this window; in order to avoid opening the
   // X display we use an arbitrary maximum size...
-  ((Fl_Window *)(this->o))->size_range(gridx, gridy,
-                                       3072, 2048,
-                                       gridx, gridy, 0);
+  ((Fl_Window *)(this->o))->size_range(gridx, gridy, 6144, 4096);
   myo->factory = this;
   myo->drag = 0;
   myo->numselected = 0;


### PR DESCRIPTION
#393 Applying the grid increments to window resizing in Fluid does not always work as expected. Depending on the Window Manager, `size_range` can override numerical input. I will leave this feature disabled as fixing it is tedious and possibly harmful mit other WMs while the feature itself is relatively unimportant. It never worked on MacOS, for example.