### PR TITLE
Making building Fluid optional.

### DIFF
--- a/CMake/FLTK-Functions.cmake
+++ b/CMake/FLTK-Functions.cmake
@@ -23,13 +23,10 @@
 
 function (FLTK_RUN_FLUID TARGET SOURCES)
 
-  if (NOT FLTK_BUILD_FLUID)
-    message (WARNING "Not building ${SOURCES}. FLTK_BUILD_FLUID is OFF.")
-    return ()
-  elseif (NOT FLTK_FLUID_EXECUTABLE)
+  if (NOT FLTK_FLUID_EXECUTABLE)
     message (WARNING "Not building ${SOURCES}. FLUID executable not found.")
     return ()
-  endif (NOT FLTK_BUILD_FLUID)
+  endif (NOT FLTK_FLUID_EXECUTABLE)
 
   set (CXX_FILES)
   foreach (src ${SOURCES})

--- a/CMake/FLTK-Functions.cmake
+++ b/CMake/FLTK-Functions.cmake
@@ -22,6 +22,15 @@
 # USAGE: FLTK_RUN_FLUID TARGET_NAME "FLUID_SOURCE [.. FLUID_SOURCE]"
 
 function (FLTK_RUN_FLUID TARGET SOURCES)
+
+  if (NOT FLTK_BUILD_FLUID)
+    message (WARNING "Not building ${SOURCES}. FLTK_BUILD_FLUID is OFF.")
+    return ()
+  elseif (NOT FLTK_FLUID_EXECUTABLE)
+    message (WARNING "Not building ${SOURCES}. FLUID executable not found.")
+    return ()
+  endif (NOT FLTK_BUILD_FLUID)
+
   set (CXX_FILES)
   foreach (src ${SOURCES})
     if ("${src}" MATCHES "\\.fl$")
@@ -36,6 +45,7 @@ function (FLTK_RUN_FLUID TARGET SOURCES)
     endif ("${src}" MATCHES "\\.fl$")
   endforeach ()
   set (${TARGET} ${CXX_FILES} PARENT_SCOPE)
+
 endfunction (FLTK_RUN_FLUID TARGET SOURCES)
 
 #######################################################################

--- a/CMake/FLTKConfig.cmake.in
+++ b/CMake/FLTKConfig.cmake.in
@@ -10,7 +10,7 @@
 #  FLTK_INCLUDE_DIRS      - FLTK include directories
 #  FLTK_LIBRARIES         - list of FLTK libraries built (not yet implemented)
 #  FLTK_FLUID_EXECUTABLE  - needed by the function FLTK_RUN_FLUID
-#                          (or the deprecated fltk_wrap_ui() CMake command)
+#                           (or the deprecated fltk_wrap_ui() CMake command)
 #
 # It defines the following deprecated variables for backwards
 # compatibility (do not use for new projects):
@@ -37,17 +37,21 @@ set (FLTK_USE_FILE ${CMAKE_CURRENT_LIST_DIR}/UseFLTK.cmake)
 
 set (FLTK_INCLUDE_DIR "${FLTK_INCLUDE_DIRS}")
 
-if (CMAKE_CROSSCOMPILING)
-  find_file(FLUID_PATH
-    NAMES fluid fluid.exe
-    PATHS ENV PATH
-    NO_CMAKE_FIND_ROOT_PATH
-  )
-  add_executable(fluid IMPORTED)
-  set_target_properties(fluid
-    PROPERTIES IMPORTED_LOCATION ${FLUID_PATH}
-  )
-  set (FLTK_FLUID_EXECUTABLE ${FLUID_PATH})
+if ("@FLTK_FLUID_EXECUTABLE@")
+  if (CMAKE_CROSSCOMPILING)
+    find_file(FLUID_PATH
+      NAMES fluid fluid.exe
+      PATHS ENV PATH
+      NO_CMAKE_FIND_ROOT_PATH
+    )
+    add_executable(fluid IMPORTED)
+    set_target_properties(fluid
+      PROPERTIES IMPORTED_LOCATION ${FLUID_PATH}
+    )
+    set (FLTK_FLUID_EXECUTABLE ${FLUID_PATH})
+  else ()
+    set (FLTK_FLUID_EXECUTABLE fluid)
+  endif (CMAKE_CROSSCOMPILING)
 else ()
