### PR TITLE
Fluid: Add Undo to formula input fields.

### DIFF
--- a/documentation/src/fluid.dox
+++ b/documentation/src/fluid.dox
@@ -1028,6 +1028,25 @@ the image.
 The position fields show the current position and size of the
 widget box. Enter new values to move and/or resize a widget.
 
+\par
+These fields understand basic math and variables.
+Appending <tt>+10</tt> to the <b>X</b> coordinate will move a widget 10 units
+to the right without having to reenter the value.
+Entering the formula <tt>w+3</tt> in the <b>Width</b> field will widen all
+selected Widgets by 3 units.
+The formula <tt>py+i*20</tt> in the <b>Y</b> field will order all selected
+widgets vertically in their group by increments of 20 units.
+
+\par
+<table>
+<tr><th>Name</th><th>Value</th></tr>
+<tr><td> `i` </td><td> zero based counter of selected widgets </td></tr>
+<tr><td> `x`, `y`, `w`, `h` </td><td> position and size of the current widget </td></tr>
+<tr><td> `px`, `py`, `pw`, `ph` </td><td> dimensions of the parent widget </td></tr>
+<tr><td> `sx`, `sy`, `sw`, `sh` </td><td> dimensions of the previous sibling </td></tr>
+<tr><td> `cx`, `cy`, `cw`, `ch` </td><td> bounding box of all children </td></tr>
+</table>
+
 \par Values (text fields)
 
 \par

--- a/fluid/Fl_Widget_Type.cxx
+++ b/fluid/Fl_Widget_Type.cxx
@@ -26,6 +26,7 @@
 #include "Fluid_Image.h"
 #include "alignment_panel.h"
 #include "widget_panel.h"
+#include "undo.h"
 
 #include <FL/Fl.H>
 #include <FL/Fl_Group.H>
