### PR TITLE
This commit fixes the white corners of menus under macOS.

### DIFF
--- a/src/fl_gleam.cxx
+++ b/src/fl_gleam.cxx
@@ -63,6 +63,9 @@ static void gleam_color(Fl_Color c) {
 */
 
 static void shade_rect_top_bottom(int x, int y, int w, int h, Fl_Color fg1, Fl_Color fg2, float th) {
+  // unused background - it is white on macOS but black on Linux and Windows
+  gleam_color(fl_color_average( FL_BLACK, fg1, 0.5 ) );
+  fl_rectf(x, y, w, h);
   // calculate background size w/o borders
   x += 2; y += 2; w -= 4; h -= 4;
   // draw the shiny background using maximum limits

--- a/src/fl_gtk.cxx
+++ b/src/fl_gtk.cxx
@@ -32,6 +32,12 @@ static void gtk_color(Fl_Color c) {
 }
 
 static void gtk_up_frame(int x, int y, int w, int h, Fl_Color c) {
+  gtk_color(fl_color_average(FL_BLACK, c, 0.5));
+  fl_xyline(x, y, x + w-1);
+  fl_yxline(x, y, y + h-1);
+  fl_xyline(x, y+h-1, x + w-1);
+  fl_yxline(x+w-1, y, y+h-1);
+
   gtk_color(fl_color_average(FL_WHITE, c, 0.5));
   fl_xyline(x + 2, y + 1, x + w - 3);
   fl_yxline(x + 1, y + 2, y + h - 3);

--- a/src/fl_plastic.cxx
+++ b/src/fl_plastic.cxx
@@ -72,6 +72,12 @@ static void frame_rect(int x, int y, int w, int h, const char *c, Fl_Color bc) {
   const uchar *g = fl_gray_ramp();
   int b = ((int) strlen(c)) / 4 + 1;
 
+  fl_color(fl_color_average(FL_BLACK, bc, 0.5));
+  fl_xyline(x, y, x + w-1);
+  fl_yxline(x, y, y + h);
+  fl_xyline(x, y+h, x + w-1);
+  fl_yxline(x+w-1, y, y+h);
+
   for (x += b, y += b, w -= 2 * b, h -= 2 * b; b > 1; b --)
   {
     // Draw lines around the perimeter of the button, 4 colors per


### PR DESCRIPTION
MacOS menus would have two pixel white corners that would show up when the background was set to a dark color.  This commit fixes that display glitch.