-  set (FLTK_FLUID_EXECUTABLE fluid)
-endif (CMAKE_CROSSCOMPILING)
+  set (FLTK_FLUID_EXECUTABLE NOTFOUND)
+endif ("@FLTK_FLUID_EXECUTABLE@")

--- a/CMake/FLTKConfig.cmake.in
+++ b/CMake/FLTKConfig.cmake.in
@@ -37,21 +37,17 @@ set (FLTK_USE_FILE ${CMAKE_CURRENT_LIST_DIR}/UseFLTK.cmake)
 
 set (FLTK_INCLUDE_DIR "${FLTK_INCLUDE_DIRS}")
 
-if ("@FLTK_FLUID_EXECUTABLE@")
-  if (CMAKE_CROSSCOMPILING)
-    find_file(FLUID_PATH
-      NAMES fluid fluid.exe
-      PATHS ENV PATH
-      NO_CMAKE_FIND_ROOT_PATH
-    )
-    add_executable(fluid IMPORTED)
-    set_target_properties(fluid
-      PROPERTIES IMPORTED_LOCATION ${FLUID_PATH}
-    )
-    set (FLTK_FLUID_EXECUTABLE ${FLUID_PATH})
-  else ()
-    set (FLTK_FLUID_EXECUTABLE fluid)
-  endif (CMAKE_CROSSCOMPILING)
+if (CMAKE_CROSSCOMPILING)
+  find_file(FLUID_PATH
+    NAMES fluid fluid.exe
+    PATHS ENV PATH
+    NO_CMAKE_FIND_ROOT_PATH
+  )
+  add_executable(fluid IMPORTED)
+  set_target_properties(fluid
+    PROPERTIES IMPORTED_LOCATION ${FLUID_PATH}
+  )
+  set (FLTK_FLUID_EXECUTABLE ${FLUID_PATH})
 else ()
-  set (FLTK_FLUID_EXECUTABLE NOTFOUND)
-endif ("@FLTK_FLUID_EXECUTABLE@")
+  set (FLTK_FLUID_EXECUTABLE fluid)
+endif (CMAKE_CROSSCOMPILING)

--- a/CMake/export.cmake
+++ b/CMake/export.cmake
@@ -30,7 +30,7 @@ if (CMAKE_CROSSCOMPILING)
   )
   set (FLTK_FLUID_EXECUTABLE ${FLUID_PATH})
   set (FLUID_EXPORT "")                     # don't export fluid
-else ()
+elseif (FLTK_BUILD_FLUID)
   # use the fluid executable we build
   if (WIN32)
     set (FLTK_FLUID_EXECUTABLE fluid-cmd)
@@ -39,6 +39,8 @@ else ()
     set (FLTK_FLUID_EXECUTABLE fluid)
     set (FLUID_EXPORT fluid)                # export fluid
   endif ()
+else ()
+  set (FLTK_FLUID_EXECUTABLE NOTFOUND)
 endif (CMAKE_CROSSCOMPILING)
 
 # generate FLTK-Targets.cmake for build directory use

--- a/CMake/export.cmake
+++ b/CMake/export.cmake
@@ -21,16 +21,7 @@
 
 # Set the fluid executable path used to create .cxx/.h from .fl files
 
-if (CMAKE_CROSSCOMPILING)
-  # find a fluid executable on the host system
-  find_file(FLUID_PATH
-    NAMES fluid fluid.exe
-    PATHS ENV PATH
-    NO_CMAKE_FIND_ROOT_PATH
-  )
-  set (FLTK_FLUID_EXECUTABLE ${FLUID_PATH})
-  set (FLUID_EXPORT "")                     # don't export fluid
-elseif (FLTK_BUILD_FLUID)
+if (FLTK_BUILD_FLUID AND NOT CMAKE_CROSSCOMPILING)
   # use the fluid executable we build
   if (WIN32)
     set (FLTK_FLUID_EXECUTABLE fluid-cmd)
@@ -40,8 +31,15 @@ elseif (FLTK_BUILD_FLUID)
     set (FLUID_EXPORT fluid)                # export fluid
   endif ()
 else ()
