### PR TITLE
Add Fl_Int_Vector, an STL-ish vector without templates

### DIFF
--- a/FL/Fl_Int_Vector.H
+++ b/FL/Fl_Int_Vector.H
@@ -1,0 +1,83 @@
+//
+// An STL-ish vector without templates for the Fast Light Tool Kit (FLTK).
+//
+// Copyright 2002 by Greg Ercolano.
+// Copyright 2022 by Bill Spitzak and others.
+//
+// This library is free software. Distribution and use rights are outlined in
+// the file "COPYING" which should have been included with this file.  If this
+// file is missing or damaged, see the license at:
+//
+//     https://www.fltk.org/COPYING.php
+//
+// Please see the following page on how to report bugs and issues:
+//
+//     https://www.fltk.org/bugs.php
+//
+
+#ifndef Fl_Int_Vector_H
+#define Fl_Int_Vector_H
+
+#include <FL/Fl.H>
+
+class FL_EXPORT Fl_Int_Vector {
+  int *arr_;
+  unsigned int size_;
+  void init() {
+    arr_ = 0;
+    size_ = 0;
+  }
+  void copy(int *newarr, unsigned int newsize);
+
+public:
+  Fl_Int_Vector() {
+    init();
+  }
+
+  ~Fl_Int_Vector();
+
+  // copy constructor
+  Fl_Int_Vector(Fl_Int_Vector &o) {
+    init();
+    copy(o.arr_, o.size_);
+  }
+
+  // assignment operator
+  Fl_Int_Vector &operator=(Fl_Int_Vector &o) {
+    init();
+    copy(o.arr_, o.size_);
+    return *this;
+  }
+
+  int operator[](int x) const {
+    return arr_[x];
+  }
+
+  int &operator[](int x) {
+    return arr_[x];
+  }
+
+  unsigned int size() {
+    return size_;
+  }
+
+  void size(unsigned int count);
+
+  int pop_back() {
+    int tmp = arr_[size_ - 1];
+    size_--;
+    return tmp;
+  }
+
+  void push_back(int val) {
+    unsigned int x = size_;
+    size(size_ + 1);
+    arr_[x] = val;
+  }
+
+  int back() {
+    return arr_[size_ - 1];
+  }
+};
+
+#endif // Fl_Int_Vector_H

--- a/FL/Fl_Table.H
+++ b/FL/Fl_Table.H
@@ -20,6 +20,7 @@
 
 #include <FL/Fl_Group.H>
 #include <FL/Fl_Scroll.H>
+#include <FL/Fl_Int_Vector.H>
 
 /**
   A table of widgets or other content.
@@ -154,35 +155,8 @@ private:
   };
   unsigned int flags_;
 
-  // An STL-ish vector without templates
-  class FL_EXPORT IntVector {
-    int *arr;
-    unsigned int _size;
-    void init() {
-      arr = 0;
-      _size = 0;
-    }
-    void copy(int *newarr, unsigned int newsize);
-  public:
-    IntVector() { init(); }                                     // CTOR
-    ~IntVector();                                               // DTOR
-    IntVector(IntVector&o) { init(); copy(o.arr, o._size); }    // COPY CTOR
-    IntVector& operator=(IntVector&o) {                         // ASSIGN
-      init();
-      copy(o.arr, o._size);
-      return(*this);
-    }
-    int operator[](int x) const { return(arr[x]); }
-    int& operator[](int x) { return(arr[x]); }
-    unsigned int size() { return(_size); }
-    void size(unsigned int count);
-    int pop_back() { int tmp = arr[_size-1]; _size--; return(tmp); }
-    void push_back(int val) { unsigned int x = _size; size(_size+1); arr[x] = val; }
-    int back() { return(arr[_size-1]); }
-  };
-
-  IntVector _colwidths;                 // column widths in pixels
-  IntVector _rowheights;                // row heights in pixels
+  Fl_Int_Vector _colwidths;             // column widths in pixels
+  Fl_Int_Vector _rowheights;            // row heights in pixels
 
   Fl_Cursor _last_cursor;               // last mouse cursor before changed to 'resize' cursor
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ set (CPPFILES
   Fl_Input.cxx
   Fl_Input_.cxx
   Fl_Input_Choice.cxx
+  Fl_Int_Vector.cxx
   Fl_Light_Button.cxx
   Fl_Menu.cxx
   Fl_Menu_.cxx

--- a/src/Fl_Int_Vector.cxx
+++ b/src/Fl_Int_Vector.cxx
@@ -1,0 +1,43 @@
+//
+// An STL-ish vector without templates for the Fast Light Tool Kit (FLTK).
+//
+// Copyright 2002 by Greg Ercolano.
+// Copyright 2022 by Bill Spitzak and others.
+//
+// This library is free software. Distribution and use rights are outlined in
+// the file "COPYING" which should have been included with this file.  If this
+// file is missing or damaged, see the license at:
+//
+//     https://www.fltk.org/COPYING.php
+//
+// Please see the following page on how to report bugs and issues:
+//
+//     https://www.fltk.org/bugs.php
+//
+
+#include <FL/Fl_Int_Vector.H>
+#include <stdlib.h>
+
+void Fl_Int_Vector::copy(int *newarr, unsigned int newsize) {
+  size(newsize);
+  memcpy(arr_, newarr, newsize * sizeof(int));
+}
+
+Fl_Int_Vector::~Fl_Int_Vector() {
+  if (arr_)
+    free(arr_);
+}
+
+void Fl_Int_Vector::size(unsigned int count) {
+  if (count <= 0) {
+    if (arr_)
+      free(arr_);
+    arr_ = 0;
+    size_ = 0;
+    return;
+  }
+  if (count > size_) {
+    arr_ = (int *)realloc(arr_, count * sizeof(int));
+    size_ = count;
+  }
+}

--- a/src/Fl_Table.cxx
+++ b/src/Fl_Table.cxx
@@ -26,27 +26,6 @@
 #include <stdlib.h>             // realloc/free
 
 
-// An STL-ish vector without templates (private to Fl_Table)
-
-void Fl_Table::IntVector::copy(int *newarr, unsigned int newsize) {
-    size(newsize);
-    memcpy(arr, newarr, newsize * sizeof(int));
-}
-
-Fl_Table::IntVector::~IntVector() { // DTOR
-  if (arr)
-    free(arr);
-  arr = 0;
-}
-
-void Fl_Table::IntVector::size(unsigned int count) {
-  if (count != _size) {
-    arr = (int*)realloc(arr, count * sizeof(int));
-    _size = count;
-  }
-}
-
-
 /** Sets the vertical scroll position so 'row' is at the top,
     and causes the screen to redraw.
 */

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,6 +51,7 @@ CPPFILES = \
 	Fl_Input.cxx \
 	Fl_Input_.cxx \
 	Fl_Input_Choice.cxx \
+	Fl_Int_Vector.cxx \
 	Fl_Light_Button.cxx \
 	Fl_Menu.cxx \
 	Fl_Menu_.cxx \


### PR DESCRIPTION
We need a vector of `int`'s in several places to simplify our code. Since we can't use std::vector I propose to add a new official class `Fl_Int_Vector` for a vector of `int`'s without templates.

The original code was taken from class `Fl_Table` which used an internal class `IntVector`, copied in its own files, and reformatted.

The second commit of this PR (branch) removes the internal class definition `IntVector` from `Fl_Table` and uses `Fl_Int_Vector` instead.

Tested and works for me.

@erco77 Could you please take a look at the copied and modified code, including the copyright note? Thanks in advance.