### PR TITLE
Add utf8 encoding support in setup.cmake for MSVC compiling

### DIFF
--- a/CMake/setup.cmake
+++ b/CMake/setup.cmake
@@ -103,7 +103,7 @@ if (WIN32)
   if (MSVC)
     add_definitions (-DWIN32_LEAN_AND_MEAN)
     add_definitions (-D_CRT_SECURE_NO_WARNINGS)
-    add_definitions ("/utf-8")  # This is equivalent to specifying `/source-charset:utf-8 /execution-charset:utf-8`
+    add_compile_options (/utf-8)  # This is equivalent to specifying `/source-charset:utf-8 /execution-charset:utf-8`
     set (BORDER_WIDTH 2)
   endif (MSVC)
   if (CMAKE_C_COMPILER_ID STREQUAL GNU)

--- a/CMake/setup.cmake
+++ b/CMake/setup.cmake
@@ -103,6 +103,7 @@ if (WIN32)
   if (MSVC)
     add_definitions (-DWIN32_LEAN_AND_MEAN)
     add_definitions (-D_CRT_SECURE_NO_WARNINGS)
+    add_definitions ("/utf-8")  # This is equivalent to specifying `/source-charset:utf-8 /execution-charset:utf-8`
     set (BORDER_WIDTH 2)
   endif (MSVC)
   if (CMAKE_C_COMPILER_ID STREQUAL GNU)

--- a/FL/Fl_Image.H
+++ b/FL/Fl_Image.H
@@ -187,7 +187,7 @@ public:
     \see count(), w(), h(), data_w(), data_h(), d(), ld()
    */
   const char * const *data() const {return data_;}
-  int fail();
+  int fail() const;
   /**
     Releases an Fl_Image - the same as '\p delete \p this'.
 

--- a/src/Fl_Image.cxx
+++ b/src/Fl_Image.cxx
@@ -168,7 +168,7 @@ void Fl_Image::label(Fl_Menu_Item* m) {
  \return ERR_FILE_ACCESS if there was a file access related error (errno should be set)
  \return ERR_FORMAT if image decoding failed.
  */
-int Fl_Image::fail()
+int Fl_Image::fail() const
 {
     // if no image exists, ld_ may contain a simple error code
     if ( (w_<=0) || (h_<=0) || (d_<=0) ) {


### PR DESCRIPTION
The source files are all encoded by UTF-8 without BOM. This will raise warnings and errors when compiling by the MSVC with some active code pages (ACP). The file `test/ask.cxx` contains such characters with UTF-8 encoding. Adding `/utf-8` here is equivalent to specifying `/source-charset:utf-8 /execution-charset:utf-8`, and all warnings and errors are removed.