-  set (FLTK_FLUID_EXECUTABLE NOTFOUND)
-endif (CMAKE_CROSSCOMPILING)
+  # find a fluid executable on the host system
+  find_file(FLUID_PATH
+    NAMES fluid fluid.exe
+    PATHS ENV PATH
+    NO_CMAKE_FIND_ROOT_PATH
+  )
+  set (FLTK_FLUID_EXECUTABLE ${FLUID_PATH})
+  set (FLUID_EXPORT "")                     # don't export fluid
+endif (FLTK_BUILD_FLUID AND NOT CMAKE_CROSSCOMPILING)
 
 # generate FLTK-Targets.cmake for build directory use
 export (TARGETS ${FLUID_EXPORT} ${FLTK_LIBRARIES} FILE ${CMAKE_CURRENT_BINARY_DIR}/FLTK-Targets.cmake)

--- a/CMake/fl_create_example.cmake
+++ b/CMake/fl_create_example.cmake
@@ -50,7 +50,7 @@
 #
 ################################################################################
 
-macro (CREATE_EXAMPLE NAME SOURCES LIBRARIES)
+function (CREATE_EXAMPLE NAME SOURCES LIBRARIES)
 
   set (srcs)                    # source files
   set (flsrcs)                  # fluid source (.fl) files
@@ -91,9 +91,17 @@ macro (CREATE_EXAMPLE NAME SOURCES LIBRARIES)
   # generate source files from .fl files, add output to sources
 
   if (flsrcs)
-    FLTK_RUN_FLUID (FLUID_SOURCES "${flsrcs}")
-    list (APPEND srcs ${FLUID_SOURCES})
-    unset (FLUID_SOURCES)
+    if (NOT FLTK_BUILD_FLUID)
+      message(STATUS "Example app \"${NAME}\" will not be built (set FLTK_BUILD_FLUID=ON to build).")
+      return ()
+    elseif (NOT FLTK_FLUID_EXECUTABLE)
+      message(STATUS "Example app \"${NAME}\" will not be built. FLUID executable not found.")
+      return ()
+    else ()
+      FLTK_RUN_FLUID (FLUID_SOURCES "${flsrcs}")
+      list (APPEND srcs ${FLUID_SOURCES})
+      unset (FLUID_SOURCES)
+    endif (NOT FLTK_BUILD_FLUID)
   endif (flsrcs)
 
   # set macOS (icon) resource path if applicable
@@ -176,4 +184,4 @@ macro (CREATE_EXAMPLE NAME SOURCES LIBRARIES)
   # *unused* #    endforeach ()
   # *unused* #  endif ()
 
-endmacro (CREATE_EXAMPLE NAME SOURCES LIBRARIES)
+endfunction ()

--- a/CMake/fl_create_example.cmake
+++ b/CMake/fl_create_example.cmake
@@ -91,17 +91,13 @@ function (CREATE_EXAMPLE NAME SOURCES LIBRARIES)
   # generate source files from .fl files, add output to sources
 
   if (flsrcs)
-    if (NOT FLTK_BUILD_FLUID)
-      message(STATUS "Example app \"${NAME}\" will not be built (set FLTK_BUILD_FLUID=ON to build).")
-      return ()
-    elseif (NOT FLTK_FLUID_EXECUTABLE)
+    if (NOT FLTK_FLUID_EXECUTABLE)
       message(STATUS "Example app \"${NAME}\" will not be built. FLUID executable not found.")
       return ()
-    else ()
-      FLTK_RUN_FLUID (FLUID_SOURCES "${flsrcs}")
-      list (APPEND srcs ${FLUID_SOURCES})
-      unset (FLUID_SOURCES)
-    endif (NOT FLTK_BUILD_FLUID)
+    endif ()
+    FLTK_RUN_FLUID (FLUID_SOURCES "${flsrcs}")
+    list (APPEND srcs ${FLUID_SOURCES})
+    unset (FLUID_SOURCES)
   endif (flsrcs)
 
   # set macOS (icon) resource path if applicable

--- a/CMake/install.cmake
+++ b/CMake/install.cmake
@@ -122,14 +122,17 @@ if (UNIX OR MSYS OR MINGW)
     )
   endmacro (INSTALL_MAN FILE LEVEL)
 
