### PR TITLE
Remove vsscanf_l() call from Win32 driver (it appears to be a BSD-ism…

### DIFF
--- a/src/Fl_Preferences.cxx
+++ b/src/Fl_Preferences.cxx
@@ -38,7 +38,7 @@ static int clocale_snprintf(char *buffer, size_t buffer_size, const char *format
 {
   va_list args;
   va_start(args, format);
-  int retval = Fl::system_driver()->clocale_snprintf(buffer, buffer_size, format, args);
+  int retval = Fl::system_driver()->clocale_vsnprintf(buffer, buffer_size, format, args);
   va_end(args);
   return retval;
 }
@@ -47,7 +47,7 @@ static int clocale_sscanf(const char *input, const char *format, ...)
 {
   va_list args;
   va_start(args, format);
-  int retval = Fl::system_driver()->clocale_sscanf(input, format, args);
+  int retval = Fl::system_driver()->clocale_vsscanf(input, format, args);
   va_end(args);
   return retval;
 }

--- a/src/Fl_System_Driver.H
+++ b/src/Fl_System_Driver.H
@@ -127,9 +127,9 @@ public:
   virtual unsigned utf8to_mb(const char* src, unsigned srclen, char* dst, unsigned dstlen);
   virtual unsigned utf8from_mb(char* dst, unsigned dstlen, const char* src, unsigned srclen);
   // implement to shield fprintf() from locale changes in decimal point
-  virtual int clocale_printf(FILE *output, const char *format, va_list args);
-  virtual int clocale_snprintf(char *output, size_t output_size, const char *format, va_list args);
-  virtual int clocale_sscanf(const char *input, const char *format, va_list args);
+  virtual int clocale_vprintf(FILE *output, const char *format, va_list args);
+  virtual int clocale_vsnprintf(char *output, size_t output_size, const char *format, va_list args);
+  virtual int clocale_vsscanf(const char *input, const char *format, va_list args);
   // implement functions telling whether a key is pressed
   virtual int event_key(int) {return 0;}
   virtual int get_key(int) {return 0;}

--- a/src/Fl_System_Driver.cxx
+++ b/src/Fl_System_Driver.cxx
@@ -401,15 +401,15 @@ unsigned Fl_System_Driver::utf8from_mb(char* dst, unsigned dstlen, const char* s
   return srclen;
 }
 
-int Fl_System_Driver::clocale_printf(FILE *output, const char *format, va_list args) {
+int Fl_System_Driver::clocale_vprintf(FILE *output, const char *format, va_list args) {
   return vfprintf(output, format, args);
 }
 
-int Fl_System_Driver::clocale_snprintf(char *output, size_t output_size, const char *format, va_list args) {
+int Fl_System_Driver::clocale_vsnprintf(char *output, size_t output_size, const char *format, va_list args) {
   return 0; // overridden in platform drivers
 }
 
-int Fl_System_Driver::clocale_sscanf(const char *input, const char *format, va_list args) {
+int Fl_System_Driver::clocale_vsscanf(const char *input, const char *format, va_list args) {
   return 0; // overridden in platform drivers
 }
 
@@ -509,7 +509,7 @@ void Fl_System_Driver::gettime(time_t *sec, int *usec) {
   Platform drivers \b MUST override this virtual method to do
   their own stuff and call this base class method to run
   the platform independent wait functions.
- 
+
   Overriden methods will typically call this method early and perform
   platform-specific operations after that in order to work with the
  \p time_to_wait value possibly modified by this method.

--- a/src/drivers/Darwin/Fl_Darwin_System_Driver.H
+++ b/src/drivers/Darwin/Fl_Darwin_System_Driver.H
@@ -44,9 +44,9 @@ public:
   Fl_Darwin_System_Driver();
   virtual int single_arg(const char *arg);
   virtual int arg_and_value(const char *name, const char *value);
-  virtual int clocale_printf(FILE *output, const char *format, va_list args);
-  virtual int clocale_snprintf(char *output, size_t output_size, const char *format, va_list args);
-  virtual int clocale_sscanf(const char *input, const char *format, va_list args);
+  virtual int clocale_vprintf(FILE *output, const char *format, va_list args);
+  virtual int clocale_vsnprintf(char *output, size_t output_size, const char *format, va_list args);
+  virtual int clocale_vsscanf(const char *input, const char *format, va_list args);
   static void *get_carbon_function(const char *name);
   static int calc_mac_os_version(); // computes the fl_mac_os_version global variable
   static unsigned short *compute_macKeyLookUp();

--- a/src/drivers/Darwin/Fl_Darwin_System_Driver.cxx
+++ b/src/drivers/Darwin/Fl_Darwin_System_Driver.cxx
@@ -110,7 +110,7 @@ int Fl_Darwin_System_Driver::arg_and_value(const char *name, const char *value) 
 static locale_t postscript_locale = NULL;
 #endif
 
-int Fl_Darwin_System_Driver::clocale_printf(FILE *output, const char *format, va_list args) {
+int Fl_Darwin_System_Driver::clocale_vprintf(FILE *output, const char *format, va_list args) {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_4
   if (fl_mac_os_version >= 100400) {
     if (!postscript_locale)
@@ -125,7 +125,7 @@ int Fl_Darwin_System_Driver::clocale_printf(FILE *output, const char *format, va
   return retval;
 }
 
-int Fl_Darwin_System_Driver::clocale_snprintf(char *output, size_t output_size, const char *format, va_list args) {
+int Fl_Darwin_System_Driver::clocale_vsnprintf(char *output, size_t output_size, const char *format, va_list args) {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_4
   if (fl_mac_os_version >= 100400) {
     if (!postscript_locale)
@@ -140,7 +140,7 @@ int Fl_Darwin_System_Driver::clocale_snprintf(char *output, size_t output_size, 
   return retval;
 }
 
-int Fl_Darwin_System_Driver::clocale_sscanf(const char *input, const char *format, va_list args) {
+int Fl_Darwin_System_Driver::clocale_vsscanf(const char *input, const char *format, va_list args) {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_4
   if (fl_mac_os_version >= 100400) {
     if (!postscript_locale)

--- a/src/drivers/PostScript/Fl_PostScript.cxx
+++ b/src/drivers/PostScript/Fl_PostScript.cxx
@@ -261,7 +261,7 @@ int Fl_PostScript_Graphics_Driver::clocale_printf(const char *format, ...)
 {
   va_list args;
   va_start(args, format);
-  int retval = Fl::system_driver()->clocale_printf(output, format, args);
+  int retval = Fl::system_driver()->clocale_vprintf(output, format, args);
   va_end(args);
   return retval;
 }

--- a/src/drivers/Unix/Fl_Unix_System_Driver.H
+++ b/src/drivers/Unix/Fl_Unix_System_Driver.H
@@ -23,9 +23,9 @@ class Fl_RGB_Image;
 
 class FL_EXPORT Fl_Unix_System_Driver : public Fl_Posix_System_Driver {
 public:
-  virtual int clocale_snprintf(char *output, size_t output_size, const char *format, va_list args);
-  virtual int clocale_sscanf(const char *input, const char *format, va_list args);
-  virtual int clocale_printf(FILE *output, const char *format, va_list args);
+  virtual int clocale_vsnprintf(char *output, size_t output_size, const char *format, va_list args);
+  virtual int clocale_vsscanf(const char *input, const char *format, va_list args);
+  virtual int clocale_vprintf(FILE *output, const char *format, va_list args);
   virtual int filename_list(const char *d, dirent ***list,
                             int (*sort)(struct dirent **, struct dirent **),
                             char *errmsg=NULL, int errmsg_sz=0);

--- a/src/drivers/Unix/Fl_Unix_System_Driver.cxx
+++ b/src/drivers/Unix/Fl_Unix_System_Driver.cxx
@@ -73,7 +73,7 @@ static locale_t c_locale = NULL;
 #endif
 
 
-int Fl_Unix_System_Driver::clocale_printf(FILE *output, const char *format, va_list args) {
+int Fl_Unix_System_Driver::clocale_vprintf(FILE *output, const char *format, va_list args) {
 #if defined(__linux__) && defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700
   if (!c_locale)
     c_locale = newlocale(LC_NUMERIC_MASK, "C", duplocale(LC_GLOBAL_LOCALE));
@@ -89,7 +89,7 @@ int Fl_Unix_System_Driver::clocale_printf(FILE *output, const char *format, va_l
   return retval;
 }
 
-int Fl_Unix_System_Driver::clocale_snprintf(char *output, size_t output_size, const char *format, va_list args) {
+int Fl_Unix_System_Driver::clocale_vsnprintf(char *output, size_t output_size, const char *format, va_list args) {
 #if defined(__linux__) && defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700
   if (!c_locale)
     c_locale = newlocale(LC_NUMERIC_MASK, "C", duplocale(LC_GLOBAL_LOCALE));
@@ -105,7 +105,7 @@ int Fl_Unix_System_Driver::clocale_snprintf(char *output, size_t output_size, co
   return retval;
 }
 
-int Fl_Unix_System_Driver::clocale_sscanf(const char *input, const char *format, va_list args) {
+int Fl_Unix_System_Driver::clocale_vsscanf(const char *input, const char *format, va_list args) {
 #if defined(__linux__) && defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700
   if (!c_locale)
     c_locale = newlocale(LC_NUMERIC_MASK, "C", duplocale(LC_GLOBAL_LOCALE));

--- a/src/drivers/WinAPI/Fl_WinAPI_System_Driver.H
+++ b/src/drivers/WinAPI/Fl_WinAPI_System_Driver.H
@@ -66,9 +66,9 @@ public:
   virtual int utf8locale();
   virtual unsigned utf8to_mb(const char *src, unsigned srclen, char *dst, unsigned dstlen);
   virtual unsigned utf8from_mb(char *dst, unsigned dstlen, const char *src, unsigned srclen);
-  virtual int clocale_printf(FILE *output, const char *format, va_list args);
-  virtual int clocale_snprintf(char *output, size_t output_size, const char *format, va_list args);
-  virtual int clocale_sscanf(const char *input, const char *format, va_list args);
+  virtual int clocale_vprintf(FILE *output, const char *format, va_list args);
+  virtual int clocale_vsnprintf(char *output, size_t output_size, const char *format, va_list args);
+  virtual int clocale_vsscanf(const char *input, const char *format, va_list args);
   // these 2 are in Fl_get_key_win32.cxx
   virtual int event_key(int k);
   virtual int get_key(int k);

--- a/src/drivers/WinAPI/Fl_WinAPI_System_Driver.cxx
+++ b/src/drivers/WinAPI/Fl_WinAPI_System_Driver.cxx
@@ -450,7 +450,7 @@ unsigned Fl_WinAPI_System_Driver::utf8from_mb(char *dst, unsigned dstlen, const 
 static _locale_t c_locale = NULL;
 #endif
 
-int Fl_WinAPI_System_Driver::clocale_printf(FILE *output, const char *format, va_list args) {
+int Fl_WinAPI_System_Driver::clocale_vprintf(FILE *output, const char *format, va_list args) {
 #if defined(_MSC_VER) && (_MSC_VER >= 1400 /*Visual Studio 2005*/)
   if (!c_locale)
     c_locale = _create_locale(LC_NUMERIC, "C");
@@ -464,7 +464,7 @@ int Fl_WinAPI_System_Driver::clocale_printf(FILE *output, const char *format, va
   return retval;
 }
 
-int Fl_WinAPI_System_Driver::clocale_snprintf(char *output, size_t output_size, const char *format, va_list args) {
+int Fl_WinAPI_System_Driver::clocale_vsnprintf(char *output, size_t output_size, const char *format, va_list args) {
 #if defined(_MSC_VER) && (_MSC_VER >= 1400 /*Visual Studio 2005*/)
   if (!c_locale)
     c_locale = _create_locale(LC_NUMERIC, "C");
@@ -478,17 +478,11 @@ int Fl_WinAPI_System_Driver::clocale_snprintf(char *output, size_t output_size, 
   return retval;
 }
 
-int Fl_WinAPI_System_Driver::clocale_sscanf(const char *input, const char *format, va_list args) {
-#if defined(_MSC_VER) && (_MSC_VER >= 1400 /*Visual Studio 2005*/)
-  if (!c_locale)
-    c_locale = _create_locale(LC_NUMERIC, "C");
-  int retval = _vsscanf_l(input, format, c_locale, args);
-#else
+int Fl_WinAPI_System_Driver::clocale_vsscanf(const char *input, const char *format, va_list args) {
   char *saved_locale = setlocale(LC_NUMERIC, NULL);
   setlocale(LC_NUMERIC, "C");
   int retval = vsscanf(input, format, args);
   setlocale(LC_NUMERIC, saved_locale);
-#endif
   return retval;
 }
 


### PR DESCRIPTION
… and unsupported by the MS tools) and rename several clocale specific methods from "name" to "vname" since they take a va_list not a variable list of arguments.