### PR TITLE
Fixes fullscreen_active not being correctly set

### DIFF
--- a/src/Fl_Window_fullscreen.cxx
+++ b/src/Fl_Window_fullscreen.cxx
@@ -42,7 +42,6 @@ void Fl_Window::fullscreen() {
   no_fullscreen_h = h();
   if (shown() && !(flags() & Fl_Widget::FULLSCREEN)) {
     pWindowDriver->fullscreen_on();
-  } else {
     set_flag(FULLSCREEN);
   }
 }
@@ -50,7 +49,6 @@ void Fl_Window::fullscreen() {
 void Fl_Window::fullscreen_off(int X,int Y,int W,int H) {
   if (shown() && (flags() & Fl_Widget::FULLSCREEN)) {
     pWindowDriver->fullscreen_off(X, Y, W, H);
-  } else {
     clear_flag(FULLSCREEN);
   }
   no_fullscreen_x = no_fullscreen_y = no_fullscreen_w = no_fullscreen_h = 0;


### PR DESCRIPTION
When fullscreen() or fullscreen_off() were called the FULLSCREEN flag would not get set when the window was shown (the normal behavior), leading to fullscreen_active() always returning 0.