### PR TITLE
Add missing FL_RELEASE event after dnd()

### DIFF
--- a/src/fl_dnd_x.cxx
+++ b/src/fl_dnd_x.cxx
@@ -202,6 +202,7 @@ int Fl_X11_Screen_Driver::dnd(int unused) {
   }
 
   fl_local_grab = 0;
+  Fl::handle(FL_RELEASE, source_fl_win);
   source_fl_win->cursor(FL_CURSOR_DEFAULT);
   return 1;
 }


### PR DESCRIPTION
On X11, FLTK would not send a required FL_RELEASE
event to the data source window.

This is an attempt at fixing #412 without in-depth knowledge of X11. fl_dnd_x.cxx seems to go through various attempts of correctly delivering a DND package. The patch seems to work well at finalising the DND with an FL_RELEASE event at what was most likely the source widget for the drag and drop operation.