### PR TITLE
Fixes incorrect install of fluid in macOS Applications directory.

### DIFF
--- a/fluid/CMakeLists.txt
+++ b/fluid/CMakeLists.txt
@@ -163,7 +163,7 @@ if (APPLE AND (NOT OPTION_APPLE_X11))
   # ## set_target_properties (fluid PROPERTIES RESOURCE ${ICON_PATH})
 
   # install fluid GUI and commandline tools
-  install (TARGETS fluid DESTINATION "/Applications")
+  #install (TARGETS fluid DESTINATION "/Applications")
 
   # install command line tool
   install (PROGRAMS $<TARGET_FILE:fluid> DESTINATION ${FLTK_BINDIR})


### PR DESCRIPTION
This requires sudo permissions to do it, and breaks ExtenalProject_Add.  The install on the /Applications directory should be done by creating a macOS bundle (ie. a .dmg file) if this is so much desired.