### PR TITLE
Check for child visibility in Fl_Scroll.

### DIFF
--- a/src/Fl_Scroll.cxx
+++ b/src/Fl_Scroll.cxx
@@ -147,7 +147,7 @@ void Fl_Scroll::recalc_scrollbars(ScrollInfo &si) const {
   Fl_Widget*const* a = array();
   for (int i=children(); i--;) {
     Fl_Widget* o = *a++;
-    if ( o==&scrollbar || o==&hscrollbar ) continue;
+    if ( o==&scrollbar || o==&hscrollbar || o->visible==0 ) continue;
     if ( first ) {
         first = 0;
         si.child.l = o->x();

--- a/src/Fl_Scroll.cxx
+++ b/src/Fl_Scroll.cxx
@@ -147,7 +147,7 @@ void Fl_Scroll::recalc_scrollbars(ScrollInfo &si) const {
   Fl_Widget*const* a = array();
   for (int i=children(); i--;) {
     Fl_Widget* o = *a++;
-    if ( o==&scrollbar || o==&hscrollbar || o->visible==0 ) continue;
+    if ( o==&scrollbar || o==&hscrollbar || o->visible()==0 ) continue;
     if ( first ) {
         first = 0;
         si.child.l = o->x();


### PR DESCRIPTION
Hi there,

I'd like to suggest the inclusion of a check for child visibility when calculating the scroll area in a Fl_Scroll widget. This means the total area scrollable will be according to shown widgets only.

Thanks!
David