@@ -666,6 +667,7 @@ void x_cb(Fluid_Coord_Input *i, void *v) {
       x_input->activate();
     } else x_input->deactivate();
   } else {
+    undo_checkpoint();
     widget_i = 0;
     int mod = 0;
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
@@ -690,6 +692,7 @@ void y_cb(Fluid_Coord_Input *i, void *v) {
       y_input->activate();
     } else y_input->deactivate();
   } else {
+    undo_checkpoint();
     widget_i = 0;
     int mod = 0;
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
@@ -714,6 +717,7 @@ void w_cb(Fluid_Coord_Input *i, void *v) {
       w_input->activate();
     } else w_input->deactivate();
   } else {
+    undo_checkpoint();
     widget_i = 0;
     int mod = 0;
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
@@ -738,6 +742,7 @@ void h_cb(Fluid_Coord_Input *i, void *v) {
       h_input->activate();
     } else h_input->deactivate();
   } else {
+    undo_checkpoint();
     widget_i = 0;
     int mod = 0;
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {

--- a/fluid/widget_panel.cxx
+++ b/fluid/widget_panel.cxx
@@ -274,7 +274,8 @@ Fl_Double_Window* make_widget_panel() {
           o->callback((Fl_Callback*)position_group_cb);
           o->align(Fl_Align(FL_ALIGN_LEFT));
           { widget_x_input = new Fluid_Coord_Input(95, 150, 55, 20, "X:");
-            widget_x_input->tooltip("The X position of the widget.");
+            widget_x_input->tooltip("The X position of the widget as a number or formula.\nFormulas can be simple \
+math, including the variables\nx, px, sx, cx, and i");
             widget_x_input->box(FL_DOWN_BOX);
             widget_x_input->color(FL_BACKGROUND2_COLOR);
             widget_x_input->selection_color(FL_SELECTION_COLOR);
@@ -288,7 +289,8 @@ Fl_Double_Window* make_widget_panel() {
             widget_x_input->when(FL_WHEN_RELEASE);
           } // Fluid_Coord_Input* widget_x_input
           { widget_y_input = new Fluid_Coord_Input(155, 150, 55, 20, "Y:");
-            widget_y_input->tooltip("The Y position of the widget.");
+            widget_y_input->tooltip("The Y position of the widget as a number or formula.\nFormulas can be simple \
+math, including the variables\ny, py, sy, cy, and i");
             widget_y_input->box(FL_DOWN_BOX);
             widget_y_input->color(FL_BACKGROUND2_COLOR);
             widget_y_input->selection_color(FL_SELECTION_COLOR);
@@ -302,7 +304,8 @@ Fl_Double_Window* make_widget_panel() {
             widget_y_input->when(FL_WHEN_RELEASE);
           } // Fluid_Coord_Input* widget_y_input
           { widget_w_input = new Fluid_Coord_Input(215, 150, 55, 20, "Width:");
-            widget_w_input->tooltip("The width of the widget.");
+            widget_w_input->tooltip("The width of the widget as a number or formula.\nFormulas can be simple math,\
+ including the variables\nw, pw, sw, cw, and i");
             widget_w_input->box(FL_DOWN_BOX);
             widget_w_input->color(FL_BACKGROUND2_COLOR);
             widget_w_input->selection_color(FL_SELECTION_COLOR);
@@ -316,7 +319,8 @@ Fl_Double_Window* make_widget_panel() {
             widget_w_input->when(FL_WHEN_RELEASE);
           } // Fluid_Coord_Input* widget_w_input
           { widget_h_input = new Fluid_Coord_Input(275, 150, 55, 20, "Height:");
-            widget_h_input->tooltip("The height of the widget.");
+            widget_h_input->tooltip("The height of the widget as a number or formula.\nFormulas can be simple math\
+, including the variables\nh, ph, sh, ch, and i");
             widget_h_input->box(FL_DOWN_BOX);
             widget_h_input->color(FL_BACKGROUND2_COLOR);
             widget_h_input->selection_color(FL_SELECTION_COLOR);

--- a/fluid/widget_panel.fl
+++ b/fluid/widget_panel.fl
@@ -264,30 +264,38 @@ Use Ctrl-J for newlines.} xywh {95 40 190 20} labelfont 1 labelsize 11 when 1 te
           Fl_Input widget_x_input {
             label {X:}
             callback x_cb
-            tooltip {The X position of the widget.} xywh {95 150 55 20} labelsize 11 align 5 textsize 11
+            tooltip {The X position of the widget as a number or formula.
+Formulas can be simple math, including the variables
+x, px, sx, cx, and i} xywh {95 150 55 20} labelsize 11 align 5 textsize 11
             class Fluid_Coord_Input
           }
           Fl_Input widget_y_input {
             label {Y:}
             callback y_cb
-            tooltip {The Y position of the widget.} xywh {155 150 55 20} labelsize 11 align 5 textsize 11
+            tooltip {The Y position of the widget as a number or formula.
+Formulas can be simple math, including the variables
+y, py, sy, cy, and i} xywh {155 150 55 20} labelsize 11 align 5 textsize 11
             class Fluid_Coord_Input
           }
           Fl_Input widget_w_input {
             label {Width:}
             callback w_cb
-            tooltip {The width of the widget.} xywh {215 150 55 20} labelsize 11 align 5 textsize 11
+            tooltip {The width of the widget as a number or formula.
+Formulas can be simple math, including the variables
+w, pw, sw, cw, and i} xywh {215 150 55 20} labelsize 11 align 5 textsize 11
             class Fluid_Coord_Input
           }
           Fl_Input widget_h_input {
             label {Height:}
-            callback h_cb
-            tooltip {The height of the widget.} xywh {275 150 55 20} labelsize 11 align 5 textsize 11
+            callback h_cb selected
+            tooltip {The height of the widget as a number or formula.
+Formulas can be simple math, including the variables
+h, ph, sh, ch, and i} xywh {275 150 55 20} labelsize 11 align 5 textsize 11
             class Fluid_Coord_Input
           }
           Fl_Choice {} {
             label {Children:}
-            callback wc_relative_cb open selected
+            callback wc_relative_cb open
             tooltip {When instantiating a widget class, the children can either be fixed in their original position, automatically be repositioned, or both repsositioned and resized to fit the container.} xywh {335 150 65 20} down_box BORDER_BOX labelsize 11 align 5 textsize 11
           } {
             MenuItem {} {


### PR DESCRIPTION
Fixing Issue #400.

Entering formulas in the Widget Panel size fields would not undo and could mess up the whole formula experience.