### PR TITLE
Fix selection extension in Fl_Text_*, issue 196

### DIFF
--- a/FL/Fl_Text_Display.H
+++ b/FL/Fl_Text_Display.H
@@ -124,6 +124,7 @@ public:
     WRAP_AT_BOUNDS  /**< wrap text so that it fits into the widget width */
   };
 
+  friend int fl_text_drag_prepare(int pos, int key, Fl_Text_Display* d);
   friend void fl_text_drag_me(int pos, Fl_Text_Display* d);
 
   typedef void (*Unfinished_Style_Cb)(int, void *);

--- a/src/Fl_Text_Display.cxx
+++ b/src/Fl_Text_Display.cxx
@@ -3961,12 +3961,13 @@ void Fl_Text_Display::draw(void) {
   fl_pop_clip();
 }
 
-// GitHub Issue #196: internal selection nd visible selection can run out of
+// GitHub Issue #196: internal selection and visible selection can run out of
 // sync, giving the user unexpected keyboard selection. The code block below
 // captures that and fixes it.
-// set pos to the drag target postion or -1 if we don;t know
-// if pos is -1, and key is not -1, key can be set to indicate a direction (e.g. FL_Left)
-// return 0 if nothing changed, return 1 if dragPos or mCursorPos were modified.
+// - set pos to the drag target postion or -1 if we don't know
+// - if pos is -1, and key is not -1, key can be set to indicate a direction
+//   (e.g. FL_Left)
+// return 0 if nothing changed, return 1 if dragPos or mCursorPos were modified
 int fl_text_drag_prepare(int pos, int key, Fl_Text_Display* d) {
   if (d->buffer()->selected()) {
     int start, end;

--- a/src/Fl_Text_Display.cxx
+++ b/src/Fl_Text_Display.cxx
@@ -3987,6 +3987,9 @@ int fl_text_drag_prepare(int pos, int key, Fl_Text_Display* d) {
           default:
             d->dragPos = start; d->mCursorPos = end; break;
         }
+      } else {
+        d->dragPos = start;
+        d->mCursorPos = end;
       }
       return 1;
     }

--- a/src/Fl_Text_Editor.cxx
+++ b/src/Fl_Text_Editor.cxx
@@ -284,6 +284,7 @@ int Fl_Text_Editor::kf_enter(int, Fl_Text_Editor* e) {
   return 1;
 }
 
+extern int fl_text_drag_prepare(int pos, int key, Fl_Text_Display* d);
 extern void fl_text_drag_me(int pos, Fl_Text_Display* d);
 /** Moves the text cursor in the direction indicated by key \p 'c' in editor \p 'e'.
     Supported values for 'c' are currently:
@@ -339,6 +340,7 @@ int Fl_Text_Editor::kf_move(int c, Fl_Text_Editor* e) {
     \see kf_move()
 */
 int Fl_Text_Editor::kf_shift_move(int c, Fl_Text_Editor* e) {
+  fl_text_drag_prepare(-1, c, e);
   kf_move(c, e);
   fl_text_drag_me(e->insert_position(), e);
   char *copy = e->buffer()->selection_text();
@@ -441,6 +443,7 @@ int Fl_Text_Editor::kf_meta_move(int c, Fl_Text_Editor* e) {
     \see kf_meta_move().
 */
 int Fl_Text_Editor::kf_m_s_move(int c, Fl_Text_Editor* e) {
+  fl_text_drag_prepare(-1, c, e);
   kf_meta_move(c, e);
   fl_text_drag_me(e->insert_position(), e);
   return 1;
@@ -450,6 +453,7 @@ int Fl_Text_Editor::kf_m_s_move(int c, Fl_Text_Editor* e) {
     \see kf_ctrl_move().
 */
 int Fl_Text_Editor::kf_c_s_move(int c, Fl_Text_Editor* e) {
+  fl_text_drag_prepare(-1, c, e);
   kf_ctrl_move(c, e);
   fl_text_drag_me(e->insert_position(), e);
   return 1;
@@ -709,7 +713,7 @@ int Fl_Text_Editor::handle(int event) {
         dragType = DRAG_NONE;
         if(buffer()->selected()) {
           buffer()->unselect();
-          }
+        }
         int pos = xy_to_position(Fl::event_x(), Fl::event_y(), CURSOR_POS);
         insert_position(pos);
         Fl::paste(*this, 0);


### PR DESCRIPTION
Selecting a text range programmatically would not sync some variables with the actual selection. This also fixes a crash bug in macOS when dragging text that was selected by buffer()->select() only (*1).

This PR fixes issue #196 .

*1) this is actually funny in a way. Initiating a DND operation did not copy the text to be dragged to the clipboard first as Fl:dnd(1) expects. On macOS this would crash the app. This does not happen if a selection was mad with the cursor keys or the mouse. Replicate: open any text with test/Editor, before using any mouse buttons or keystrokes, use Find to select something, then drag that selected text somewhere. macOS will crash before the DND operation is initiated.