### PR TITLE
Improve Fluid argument handling and relative paths.

### DIFF
--- a/fluid/Fl_Function_Type.cxx
+++ b/fluid/Fl_Function_Type.cxx
@@ -1128,9 +1128,9 @@ void Fl_Data_Type::open() {
       if (w == data_panel_cancel) goto BREAK2;
       else if (w == data_panel_ok) break;
       else if (w == data_filebrowser) {
-        goto_designfile_dir();
+        enter_project_dir();
         const char *fn = fl_file_chooser("Load Inline Data", 0L, data_filename->value(), 1);
-        leave_designfile_dir();
+        leave_project_dir();
         if (fn) {
           if (strcmp(fn, data_filename->value()))
             set_modflag(1);
@@ -1217,9 +1217,9 @@ void Fl_Data_Type::write_code1() {
   int nData = -1;
   // path should be set correctly already
   if (filename_ && !write_sourceview) {
-    goto_designfile_dir();
+    enter_project_dir();
     FILE *f = fl_fopen(filename_, "rb");
-    leave_designfile_dir();
+    leave_project_dir();
     if (!f) {
       message = "Can't include data from file. Can't open";
     } else {

--- a/fluid/Fluid_Image.cxx
+++ b/fluid/Fluid_Image.cxx
@@ -104,9 +104,9 @@ void Fluid_Image::write_static() {
     }
     write_c("static const unsigned char %s[] =\n", idata_name);
 
-    goto_designfile_dir();
+    enter_project_dir();
     FILE *f = fl_fopen(name(), "rb");
-    leave_designfile_dir();
+    leave_project_dir();
     if (!f) {
       write_file_error("JPEG");
     } else {
@@ -133,9 +133,9 @@ void Fluid_Image::write_static() {
     }
     write_c("static const char %s[] =\n", idata_name);
 
-    goto_designfile_dir();
+    enter_project_dir();
     FILE *f = fl_fopen(name(), "rb");
-    leave_designfile_dir();
+    leave_project_dir();
     if (!f) {
       write_file_error("SVG");
     } else {
@@ -170,9 +170,9 @@ void Fluid_Image::write_static() {
 
 void Fluid_Image::write_file_error(const char *fmt) {
   write_c("#warning Cannot read %s file \"%s\": %s\n", fmt, name(), strerror(errno));
-  goto_designfile_dir();
+  enter_project_dir();
   write_c("// Searching in path \"%s\"\n", fl_getcwd(0, FL_PATH_MAX));
-  leave_designfile_dir();
+  leave_project_dir();
 }
 
 void Fluid_Image::write_initializer(const char *type_name, const char *format, ...) {
@@ -224,11 +224,11 @@ Fluid_Image* Fluid_Image::find(const char *iname) {
 
   // no, so now see if the file exists:
 
-  goto_designfile_dir();
+  enter_project_dir();
   FILE *f = fl_fopen(iname,"rb");
   if (!f) {
     read_error("%s : %s",iname,strerror(errno));
-    leave_designfile_dir();
+    leave_project_dir();
     return 0;
   }
   fclose(f);
@@ -240,7 +240,7 @@ Fluid_Image* Fluid_Image::find(const char *iname) {
     ret = 0;
     read_error("%s : unrecognized image format", iname);
   }
-  leave_designfile_dir();
+  leave_project_dir();
   if (!ret) return 0;
 
   // make a new entry in the table:
@@ -289,12 +289,12 @@ Fluid_Image::~Fluid_Image() {
 
 const char *ui_find_image_name;
 Fluid_Image *ui_find_image(const char *oldname) {
-  goto_designfile_dir();
+  enter_project_dir();
   fl_file_chooser_ok_label("Use Image");
   const char *name = fl_file_chooser("Image?","Image Files (*.{bm,bmp,gif,jpg,pbm,pgm,png,ppm,xbm,xpm,svg})",oldname,1);
   fl_file_chooser_ok_label(NULL);
   ui_find_image_name = name;
   Fluid_Image *ret = (name && *name) ? Fluid_Image::find(name) : 0;
-  leave_designfile_dir();
+  leave_project_dir();
   return ret;
 }

--- a/fluid/fluid.cxx
+++ b/fluid/fluid.cxx
@@ -147,9 +147,9 @@ int modflag_c = 0;
 /// \see goto_source_dir()
 static char* app_work_dir = NULL;
 
-/// Set, if the current working directory is in the source code folder vs. the app working space.
-/// \see goto_source_dir()
-static char in_designfile_dir = 0;
+/// Used as a counter to set the .fl project dir as the current directory.
+/// \see enter_project_dir(), leave_project_dir()
+static char in_project_dir = 0;
 
 /// Set, if Fluid was started with the command line argument -u
 int update_file = 0;            // fluid -u
@@ -249,47 +249,69 @@ void update_sourceview_timer(void*);
 // ----
 
 /**
- Change the current working directory to the source code folder.
- Remember the the previous directory, so \c leave_source_dir() can return there.
- \see leave_source_dir(), pwd, in_source_dir
+ Change the current working directory to the .fl project directory.
+
+ Every call to enter_project_dir() must have a corresponding leave_project_dir()
+ call. Enter and leave calls can be nested.
+
+ The first call to enter_project_dir() remembers the original directory, usually
+ the launch directory of the application. Nested cllas will incrment a nesting
+ counter. When the nesting counter is back to 0, leave_source_dir() will return
+ to the original directory.
+
+ The global variable 'filenae' must be set to the current project file with
+ absolute or relative path information.
+
+ \see leave_source_dir(), pwd, in_project_dir
  */
-void goto_designfile_dir() {
-  in_designfile_dir++;
-  if (in_designfile_dir>1) return;
-  if (!filename || !*filename) return;
-  const char *p = fl_filename_name(filename);
-  if (p <= filename) return; // it is in the current directory
-  char buffer[FL_PATH_MAX];
-  strlcpy(buffer, filename, sizeof(buffer));
-  int n = (int)(p-filename);
-  if (n>1) n--;
-  buffer[n] = 0;
-  if (!app_work_dir) {
-    app_work_dir = fl_getcwd(0, FL_PATH_MAX);
-    if (!app_work_dir) {
-      fprintf(stderr, "goto_source_dir: getwd: %s\n", strerror(errno));
-      return;
-    }
+void enter_project_dir() {
+  if (in_project_dir<0) {
+    fprintf(stderr, "** Fluid internal error: enter_project_dir() calls unmatched\n");
+    return;
   }
-  if (buffer[0] && (fl_chdir(buffer) < 0)) {
-    fprintf(stderr, "goto_source_dir: can't chdir to %s: %s\n", buffer, strerror(errno));
+  in_project_dir++;
+  // check if we are already in the project dir and do nothing if so
+  if (in_project_dir>1) return;
+  // check if there is an active project, and do nothing if there is none
+  if (!filename || !*filename) {
+    fprintf(stderr, "** Fluid internal error: enter_project_dir() no filename set\n");
+    return;
+  }
+  // get the absolute path to the current project
+  char project_path[FL_PATH_MAX]; project_path[0] = 0;
+  fl_filename_absolute(project_path, FL_PATH_MAX, filename);
+  // cut the name part and leave only the path to our project
+  char *p = (char*)fl_filename_name(project_path);
+  if (p) *p = 0;
+  // store the current working directory for later
+  if (!app_work_dir) app_work_dir = (char*)malloc(FL_PATH_MAX);
+  fl_getcwd(app_work_dir, FL_PATH_MAX);
+  // now set the current directory to the path of our .fl file
+  if (fl_chdir(project_path)==-1) {
+    fprintf(stderr, "** Fluid internal error: enter_project_dir() can't chdir to %s: %s\n",
+            project_path, strerror(errno));
     return;
   }
   // fprintf(stderr, "chdir to %s\n", fl_getcwd(0, FL_PATH_MAX));
 }
 
 /**
- Change the current working directory to its previous directory.
- \see goto_source_dir(), pwd, in_source_dir
+ Change the current working directory to the previous directory.
+ \see enter_project_dir(), pwd, in_project_dir
  */
-void leave_designfile_dir() {
-  if (in_designfile_dir == 0) return; // error: called leave_... more often the goto_...
-  in_designfile_dir--;
-  if (in_designfile_dir) return;
-  if (fl_chdir(app_work_dir) < 0) {
-    fprintf(stderr, "Can't chdir to %s : %s\n", app_work_dir, strerror(errno));
+void leave_project_dir() {
+  if (in_project_dir == 0) {
+    fprintf(stderr, "** Fluid internal error: leave_project_dir() calls unmatched\n");
+    return;
   }
-  // fprintf(stderr, "chdir back to %s\n", app_work_dir);
+  in_project_dir--;
+  // still nested, stay in the project directory
+  if (in_project_dir > 0) return;
+  // no longer nested, return to the original, usually the application working directory
+  if (fl_chdir(app_work_dir) < 0) {
+    fprintf(stderr, "** Fluid internal error: leave_project_dir() can't chdir back to %s : %s\n",
+            app_work_dir, strerror(errno));
+  }
 }
 
 /**
@@ -926,9 +948,9 @@ int write_code_files() {
   } else {
     strlcpy(hname, header_file_name, sizeof(hname));
   }
-  if (!batch_mode) goto_designfile_dir();
+  if (!batch_mode) enter_project_dir();
   int x = write_code(cname,hname);
-  if (!batch_mode) leave_designfile_dir();
+  if (!batch_mode) leave_project_dir();
   strlcat(cname, " and ", sizeof(cname));
   strlcat(cname, hname, sizeof(cname));
   if (batch_mode) {
@@ -965,9 +987,9 @@ void write_strings_cb(Fl_Widget *, void *) {
   char sname[FL_PATH_MAX];
   strlcpy(sname, fl_filename_name(filename), sizeof(sname));
   fl_filename_setext(sname, sizeof(sname), exts[i18n_type]);
-  if (!batch_mode) goto_designfile_dir();
+  if (!batch_mode) enter_project_dir();
   int x = write_strings(sname);
-  if (!batch_mode) leave_designfile_dir();
+  if (!batch_mode) leave_project_dir();
   if (batch_mode) {
     if (x) {fprintf(stderr,"%s : %s\n",sname,strerror(errno)); exit(1);}
   } else {
@@ -1835,6 +1857,8 @@ void update_sourceview_timer(void*)
  \return number of arguments used; if 0, the argument is not supported
  */
 static int arg(int argc, char** argv, int& i) {
+  if (argv[i][0]!='-')
+    return 0;
   if (argv[i][1] == 'd' && !argv[i][2]) {G_debug=1; i++; return 1;}
   if (argv[i][1] == 'u' && !argv[i][2]) {update_file++; batch_mode++; i++; return 1;}
   if (argv[i][1] == 'c' && !argv[i][2]) {compile_file++; batch_mode++; i++; return 1;}
@@ -1842,14 +1866,21 @@ static int arg(int argc, char** argv, int& i) {
   if (argv[i][1] == 'o' && !argv[i][2] && i+1 < argc) {
     code_file_name = argv[i+1];
     code_file_set  = 1;
+    batch_mode++;
     i += 2;
     return 2;
   }
   if (argv[i][1] == 'h' && !argv[i][2]) {
-    header_file_name = argv[i+1];
-    header_file_set  = 1;
-    i += 2;
-    return 2;
+    if (i+1 < argc) {
+      header_file_name = argv[i+1];
+      header_file_set  = 1;
+      batch_mode++;
+      i += 2;
+      return 2;
+    } else {
+      // a lone "-h" without a filename will output the help string
+      return 0;
+    }
   }
   return 0;
 }
@@ -1901,7 +1932,9 @@ int main(int argc,char **argv) {
   setlocale(LC_ALL, "");      // enable multilanguage errors in file chooser
   setlocale(LC_NUMERIC, "C"); // make sure numeric values are written correctly
 
-  if (!Fl::args(argc,argv,i,arg) || i < argc-1) {
+  if (   (Fl::args(argc,argv,i,arg) == 0)   // unsupported argument found
+      || (batch_mode && (i != argc-1))      // .fl filename missing
+      || (!batch_mode && (i < argc-1)) ) {  // more than one filename found
     static const char *msg =
       "usage: %s <switches> name.fl\n"
       " -u : update .fl file and exit (may be combined with '-c' or '-cs')\n"

--- a/fluid/fluid.h
+++ b/fluid/fluid.h
@@ -67,8 +67,8 @@ extern Fl_Menu_Item *overlay_item;
 
 extern int modflag;
 
-extern void goto_designfile_dir();
-extern void leave_designfile_dir();
+extern void enter_project_dir();
+extern void leave_project_dir();
 
 extern int update_file;            // fluid -u
 extern int compile_file;           // fluid -c


### PR DESCRIPTION
This commit fixes the warnings from Issue #543 and the crash in issue #514 .

#543 was a bug that was probably there for a while, but finally detected by an error message that I added in a recent commit. I rewrote the function that make sure that all paths within .fl files are seen relative to the file itself.

#514 was caused by an incomplete handling of invalid command line arguments. The new handler adds more error handling, especially if batch mode is requested, but no filename is given. It also outputs a brief usage hint when the user types `fluid -h`. The old parameter syntax `fluid -c -h .hxx project.fl` still works.