### PR TITLE
Fix unicode support in scandir_win32.c by using GetFileAttributesW

### DIFF
--- a/src/scandir_win32.c
+++ b/src/scandir_win32.c
@@ -89,7 +89,6 @@ int fl_scandir(const char *dirname, struct dirent ***namelist,
   strcpy(findIn, dirname);
 
   /* #if defined(__GNUC__) */
-  /* #warning FIXME This probably needs to be MORE UTF8 aware now */
   /* #endif */
   for (d = findIn; *d; d++) if (*d=='/') *d='\\';
   if (len==0) { strcpy(findIn, ".\\*"); }
@@ -97,20 +96,21 @@ int fl_scandir(const char *dirname, struct dirent ***namelist,
   if ((len==1)&& (d[-1]=='.')) { strcpy(findIn, ".\\*"); is_dir = 1; }
   if ((len>0) && (d[-1]=='\\')) { *d++ = '*'; *d = 0; is_dir = 1; }
   if ((len>1) && (d[-1]=='.') && (d[-2]=='\\')) { d[-1] = '*'; is_dir = 1; }
-  if (!is_dir) { /* this file may still be a directory that we need to list */
-    DWORD attr = GetFileAttributes(findIn);
-    if (attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY) )
-      strcpy(d, "\\*");
-  }
   { /* Create a block to limit the scope while we find the initial "wide" filename */
      /* unsigned short * wbuf = (unsigned short*)malloc(sizeof(short) *(len + 10)); */
      /* wbuf[fl_utf2unicode(findIn, strlen(findIn), wbuf)] = 0; */
         unsigned short *wbuf = NULL;
         unsigned wlen = fl_utf8toUtf16(findIn, (unsigned) strlen(findIn), NULL, 0); /* Pass NULL to query length */
         wlen++; /* add a little extra for termination etc. */
-        wbuf = (unsigned short*)malloc(sizeof(unsigned short)*wlen);
+        wbuf = (unsigned short*)malloc(sizeof(unsigned short)*(wlen+2));
         wlen = fl_utf8toUtf16(findIn, (unsigned) strlen(findIn), wbuf, wlen); /* actually convert the filename */
         wbuf[wlen] = 0; /* NULL terminate the resultant string */
+        if (!is_dir) { /* this file may still be a directory that we need to list */
+          DWORD attr = GetFileAttributesW(wbuf);
+          if (attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY) ) {
+            wbuf[wlen] = '\\'; wbuf[wlen+1] = '*'; wbuf[wlen+2] = 0;
+          }
+        }
         h = FindFirstFileW(wbuf, &findw); /* get a handle to the first filename in the search */
         free(wbuf); /* release the "wide" buffer before the pointer goes out of scope */
   }

--- a/src/scandir_win32.c
+++ b/src/scandir_win32.c
@@ -88,8 +88,6 @@ int fl_scandir(const char *dirname, struct dirent ***namelist,
   }
   strcpy(findIn, dirname);
 
-  /* #if defined(__GNUC__) */
-  /* #endif */
   for (d = findIn; *d; d++) if (*d=='/') *d='\\';
   if (len==0) { strcpy(findIn, ".\\*"); }
   if ((len==2)&&findIn[1]==':'&&isalpha(findIn[0])) { *d++ = '\\'; *d = 0; }


### PR DESCRIPTION
There is a GetFileAttributes calling in scandir_win32.c which does not support UTF-8 encoding file name. I modified it using GetFileAttributesW.