### PR TITLE
Keep indicator that menubar is still active

### DIFF
--- a/src/Fl_Menu.cxx
+++ b/src/Fl_Menu.cxx
@@ -842,9 +842,10 @@ int menuwindow::handle_part1(int e) {
             return 1;
           }
           if (pp.current_item && pp.menu_number==0 && !pp.current_item->submenu()) {
-            if (e==FL_PUSH)
+            if (e==FL_PUSH) {
               pp.state = DONE_STATE;
-            setitem(0, -1, 0);
+              setitem(0, -1, 0);
+            }
             return 1;
           }
           // all others can stay selected


### PR DESCRIPTION
When using a button in the top level menu of `Fl_Menu_Bar` (don't!), as it is done in the `test/menubar` example code, the button was only highlighted the the mouse was over it, even though the button is technically a full menu (with just one entry), and will use up the next event to "close" itself.

This leads to a lost mouse click in the eyes of the user. So this minimal mod keeps the button highlighted, even if the mouse is not over it, to indicate that the menu is still on.

Old: open test/menubar. Activate the FL_MENU_BAR if you have a Mac. Click on the "Empty" menu title, roll over the "[_] button" menu title. Now, without touching any other menu, roll down to the "menubutton" menu. The next click will be lost. Click again, and it will be fine.

