### PR TITLE
Fix kdialog native picker not properly handling spaces in filenames

### DIFF
--- a/src/Fl_Native_File_Chooser_Kdialog.cxx
+++ b/src/Fl_Native_File_Chooser_Kdialog.cxx
@@ -102,7 +102,7 @@ int Fl_Kdialog_Native_File_Chooser_Driver::show() {
       break;
 
     case Fl_Native_File_Chooser::BROWSE_MULTI_FILE:
-      option = "--multiple --getopenfilename";
+      option = "--multiple --getopenfilename --separate-output";
       break;
 
     default:
@@ -145,15 +145,15 @@ int Fl_Kdialog_Native_File_Chooser_Driver::show() {
       delete[] _pathnames;
       char *p = data.all_files;
       int count = 1;
-      while ((p = strchr(p+1, ' '))) count++;
+      while ((p = strchr(p+1, '\n'))) count++;
       _pathnames = new char*[count];
       _tpathnames = 0;
-      char *q = strtok(data.all_files, " ");
+      char *q = strtok(data.all_files, "\n");
       while (q) {
         _pathnames[_tpathnames] = new char[strlen(q)+1];
         strcpy(_pathnames[_tpathnames], q);
         _tpathnames++;
-        q = strtok(NULL, " ");
+        q = strtok(NULL, "\n");
       }
     }
   }


### PR DESCRIPTION
After upgrading fltk I noticed that it uses the recently added `kdialog` native file picker. However it does not correctly return filenames that contain a space anywhere in the path, instead splitting them into multiple results.

This fixes it by using kdialog's `--separate-output` which modifies `--multiple` to separate multiple results with newlines instead of the default spaces.

I verified that this fixes the `native-filechooser.cxx` test app, and also tested modifying it to use `BROWSE_MULTI_FILE`. Both single and multi file select now behave correctly when selecting filenames with spaces.