-  INSTALL_MAN (fluid 1)
+  if (FLTK_BUILD_FLUID)
+    INSTALL_MAN (fluid 1)
+  endif (FLTK_BUILD_FLUID)
   INSTALL_MAN (fltk-config 1)
   INSTALL_MAN (fltk 3)
 
-  # Don't (!) install man pages of games (GitHub issue #23)
-
-  # INSTALL_MAN (blocks 6)
-  # INSTALL_MAN (checkers 6)
-  # INSTALL_MAN (sudoku 6)
+  if (FLTK_BUILD_TEST AND FLTK_BUILD_FLUID)
+    # Don't (!) install man pages of games (GitHub issue #23)
+    # INSTALL_MAN (blocks 6)
+    # INSTALL_MAN (checkers 6)
+    # INSTALL_MAN (sudoku 6)
+  endif ()
 
 endif (UNIX OR MSYS OR MINGW)

--- a/CMake/options.cmake
+++ b/CMake/options.cmake
@@ -301,6 +301,7 @@ option (OPTION_BUILD_SHARED_LIBS
 option (OPTION_PRINT_SUPPORT "allow print support" ON)
 option (OPTION_FILESYSTEM_SUPPORT "allow file system support" ON)
 
+option (FLTK_BUILD_FLUID    "Build FLUID"              ON)
 option (FLTK_BUILD_TEST     "Build test/demo programs" ON)
 option (FLTK_BUILD_EXAMPLES "Build example programs"   OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,9 +111,9 @@ add_subdirectory(src)
 # build fluid
 #######################################################################
 
-if (FLTK_BUILD_FLUID AND NOT CMAKE_CROSSCOMPILING)
+if (FLTK_BUILD_FLUID)
   add_subdirectory (fluid)
-endif (FLTK_BUILD_FLUID AND NOT CMAKE_CROSSCOMPILING)
+endif (FLTK_BUILD_FLUID)
 
 #######################################################################
 # variables shared by export and install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,9 @@ add_subdirectory(src)
 # build fluid
 #######################################################################
 
-add_subdirectory(fluid)
+if (FLTK_BUILD_FLUID AND NOT CMAKE_CROSSCOMPILING)
+  add_subdirectory (fluid)
+endif (FLTK_BUILD_FLUID AND NOT CMAKE_CROSSCOMPILING)
 
 #######################################################################
 # variables shared by export and install
@@ -209,6 +211,12 @@ if (OPTION_BUILD_SHARED_LIBS)
 else ()
   message (STATUS "Shared libraries will not be built (set OPTION_BUILD_SHARED_LIBS=ON to build)")
 endif ()
+
+if (FLTK_BUILD_FLUID)
+   message (STATUS "FLUID will be built in ${CMAKE_CURRENT_BINARY_DIR}/bin/fluid")
+ else ()
+   message (STATUS "FLUID will not be built (set FLTK_BUILD_FLUID=ON to build)")
+ endif ()
 
 if (FLTK_BUILD_TEST)
   message (STATUS "Test programs    will be built in ${CMAKE_CURRENT_BINARY_DIR}/bin/test")

--- a/README.CMake.txt
+++ b/README.CMake.txt
@@ -119,6 +119,9 @@ OPTION_BUILD_SHARED_LIBS - default OFF
    Normally FLTK is built as static libraries which makes more portable
    binaries.  If you want to use shared libraries, this will build them too.
 
+FLTK_BUILD_FLUID - default ON
+    Builds the Fast Light User-Interface Designer ("FLUID").
+
 FLTK_BUILD_TEST - default ON
    Builds the test and demo programs in the 'test' directory.
 


### PR DESCRIPTION
Based on the great submission by @AlexMax in PR #315, this PR adds the option FLTK_BUILD_FLUID to the CMake system. The default is ON. If set to OFF, Fluid will not be built.

Examples and tests can still be built, except for those that depend on Fluid. I decided to give little warning if examples or tests are enabled, but Fluid is disable and not found.

This also solves cross-compiling where Fluid is not built because it doesn't serve much purpose, but if a host Fluid is found, all tests are still cross compiled (untested, must merge first).