### PR TITLE
FLUID event handling and UI changes

### DIFF
--- a/fluid/Fl_Type.cxx
+++ b/fluid/Fl_Type.cxx
@@ -267,7 +267,6 @@ Fl_Type::Fl_Type() {
   user_data_type_ = 0;
   callback_ = 0;
   comment_ = 0;
-  rtti = 0;
   level = 0;
   code_position = header_position = -1;
   code_position_end = header_position_end = -1;

--- a/fluid/Fl_Type.h
+++ b/fluid/Fl_Type.h
@@ -64,7 +64,6 @@ public: // things that should not be public:
   char selected; // copied here by selection_changed()
   char open_;   // state of triangle in browser
   char visible; // true if all parents are open
-  char rtti;    // hack because I have no rtti, this is 0 for base class
   int level;    // number of parents over this
   static Fl_Type *first, *last;
   Fl_Type *next, *prev;

--- a/fluid/Fl_Widget_Type.cxx
+++ b/fluid/Fl_Widget_Type.cxx
@@ -823,6 +823,7 @@ void wc_relative_cb(Fl_Choice *i, void *v) {
     }
   } else {
     int mod = 0;
+    undo_checkpoint();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && !strcmp(current_widget->type_name(), "widget_class")) {
         Fl_Widget_Class_Type *t = (Fl_Widget_Class_Type *)o;
@@ -1131,6 +1132,7 @@ void resizable_cb(Fl_Light_Button* i,void* v) {
     i->activate();
     i->value(current_widget->resizable());
   } else {
+    undo_checkpoint();
     current_widget->resizable(i->value());
     set_modflag(1);
   }
@@ -1144,8 +1146,12 @@ void hotspot_cb(Fl_Light_Button* i,void* v) {
     i->activate();
     i->value(current_widget->hotspot());
   } else {
+    undo_checkpoint();
     current_widget->hotspot(i->value());
-    if (current_widget->is_menu_item()) {current_widget->redraw(); return;}
+    if (current_widget->is_menu_item()) {
+      current_widget->redraw();
+      return;
+    }
     if (i->value()) {
       Fl_Type *p = current_widget->parent;
       if (!p || !p->is_widget()) return;
@@ -1169,10 +1175,13 @@ void visible_cb(Fl_Light_Button* i, void* v) {
     int n = i->value();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_widget()) {
+        if (!mod) {
+          mod = 1;
+          undo_checkpoint();
+        }
         Fl_Widget_Type* q = (Fl_Widget_Type*)o;
         n ? q->o->show() : q->o->hide();
         q->redraw();
-        mod = 1;
         if (n && q->parent && q->parent->type_name()) {
           if (!strcmp(q->parent->type_name(), "Fl_Tabs")) {
             ((Fl_Tabs *)q->o->parent())->value(q->o);
@@ -1199,10 +1208,13 @@ void active_cb(Fl_Light_Button* i, void* v) {
     int n = i->value();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_widget()) {
+        if (!mod) {
+          mod = 1;
+          undo_checkpoint();
+        }
         Fl_Widget_Type* q = (Fl_Widget_Type*)o;
         n ? q->o->activate() : q->o->deactivate();
         q->redraw();
-        mod = 1;
       }
     }
     if (mod) set_modflag(1);
@@ -1403,6 +1415,7 @@ void align_cb(Fl_Button* i, void *v) {
     i->value(current_widget->o->align() & b);
   } else {
     int mod = 0;
+    undo_checkpoint();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_widget()) {
         Fl_Widget_Type* q = (Fl_Widget_Type*)o;
@@ -1447,6 +1460,7 @@ void align_position_cb(Fl_Choice *i, void *v) {
     const Fl_Menu_Item *mi = i->menu() + i->value();
     Fl_Align b = Fl_Align(fl_uintptr_t(mi->user_data()));
     int mod = 0;
+    undo_checkpoint();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_widget()) {
         Fl_Widget_Type* q = (Fl_Widget_Type*)o;
@@ -1476,6 +1490,7 @@ void align_text_image_cb(Fl_Choice *i, void *v) {
     const Fl_Menu_Item *mi = i->menu() + i->value();
     Fl_Align b = Fl_Align(fl_uintptr_t(mi->user_data()));
     int mod = 0;
+    undo_checkpoint();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_widget()) {
         Fl_Widget_Type* q = (Fl_Widget_Type*)o;
@@ -1704,6 +1719,7 @@ void min_w_cb(Fl_Value_Input* i, void* v) {
     i->value(((Fl_Window_Type*)current_widget)->sr_min_w);
   } else {
     int mod = 0;
+    undo_checkpoint();
     int n = (int)i->value();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_window()) {
@@ -1721,6 +1737,7 @@ void min_h_cb(Fl_Value_Input* i, void* v) {
     i->value(((Fl_Window_Type*)current_widget)->sr_min_h);
   } else {
     int mod = 0;
+    undo_checkpoint();
     int n = (int)i->value();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_window()) {
@@ -1738,6 +1755,7 @@ void max_w_cb(Fl_Value_Input* i, void* v) {
     i->value(((Fl_Window_Type*)current_widget)->sr_max_w);
   } else {
     int mod = 0;
+    undo_checkpoint();
     int n = (int)i->value();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_window()) {
@@ -1755,6 +1773,7 @@ void max_h_cb(Fl_Value_Input* i, void* v) {
     i->value(((Fl_Window_Type*)current_widget)->sr_max_h);
   } else {
     int mod = 0;
+    undo_checkpoint();
     int n = (int)i->value();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_window()) {
@@ -1770,6 +1789,7 @@ void set_min_size_cb(Fl_Button*, void* v) {
   if (v == LOAD) {
   } else {
     int mod = 0;
+    undo_checkpoint();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_window()) {
         Fl_Window_Type *win = (Fl_Window_Type*)current_widget;
@@ -1787,6 +1807,7 @@ void set_max_size_cb(Fl_Button*, void* v) {
   if (v == LOAD) {
   } else {
     int mod = 0;
+    undo_checkpoint();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_window()) {
         Fl_Window_Type *win = (Fl_Window_Type*)current_widget;
@@ -1807,6 +1828,7 @@ void slider_size_cb(Fl_Value_Input* i, void* v) {
     i->value(((Fl_Slider*)(current_widget->o))->slider_size());
   } else {
     int mod = 0;
+    undo_checkpoint();
     double n = i->value();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_widget()) {
@@ -1836,6 +1858,7 @@ void min_cb(Fl_Value_Input* i, void* v) {
     }
   } else {
     int mod = 0;
+    undo_checkpoint();
     double n = i->value();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_widget()) {
@@ -1869,6 +1892,7 @@ void max_cb(Fl_Value_Input* i, void* v) {
     }
   } else {
     int mod = 0;
+    undo_checkpoint();
     double n = i->value();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_widget()) {
@@ -1902,6 +1926,7 @@ void step_cb(Fl_Value_Input* i, void* v) {
     }
   } else {
     int mod = 0;
+    undo_checkpoint();
     double n = i->value();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_widget()) {
@@ -1936,6 +1961,7 @@ void value_cb(Fl_Value_Input* i, void* v) {
       i->deactivate();
   } else {
     int mod = 0;
+    undo_checkpoint();
     double n = i->value();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_widget()) {

--- a/fluid/Fl_Widget_Type.cxx
+++ b/fluid/Fl_Widget_Type.cxx
@@ -1319,28 +1319,75 @@ void labeltype_cb(Fl_Choice* i, void *v) {
 
 ////////////////////////////////////////////////////////////////
 
+Fl_Menu_Item colormenu[] = {
+  { "Foreground Color",   0, 0, (void*)FL_FOREGROUND_COLOR,  0, 0, FL_HELVETICA, 11},
+  { "Background Color",   0, 0, (void*)FL_BACKGROUND_COLOR,  0, 0, FL_HELVETICA, 11},
+  { "Background Color 2", 0, 0, (void*)FL_BACKGROUND2_COLOR, 0, 0, FL_HELVETICA, 11},
+  { "Selection Color",    0, 0, (void*)FL_SELECTION_COLOR,   0, 0, FL_HELVETICA, 11},
+  { "Inactive Color",     0, 0, (void*)FL_INACTIVE_COLOR,    FL_MENU_DIVIDER, 0, FL_HELVETICA, 11},
+  { "Black",              0, 0, (void*)FL_BLACK,             0, 0, FL_HELVETICA, 11},
+  { "White",              0, 0, (void*)FL_WHITE,             FL_MENU_DIVIDER, 0, FL_HELVETICA, 11},
+  { "Gray 0",             0, 0, (void*)FL_GRAY0,             0, 0, FL_HELVETICA, 11},
+  { "Dark 3",             0, 0, (void*)FL_DARK3,             0, 0, FL_HELVETICA, 11},
+  { "Dark 2",             0, 0, (void*)FL_DARK2,             0, 0, FL_HELVETICA, 11},
+  { "Dark 1",             0, 0, (void*)FL_DARK1,             0, 0, FL_HELVETICA, 11},
+  { "Light 1",            0, 0, (void*)FL_LIGHT1,            0, 0, FL_HELVETICA, 11},
+  { "Light 2",            0, 0, (void*)FL_LIGHT2,            0, 0, FL_HELVETICA, 11},
+  { "Light 3",            0, 0, (void*)FL_LIGHT3,            0, 0, FL_HELVETICA, 11},
+  { 0 }
+};
+
+void color_common(Fl_Color c) {
+  int mod = 0;
+  for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
+    if (o->selected && o->is_widget()) {
+      Fl_Widget_Type* q = (Fl_Widget_Type*)o;
+      q->o->color(c); q->o->redraw();
+      if (q->parent && q->parent->type_name() == tabs_type_name) {
+        if (q->o->parent()) q->o->parent()->redraw();
+      }
+      mod = 1;
+    }
+  }
+  if (mod) set_modflag(1);
+}
+
 void color_cb(Fl_Button* i, void *v) {
   Fl_Color c = current_widget->o->color();
   if (v == LOAD) {
     if (current_widget->is_menu_item()) {i->deactivate(); return;} else i->activate();
   } else {
-    int mod = 0;
     Fl_Color d = fl_show_colormap(c);
     if (d == c) return;
     c = d;
-    for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
-      if (o->selected && o->is_widget()) {
-        Fl_Widget_Type* q = (Fl_Widget_Type*)o;
-        q->o->color(c); q->o->redraw();
-        if (q->parent && q->parent->type_name() == tabs_type_name) {
-          if (q->o->parent()) q->o->parent()->redraw();
-        }
-        mod = 1;
-      }
-    }
-    if (mod) set_modflag(1);
+    color_common(c);
   }
   i->color(c); i->labelcolor(fl_contrast(FL_BLACK,c)); i->redraw();
+}
+
+void color_menu_cb(Fl_Menu_Button* i, void *v) {
+  Fl_Color c = current_widget->o->color();
+  if (v == LOAD) {
+    if (current_widget->is_menu_item()) {i->deactivate(); return;} else i->activate();
+  } else {
+    Fl_Color d = i->mvalue()->argument();
+    if (d == c) return;
+    c = d;
+    color_common(c);
+    w_color->color(c); w_color->labelcolor(fl_contrast(FL_BLACK,c)); w_color->redraw();
+  }
+}
+
+void color2_common(Fl_Color c) {
+  int mod = 0;
+  for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
+    if (o->selected && o->is_widget()) {
+      Fl_Widget_Type* q = (Fl_Widget_Type*)o;
+      q->o->selection_color(c); q->o->redraw();
+      mod = 1;
+    }
+  }
+  if (mod) set_modflag(1);
 }
 
 void color2_cb(Fl_Button* i, void *v) {
@@ -1348,39 +1395,59 @@ void color2_cb(Fl_Button* i, void *v) {
   if (v == LOAD) {
     if (current_widget->is_menu_item()) {i->deactivate(); return;} else i->activate();
   } else {
-    int mod = 0;
     Fl_Color d = fl_show_colormap(c);
     if (d == c) return;
     c = d;
-    for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
-      if (o->selected && o->is_widget()) {
-        Fl_Widget_Type* q = (Fl_Widget_Type*)o;
-        q->o->selection_color(c); q->o->redraw();
-        mod = 1;
-      }
-    }
-    if (mod) set_modflag(1);
+    color2_common(c);
   }
   i->color(c); i->labelcolor(fl_contrast(FL_BLACK,c)); i->redraw();
+}
+
+void color2_menu_cb(Fl_Menu_Button* i, void *v) {
+  Fl_Color c = current_widget->o->selection_color();
+  if (v == LOAD) {
+    if (current_widget->is_menu_item()) {i->deactivate(); return;} else i->activate();
+  } else {
+    Fl_Color d = i->mvalue()->argument();
+    if (d == c) return;
+    c = d;
+    color2_common(c);
+    w_selectcolor->color(c); w_selectcolor->labelcolor(fl_contrast(FL_BLACK,c)); w_selectcolor->redraw();
+  }
+}
+
+void labelcolor_common(Fl_Color c) {
+  int mod = 0;
+  for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
+    if (o->selected && o->is_widget()) {
+      Fl_Widget_Type* q = (Fl_Widget_Type*)o;
+      q->o->labelcolor(c); q->redraw();
+      mod = 1;
+    }
+  }
+  if (mod) set_modflag(1);
 }
 
 void labelcolor_cb(Fl_Button* i, void *v) {
   Fl_Color c = current_widget->o->labelcolor();
   if (v != LOAD) {
-    int mod = 0;
     Fl_Color d = fl_show_colormap(c);
     if (d == c) return;
     c = d;
-    for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
-      if (o->selected && o->is_widget()) {
-        Fl_Widget_Type* q = (Fl_Widget_Type*)o;
-        q->o->labelcolor(c); q->redraw();
-        mod = 1;
-      }
-    }
-    if (mod) set_modflag(1);
+    labelcolor_common(c);
   }
   i->color(c); i->labelcolor(fl_contrast(FL_BLACK,c)); i->redraw();
+}
+
+void labelcolor_menu_cb(Fl_Menu_Button* i, void *v) {
+  Fl_Color c = current_widget->o->labelcolor();
+  if (v != LOAD) {
+    Fl_Color d = i->mvalue()->argument();
+    if (d == c) return;
+    c = d;
+    labelcolor_common(c);
+    w_labelcolor->color(c); w_labelcolor->labelcolor(fl_contrast(FL_BLACK,c)); w_labelcolor->redraw();
+  }
 }
 
 static Fl_Button* relative(Fl_Widget* o, int i) {
@@ -1687,27 +1754,47 @@ void textsize_cb(Fl_Value_Input* i, void* v) {
   i->value(s);
 }
 
+void textcolor_common(Fl_Color c) {
+  Fl_Font n; int s;
+  int mod = 0;
+  for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
+    if (o->selected && o->is_widget()) {
+      Fl_Widget_Type* q = (Fl_Widget_Type*)o;
+      q->textstuff(3,n,s,c); q->o->redraw();
+      mod = 1;
+    }
+  }
+  if (mod) set_modflag(1);
+}
+
 void textcolor_cb(Fl_Button* i, void* v) {
   Fl_Font n; int s; Fl_Color c;
   if (v == LOAD) {
     if (!current_widget->textstuff(0,n,s,c)) {i->deactivate(); return;}
     i->activate();
   } else {
-    int mod = 0;
     c = i->color();
     Fl_Color d = fl_show_colormap(c);
     if (d == c) return;
     c = d;
-    for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
-      if (o->selected && o->is_widget()) {
-        Fl_Widget_Type* q = (Fl_Widget_Type*)o;
-        q->textstuff(3,n,s,c); q->o->redraw();
-        mod = 1;
-      }
-    }
-    if (mod) set_modflag(1);
+    textcolor_common(c);
   }
   i->color(c); i->labelcolor(fl_contrast(FL_BLACK,c)); i->redraw();
+}
+
+void textcolor_menu_cb(Fl_Menu_Button* i, void* v) {
+  Fl_Font n; int s; Fl_Color c;
+  if (v == LOAD) {
+    if (!current_widget->textstuff(0,n,s,c)) {i->deactivate(); return;}
+    i->activate();
+  } else {
+    c = i->color();
+    Fl_Color d = i->mvalue()->argument();
+    if (d == c) return;
+    c = d;
+    textcolor_common(c);
+    w_textcolor->color(c); w_textcolor->labelcolor(fl_contrast(FL_BLACK,c)); w_textcolor->redraw();
+  }
 }
 
 ////////////////////////////////////////////////////////////////

--- a/fluid/Fl_Widget_Type.cxx
+++ b/fluid/Fl_Widget_Type.cxx
@@ -377,24 +377,30 @@ void name_public_cb(Fl_Choice* i, void* v) {
   }
 }
 
-/* Treating UNDO for this widget.
+/* Treating UNDO for text widget.
 
- 1: the widget has its own undo handling for the text field, but we may want to do a global undo
+ Goal: we want to continiously update the UI while the user is typing text
+ (changing the label, in this case). Source View does deferred uodates, and
+ the widget browser and widget panel update on every keystroke. At the same
+ time, we want to limit undo actions to few and logical units.
+
+ Caveats:
+
+ 1: the text widget has its own undo handling for the text field, but we may want to do a global undo
  2: every o->label() call will create an undo entry, but we want only one single event for all selected widgets
  3: we want a single undo for the entire editing phase, but still propagate changes as they happen
 
  The edit process has these main states:
 
- 1: starting to edit [first_change==1 && incremental]; we must create a single undo checkpoint before anything changes
- 2: continue editing [first_change==0 && incremental] ; we must suspend any undo checkpoints
- 3: done editing, unfocus [first_change==0 && !incremental]; we must make sure that undo checkpoints are enabled again
- 4: losing focus without editing [first_change==1 && incremental]; don't create and checkpoints
+ 1: starting to edit [first_change==1 && !unfocus]; we must create a single undo checkpoint before anything changes
+ 2: continue editing [first_change==0 && !unfocus] ; we must suspend any undo checkpoints
+ 3: done editing, unfocus [first_change==0 && unfocus]; we must make sure that undo checkpoints are enabled again
+ 4: losing focus without editing [first_change==1 && unfocus]; don't create and checkpoints
 
  We must also check:
- 1: changing focus without changing text
- 2: copy and paste, drag and drop operations
- 3: save operation without unfocus event
-
+ 1: changing focus without changing text (works)
+ 2: copy and paste, drag and drop operations (works)
+ 3: save operation without unfocus event (works)
  */
 void label_cb(Fl_Input* i, void *v) {
   static int first_change = 1;

--- a/fluid/Fl_Widget_Type.cxx
+++ b/fluid/Fl_Widget_Type.cxx
@@ -1569,12 +1569,12 @@ void user_data_cb(Fl_Input *i, void *v) {
   }
 }
 
-void user_data_type_cb(Fl_Input *i, void *v) {
+void user_data_type_cb(Fl_Input_Choice *i, void *v) {
   static const char *dflt = "void*";
   if (v == LOAD) {
     const char *c = current_widget->user_data_type();
     if (!c) c = dflt;
-    i->static_value(c);
+    i->value(c);
   } else {
     int mod = 0;
     const char *c = i->value();

--- a/fluid/Fl_Widget_Type.cxx
+++ b/fluid/Fl_Widget_Type.cxx
@@ -389,8 +389,8 @@ void label_cb(Fl_Input* i, void *v) {
     }
     strcpy(oldlabel,i->value());
   } else {
-//    int incremental = ( (Fl::event() != FL_HIDE) && (Fl::event() != FL_UNFOCUS) );
-//    if (incremental) undo_suspend();
+    int incremental = ( (Fl::event() != FL_HIDE) && (Fl::event() != FL_UNFOCUS) );
+    if (incremental) undo_suspend();
     int mod = 0;
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_widget()) {
@@ -398,7 +398,7 @@ void label_cb(Fl_Input* i, void *v) {
         mod = 1;
       }
     }
-//    if (incremental) undo_resume();
+    if (incremental) undo_resume();
     if (mod) set_modflag(1);
   }
 }

--- a/fluid/Fl_Window_Type.cxx
+++ b/fluid/Fl_Window_Type.cxx
@@ -483,6 +483,7 @@ void modal_cb(Fl_Light_Button* i, void* v) {
     i->show();
     i->value(((Fl_Window_Type *)current_widget)->modal);
   } else {
+    undo_checkpoint();
     ((Fl_Window_Type *)current_widget)->modal = i->value();
     set_modflag(1);
   }
@@ -494,6 +495,7 @@ void non_modal_cb(Fl_Light_Button* i, void* v) {
     i->show();
     i->value(((Fl_Window_Type *)current_widget)->non_modal);
   } else {
+    undo_checkpoint();
     ((Fl_Window_Type *)current_widget)->non_modal = i->value();
     set_modflag(1);
   }
@@ -505,6 +507,7 @@ void border_cb(Fl_Light_Button* i, void* v) {
     i->show();
     i->value(((Fl_Window*)(current_widget->o))->border());
   } else {
+    undo_checkpoint();
     ((Fl_Window*)(current_widget->o))->border(i->value());
     set_modflag(1);
   }
@@ -522,6 +525,7 @@ void xclass_cb(Fl_Input* i, void* v) {
     i->value(((Fl_Widget_Type *)current_widget)->xclass);
   } else {
     int mod = 0;
+    undo_checkpoint();
     for (Fl_Type *o = Fl_Type::first; o; o = o->next) {
       if (o->selected && o->is_widget()) {
         mod = 1;

--- a/fluid/fluid.cxx
+++ b/fluid/fluid.cxx
@@ -298,6 +298,17 @@ void update_sourceview_timer(void*);
 
 // ----
 
+extern Fl_Window *the_panel;
+// make sure that a currently changed text widgets propagates its contents
+void flush_text_widgets() {
+  if (Fl::focus() && (Fl::focus()->top_window() == the_panel)) {
+    Fl_Widget *old_focus = Fl::focus();
+    Fl::focus(NULL);
+    Fl::focus(old_focus);
+  }
+}
+// ----
+
 /**
  Change the current working directory to the .fl project directory.
 
@@ -471,6 +482,7 @@ static void external_editor_timer(void*) {
  \param[in] v if v is not NULL, or no filename is set, open a filechooser.
  */
 void save_cb(Fl_Widget *, void *v) {
+  flush_text_widgets();
   Fl_Native_File_Chooser fnfc;
   const char *c = filename;
   if (v || !c || !*c) {
@@ -645,6 +657,7 @@ void revert_cb(Fl_Widget *,void *) {
  If the design was modified, a dialog will ask for confirmation.
  */
 void exit_cb(Fl_Widget *,void *) {
+  flush_text_widgets();
 
   // Stop any external editor update timers
   ExternalCodeEditor::stop_update_timer();
@@ -978,6 +991,7 @@ void new_from_template_cb(Fl_Widget *w, void *v) {
  \return 1 if the operation failed, 0 if it succeeded
  */
 int write_code_files() {
+  flush_text_widgets();
   if (!filename) {
     save_cb(0,0);
     if (!filename) return 1;
@@ -1030,6 +1044,7 @@ void write_cb(Fl_Widget *, void *) {
  */
 void write_strings_cb(Fl_Widget *, void *) {
   static const char *exts[] = { ".txt", ".po", ".msg" };
+  flush_text_widgets();
   if (!filename) {
     save_cb(0,0);
     if (!filename) return;
@@ -1066,6 +1081,7 @@ void openwidget_cb(Fl_Widget *, void *) {
  User chose to copy the currently selected widgets.
  */
 void copy_cb(Fl_Widget*, void*) {
+  flush_text_widgets();
   if (!Fl_Type::current) {
     fl_beep();
     return;
@@ -1152,6 +1168,8 @@ void duplicate_cb(Fl_Widget*, void*) {
     fl_beep();
     return;
   }
+
+  flush_text_widgets();
 
   if (!write_file(cutfname(1),1)) {
     fl_message("Can't write %s: %s", cutfname(1), strerror(errno));

--- a/fluid/undo.cxx
+++ b/fluid/undo.cxx
@@ -207,10 +207,10 @@ void undo_clear() {
 
 // Resume undo checkpoints
 void undo_resume() {
-  undo_paused = 0;
+  undo_paused--;
 }
 
 // Suspend undo checkpoints
 void undo_suspend() {
-  undo_paused = 1;
+  undo_paused++;
 }

--- a/fluid/widget_panel.cxx
+++ b/fluid/widget_panel.cxx
@@ -940,12 +940,6 @@ access the Widget pointer and \'v\' to access the user value.");
         o->hide();
         Fl_Group::current()->resizable(o);
       } // Fl_Box* o
-      { // Hidden Revert button
-        Fl_Button* o = new Fl_Button(90, 370, 60, 20, "Revert");
-        o->labelsize(11);
-        o->callback((Fl_Callback*)revert_cb);
-        o->hide();
-      } // Fl_Button* o
       { wLiveMode = new Fl_Button(155, 370, 80, 20, "Live &Resize");
         wLiveMode->tooltip("Create a live duplicate of the selected widgets to test resizing and menu beh\
 avior.");
@@ -963,12 +957,6 @@ avior.");
         o->labelsize(11);
         o->callback((Fl_Callback*)ok_cb);
       } // Fl_Return_Button* o
-      { // Hidden cancel button
-        Fl_Button* o = new Fl_Button(345, 370, 65, 20, "Cancel");
-        o->labelsize(11);
-        o->callback((Fl_Callback*)cancel_cb);
-        o->hide();
-      } // Fl_Button* o
       o->end();
     } // Fl_Group* o
     o->size_range(o->w(), o->h());

--- a/fluid/widget_panel.cxx
+++ b/fluid/widget_panel.cxx
@@ -95,6 +95,12 @@ Fl_Text_Editor *wComment=(Fl_Text_Editor *)0;
 
 CodeEditor *wCallback=(CodeEditor *)0;
 
+Fl_Menu_Item menu_4[] = {
+ {"void*", 0,  0, 0, 0, (uchar)FL_NORMAL_LABEL, 4, 11, 0},
+ {"long", 0,  0, 0, 0, (uchar)FL_NORMAL_LABEL, 4, 11, 0},
+ {0,0,0,0,0,0,0,0,0}
+};
+
 Fl_Box *w_when_box=(Fl_Box *)0;
 
 Fl_Button *wLiveMode=(Fl_Button *)0;
@@ -910,7 +916,7 @@ access the Widget pointer and \'v\' to access the user value.");
           o->labelsize(11);
           o->callback((Fl_Callback*)propagate_load);
           o->align(Fl_Align(FL_ALIGN_LEFT));
-          { Fl_Input* o = new Fl_Input(95, 335, 158, 20);
+          { Fl_Input_Choice* o = new Fl_Input_Choice(95, 335, 158, 20);
             o->tooltip("The type of the user data.");
             o->labelfont(1);
             o->labelsize(11);
@@ -918,7 +924,8 @@ access the Widget pointer and \'v\' to access the user value.");
             o->textsize(11);
             o->callback((Fl_Callback*)user_data_type_cb);
             Fl_Group::current()->resizable(o);
-          } // Fl_Input* o
+            o->menu(menu_4);
+          } // Fl_Input_Choice* o
           { w_when_box = new Fl_Box(260, 332, 145, 26, "FL_WHEN_NEVER");
             w_when_box->box(FL_FLAT_BOX);
             w_when_box->selection_color((Fl_Color)1);

--- a/fluid/widget_panel.cxx
+++ b/fluid/widget_panel.cxx
@@ -120,7 +120,6 @@ Fl_Double_Window* make_widget_panel() {
         o->labelsize(11);
         o->callback((Fl_Callback*)propagate_load);
         o->when(FL_WHEN_NEVER);
-        o->hide();
         { Fl_Group* o = new Fl_Group(95, 40, 309, 20, "Label:");
           o->labelfont(1);
           o->labelsize(11);
@@ -132,7 +131,7 @@ Fl_Double_Window* make_widget_panel() {
             o->labelsize(11);
             o->textsize(11);
             o->callback((Fl_Callback*)label_cb);
-            o->when(FL_WHEN_RELEASE_ALWAYS);
+            o->when(FL_WHEN_RELEASE | FL_WHEN_ENTER_KEY_CHANGED);
             Fl_Group::current()->resizable(o);
           } // Fl_Input* o
           { Fl_Choice* o = new Fl_Choice(284, 40, 120, 20);
@@ -747,6 +746,7 @@ sized to fit the container.");
         o->labelsize(11);
         o->callback((Fl_Callback*)propagate_load);
         o->when(FL_WHEN_NEVER);
+        o->hide();
         { Fl_Group* o = new Fl_Group(95, 40, 310, 20, "Class:");
           o->labelfont(1);
           o->labelsize(11);

--- a/fluid/widget_panel.cxx
+++ b/fluid/widget_panel.cxx
@@ -71,6 +71,14 @@ Fl_Value_Input *widget_flex_size=(Fl_Value_Input *)0;
 
 Fl_Check_Button *widget_flex_fixed=(Fl_Check_Button *)0;
 
+Fl_Button *w_labelcolor=(Fl_Button *)0;
+
+Fl_Button *w_color=(Fl_Button *)0;
+
+Fl_Button *w_selectcolor=(Fl_Button *)0;
+
+Fl_Button *w_textcolor=(Fl_Button *)0;
+
 Fl_Menu_Item menu_2[] = {
  {"private", 0,  0, (void*)(0), 0, (uchar)FL_NORMAL_LABEL, 0, 11, 0},
  {"public", 0,  0, (void*)(1), 0, (uchar)FL_NORMAL_LABEL, 0, 11, 0},
@@ -637,7 +645,7 @@ sized to fit the container.");
           o->labelsize(11);
           o->callback((Fl_Callback*)propagate_load);
           o->align(Fl_Align(FL_ALIGN_LEFT));
-          { Fl_Choice* o = new Fl_Choice(95, 40, 170, 20);
+          { Fl_Choice* o = new Fl_Choice(95, 40, 152, 20);
             o->tooltip("The style of the label text.");
             o->box(FL_THIN_UP_BOX);
             o->down_box(FL_BORDER_BOX);
@@ -648,7 +656,7 @@ sized to fit the container.");
             Fl_Group::current()->resizable(o);
             o->menu(fontmenu);
           } // Fl_Choice* o
-          { Fl_Value_Input* o = new Fl_Value_Input(264, 40, 50, 20);
+          { Fl_Value_Input* o = new Fl_Value_Input(246, 40, 50, 20);
             o->tooltip("The size of the label text.");
             o->labelsize(11);
             o->maximum(100);
@@ -657,11 +665,15 @@ sized to fit the container.");
             o->textsize(11);
             o->callback((Fl_Callback*)labelsize_cb);
           } // Fl_Value_Input* o
-          { Fl_Button* o = new Fl_Button(314, 40, 90, 20, "Label Color");
-            o->tooltip("The color of the label text.");
-            o->labelsize(11);
-            o->callback((Fl_Callback*)labelcolor_cb);
-          } // Fl_Button* o
+          { w_labelcolor = new Fl_Button(296, 40, 90, 20, "Label Color");
+            w_labelcolor->tooltip("The color of the label text.");
+            w_labelcolor->labelsize(11);
+            w_labelcolor->callback((Fl_Callback*)labelcolor_cb);
+          } // Fl_Button* w_labelcolor
+          { Fl_Menu_Button* o = new Fl_Menu_Button(386, 40, 18, 20);
+            o->callback((Fl_Callback*)labelcolor_menu_cb);
+            o->menu(colormenu);
+          } // Fl_Menu_Button* o
           o->end();
         } // Fl_Group* o
         { Fl_Group* o = new Fl_Group(95, 65, 309, 20, "Box:");
@@ -669,7 +681,7 @@ sized to fit the container.");
           o->labelsize(11);
           o->callback((Fl_Callback*)propagate_load);
           o->align(Fl_Align(FL_ALIGN_LEFT));
-          { Fl_Choice* o = new Fl_Choice(95, 65, 219, 20);
+          { Fl_Choice* o = new Fl_Choice(95, 65, 201, 20);
             o->tooltip("The \"up\" box of the widget.");
             o->box(FL_THIN_UP_BOX);
             o->down_box(FL_BORDER_BOX);
@@ -680,11 +692,15 @@ sized to fit the container.");
             Fl_Group::current()->resizable(o);
             o->menu(boxmenu);
           } // Fl_Choice* o
-          { Fl_Button* o = new Fl_Button(314, 65, 90, 20, "Color");
-            o->tooltip("The background color of the widget.");
-            o->labelsize(11);
-            o->callback((Fl_Callback*)color_cb);
-          } // Fl_Button* o
+          { w_color = new Fl_Button(296, 65, 90, 20, "Color");
+            w_color->tooltip("The background color of the widget.");
+            w_color->labelsize(11);
+            w_color->callback((Fl_Callback*)color_cb);
+          } // Fl_Button* w_color
+          { Fl_Menu_Button* o = new Fl_Menu_Button(386, 65, 18, 20);
+            o->callback((Fl_Callback*)color_menu_cb);
+            o->menu(colormenu);
+          } // Fl_Menu_Button* o
           o->end();
         } // Fl_Group* o
         { Fl_Group* o = new Fl_Group(95, 90, 309, 20, "Down Box:");
@@ -692,22 +708,27 @@ sized to fit the container.");
           o->labelsize(11);
           o->callback((Fl_Callback*)propagate_load);
           o->align(Fl_Align(FL_ALIGN_LEFT));
-          { Fl_Choice* o = new Fl_Choice(95, 90, 219, 20);
+          { Fl_Choice* o = new Fl_Choice(95, 90, 201, 20);
             o->tooltip("The \"down\" box of the widget.");
             o->box(FL_THIN_UP_BOX);
             o->down_box(FL_BORDER_BOX);
             o->labelfont(1);
             o->labelsize(11);
+            o->labelcolor(FL_DARK2);
             o->textsize(11);
             o->callback((Fl_Callback*)down_box_cb);
             Fl_Group::current()->resizable(o);
             o->menu(boxmenu);
           } // Fl_Choice* o
-          { Fl_Button* o = new Fl_Button(314, 90, 90, 20, "Select Color");
-            o->tooltip("The selection color of the widget.");
-            o->labelsize(11);
-            o->callback((Fl_Callback*)color2_cb);
-          } // Fl_Button* o
+          { w_selectcolor = new Fl_Button(296, 90, 90, 20, "Select Color");
+            w_selectcolor->tooltip("The selection color of the widget.");
+            w_selectcolor->labelsize(11);
+            w_selectcolor->callback((Fl_Callback*)color2_cb);
+          } // Fl_Button* w_selectcolor
+          { Fl_Menu_Button* o = new Fl_Menu_Button(386, 90, 18, 20);
+            o->callback((Fl_Callback*)color2_menu_cb);
+            o->menu(colormenu);
+          } // Fl_Menu_Button* o
           o->end();
         } // Fl_Group* o
         { Fl_Group* o = new Fl_Group(95, 115, 309, 20, "Text Font:");
@@ -715,7 +736,7 @@ sized to fit the container.");
           o->labelsize(11);
           o->callback((Fl_Callback*)propagate_load);
           o->align(Fl_Align(FL_ALIGN_LEFT));
-          { Fl_Choice* o = new Fl_Choice(95, 115, 170, 20);
+          { Fl_Choice* o = new Fl_Choice(95, 115, 152, 20);
             o->tooltip("The value text style.");
             o->box(FL_DOWN_BOX);
             o->down_box(FL_BORDER_BOX);
@@ -726,7 +747,7 @@ sized to fit the container.");
             Fl_Group::current()->resizable(o);
             o->menu(fontmenu);
           } // Fl_Choice* o
-          { Fl_Value_Input* o = new Fl_Value_Input(264, 115, 50, 20);
+          { Fl_Value_Input* o = new Fl_Value_Input(246, 115, 50, 20);
             o->tooltip("The value text size.");
             o->labelsize(11);
             o->maximum(100);
@@ -735,11 +756,15 @@ sized to fit the container.");
             o->textsize(11);
             o->callback((Fl_Callback*)textsize_cb);
           } // Fl_Value_Input* o
-          { Fl_Button* o = new Fl_Button(314, 115, 90, 20, "Text Color");
-            o->tooltip("The value text color.");
-            o->labelsize(11);
-            o->callback((Fl_Callback*)textcolor_cb);
-          } // Fl_Button* o
+          { w_textcolor = new Fl_Button(296, 115, 90, 20, "Text Color");
+            w_textcolor->tooltip("The value text color.");
+            w_textcolor->labelsize(11);
+            w_textcolor->callback((Fl_Callback*)textcolor_cb);
+          } // Fl_Button* w_textcolor
+          { Fl_Menu_Button* o = new Fl_Menu_Button(386, 115, 18, 20);
+            o->callback((Fl_Callback*)textcolor_menu_cb);
+            o->menu(colormenu);
+          } // Fl_Menu_Button* o
           o->end();
         } // Fl_Group* o
         { Fl_Box* o = new Fl_Box(95, 140, 300, 40);
@@ -930,7 +955,7 @@ access the Widget pointer and \'v\' to access the user value.");
             w_when_box->box(FL_FLAT_BOX);
             w_when_box->selection_color((Fl_Color)1);
             w_when_box->labelsize(8);
-            w_when_box->align(Fl_Align(192));
+            w_when_box->align(Fl_Align(193|FL_ALIGN_INSIDE));
           } // Fl_Box* w_when_box
           o->end();
         } // Fl_Group* o

--- a/fluid/widget_panel.cxx
+++ b/fluid/widget_panel.cxx
@@ -95,6 +95,8 @@ Fl_Text_Editor *wComment=(Fl_Text_Editor *)0;
 
 CodeEditor *wCallback=(CodeEditor *)0;
 
+Fl_Box *w_when_box=(Fl_Box *)0;
+
 Fl_Button *wLiveMode=(Fl_Button *)0;
 
 /**
@@ -118,6 +120,7 @@ Fl_Double_Window* make_widget_panel() {
         o->labelsize(11);
         o->callback((Fl_Callback*)propagate_load);
         o->when(FL_WHEN_NEVER);
+        o->hide();
         { Fl_Group* o = new Fl_Group(95, 40, 309, 20, "Label:");
           o->labelfont(1);
           o->labelsize(11);
@@ -129,7 +132,7 @@ Fl_Double_Window* make_widget_panel() {
             o->labelsize(11);
             o->textsize(11);
             o->callback((Fl_Callback*)label_cb);
-            o->when(FL_WHEN_CHANGED);
+            o->when(FL_WHEN_RELEASE_ALWAYS);
             Fl_Group::current()->resizable(o);
           } // Fl_Input* o
           { Fl_Choice* o = new Fl_Choice(284, 40, 120, 20);
@@ -744,7 +747,6 @@ sized to fit the container.");
         o->labelsize(11);
         o->callback((Fl_Callback*)propagate_load);
         o->when(FL_WHEN_NEVER);
-        o->hide();
         { Fl_Group* o = new Fl_Group(95, 40, 310, 20, "Class:");
           o->labelfont(1);
           o->labelsize(11);
@@ -890,7 +892,7 @@ access the Widget pointer and \'v\' to access the user value.");
             o->callback((Fl_Callback*)user_data_cb);
             Fl_Group::current()->resizable(o);
           } // Fl_Input* o
-          { Fl_Choice* o = new Fl_Choice(300, 310, 105, 20, "When:");
+          { Fl_Menu_Button* o = new Fl_Menu_Button(260, 310, 145, 20, "When");
             o->tooltip("When to call the callback function.");
             o->box(FL_THIN_UP_BOX);
             o->down_box(FL_BORDER_BOX);
@@ -900,7 +902,7 @@ access the Widget pointer and \'v\' to access the user value.");
             o->callback((Fl_Callback*)when_cb);
             o->when(FL_WHEN_CHANGED);
             o->menu(whenmenu);
-          } // Fl_Choice* o
+          } // Fl_Menu_Button* o
           o->end();
         } // Fl_Group* o
         { Fl_Group* o = new Fl_Group(95, 335, 310, 20, "Type:");
@@ -917,12 +919,12 @@ access the Widget pointer and \'v\' to access the user value.");
             o->callback((Fl_Callback*)user_data_type_cb);
             Fl_Group::current()->resizable(o);
           } // Fl_Input* o
-          { Fl_Light_Button* o = new Fl_Light_Button(300, 335, 105, 20, "No Change");
-            o->tooltip("Call the callback even if the value has not changed.");
-            o->selection_color((Fl_Color)1);
-            o->labelsize(11);
-            o->callback((Fl_Callback*)when_button_cb);
-          } // Fl_Light_Button* o
+          { w_when_box = new Fl_Box(260, 332, 145, 26, "FL_WHEN_NEVER");
+            w_when_box->box(FL_FLAT_BOX);
+            w_when_box->selection_color((Fl_Color)1);
+            w_when_box->labelsize(8);
+            w_when_box->align(Fl_Align(192));
+          } // Fl_Box* w_when_box
           o->end();
         } // Fl_Group* o
         o->end();

--- a/fluid/widget_panel.fl
+++ b/fluid/widget_panel.fl
@@ -49,7 +49,7 @@ Function {make_widget_panel()} {
           xywh {95 40 309 20} labelfont 1 labelsize 11 align 4
         } {
           Fl_Input {} {
-            callback label_cb selected
+            callback label_cb
             tooltip {The label text for the widget.
 Use Ctrl-J for newlines.} xywh {95 40 190 20} labelfont 1 labelsize 11 when 15 textsize 11 resizable
           }
@@ -744,18 +744,12 @@ wCallback->do_callback(wCallback, v);} open
         }
       }
     }
-    Fl_Group {} {open
+    Fl_Group {} {open selected
       xywh {10 370 400 20} labelsize 11
     } {
       Fl_Box {} {
         comment {Hidden resizable box}
         xywh {10 370 75 20} labelsize 11 hide resizable
-      }
-      Fl_Button {} {
-        label Revert
-        callback revert_cb
-        comment {Hidden Revert button}
-        xywh {90 370 60 20} labelsize 11 hide
       }
       Fl_Button wLiveMode {
         label {Live &Resize}
@@ -771,12 +765,6 @@ wCallback->do_callback(wCallback, v);} open
         label Close
         callback ok_cb
         xywh {345 370 65 20} labelsize 11
-      }
-      Fl_Button {} {
-        label Cancel
-        callback cancel_cb
-        comment {Hidden cancel button}
-        xywh {345 370 65 20} labelsize 11 hide
       }
     }
   }

--- a/fluid/widget_panel.fl
+++ b/fluid/widget_panel.fl
@@ -30,7 +30,7 @@ Function {make_widget_panel()} {
   comment {Create a panel that can be used with all known widgets} open
 } {
   Fl_Window {} {
-    comment {Use a Double Window to avoid flickering.} open selected
+    comment {Use a Double Window to avoid flickering.} open
     xywh {500 209 420 400} type Double labelsize 11 align 80 resizable hotspot
     code0 {o->size_range(o->w(), o->h());} size_range {420 400 0 0} visible
   } {
@@ -41,7 +41,7 @@ Function {make_widget_panel()} {
       Fl_Group {} {
         label GUI
         callback propagate_load open
-        xywh {10 30 400 330} labelsize 11 when 0 hide resizable
+        xywh {10 30 400 330} labelsize 11 when 0 resizable
       } {
         Fl_Group {} {
           label {Label:}
@@ -49,9 +49,9 @@ Function {make_widget_panel()} {
           xywh {95 40 309 20} labelfont 1 labelsize 11 align 4
         } {
           Fl_Input {} {
-            callback label_cb
+            callback label_cb selected
             tooltip {The label text for the widget.
-Use Ctrl-J for newlines.} xywh {95 40 190 20} labelfont 1 labelsize 11 when 6 textsize 11 resizable
+Use Ctrl-J for newlines.} xywh {95 40 190 20} labelfont 1 labelsize 11 when 15 textsize 11 resizable
           }
           Fl_Choice {} {
             callback labeltype_cb open
@@ -601,7 +601,7 @@ Use Ctrl-J for newlines.} xywh {95 285 310 20} labelfont 1 labelsize 11 textsize
       Fl_Group {} {
         label {C++}
         callback propagate_load open
-        xywh {10 30 400 330} labelsize 11 when 0
+        xywh {10 30 400 330} labelsize 11 when 0 hide
       } {
         Fl_Group {} {
           label {Class:}

--- a/fluid/widget_panel.fl
+++ b/fluid/widget_panel.fl
@@ -40,7 +40,7 @@ Function {make_widget_panel()} {
     } {
       Fl_Group {} {
         label GUI
-        callback propagate_load open selected
+        callback propagate_load open
         xywh {10 30 400 330} labelsize 11 when 0 resizable
       } {
         Fl_Group {} {
@@ -49,7 +49,7 @@ Function {make_widget_panel()} {
           xywh {95 40 309 20} labelfont 1 labelsize 11 align 4
         } {
           Fl_Input {} {
-            callback label_cb
+            callback label_cb selected
             tooltip {The label text for the widget.
 Use Ctrl-J for newlines.} xywh {95 40 190 20} labelfont 1 labelsize 11 when 15 textsize 11 resizable
           }

--- a/fluid/widget_panel.fl
+++ b/fluid/widget_panel.fl
@@ -31,7 +31,7 @@ Function {make_widget_panel()} {
 } {
   Fl_Window {} {
     comment {Use a Double Window to avoid flickering.} open
-    xywh {500 209 420 400} type Double labelsize 11 align 80 resizable hotspot
+    xywh {566 244 420 400} type Double labelsize 11 align 80 resizable hotspot
     code0 {o->size_range(o->w(), o->h());} size_range {420 400 0 0} visible
   } {
     Fl_Tabs {} {
@@ -515,84 +515,108 @@ Use Ctrl-J for newlines.} xywh {95 285 310 20} labelfont 1 labelsize 11 textsize
       }
       Fl_Group {} {
         label Style
-        callback propagate_load
+        callback propagate_load open
         xywh {10 30 400 330} labelsize 11 when 0 hide
       } {
         Fl_Group {} {
           label {Label Font:}
-          callback propagate_load
+          callback propagate_load open
           xywh {95 40 309 20} labelfont 1 labelsize 11 align 4
         } {
           Fl_Choice {} {
             callback labelfont_cb open
-            tooltip {The style of the label text.} xywh {95 40 170 20} box THIN_UP_BOX down_box BORDER_BOX labelfont 1 labelsize 11 textsize 11 resizable
+            tooltip {The style of the label text.} xywh {95 40 152 20} box THIN_UP_BOX down_box BORDER_BOX labelfont 1 labelsize 11 textsize 11 resizable
             code0 {extern Fl_Menu_Item fontmenu[];}
             code1 {o->menu(fontmenu);}
           } {}
           Fl_Value_Input {} {
             callback labelsize_cb
-            tooltip {The size of the label text.} xywh {264 40 50 20} labelsize 11 maximum 100 step 1 value 14 textsize 11
+            tooltip {The size of the label text.} xywh {246 40 50 20} labelsize 11 maximum 100 step 1 value 14 textsize 11
           }
-          Fl_Button {} {
+          Fl_Button w_labelcolor {
             label {Label Color}
             callback labelcolor_cb
-            tooltip {The color of the label text.} xywh {314 40 90 20} labelsize 11
+            tooltip {The color of the label text.} xywh {296 40 90 20} labelsize 11
           }
+          Fl_Menu_Button {} {
+            callback labelcolor_menu_cb open
+            xywh {386 40 18 20}
+            code0 {extern Fl_Menu_Item colormenu[];}
+            code1 {o->menu(colormenu);}
+          } {}
         }
         Fl_Group {} {
           label {Box:}
-          callback propagate_load
+          callback propagate_load open
           xywh {95 65 309 20} labelfont 1 labelsize 11 align 4
         } {
           Fl_Choice {} {
             callback box_cb open
-            tooltip {The "up" box of the widget.} xywh {95 65 219 20} box THIN_UP_BOX down_box BORDER_BOX labelfont 1 labelsize 11 textsize 11 resizable
+            tooltip {The "up" box of the widget.} xywh {95 65 201 20} box THIN_UP_BOX down_box BORDER_BOX labelfont 1 labelsize 11 textsize 11 resizable
             code0 {extern Fl_Menu_Item boxmenu[];}
             code1 {o->menu(boxmenu);}
           } {}
-          Fl_Button {} {
+          Fl_Button w_color {
             label Color
             callback color_cb
-            tooltip {The background color of the widget.} xywh {314 65 90 20} labelsize 11
+            tooltip {The background color of the widget.} xywh {296 65 90 20} labelsize 11
           }
+          Fl_Menu_Button {} {
+            callback color_menu_cb open
+            xywh {386 65 18 20}
+            code0 {extern Fl_Menu_Item colormenu[];}
+            code1 {o->menu(colormenu);}
+          } {}
         }
         Fl_Group {} {
           label {Down Box:}
-          callback propagate_load
+          callback propagate_load open
           xywh {95 90 309 20} labelfont 1 labelsize 11 align 4
         } {
           Fl_Choice {} {
             callback down_box_cb open
-            tooltip {The "down" box of the widget.} xywh {95 90 219 20} box THIN_UP_BOX down_box BORDER_BOX labelfont 1 labelsize 11 textsize 11 resizable
+            tooltip {The "down" box of the widget.} xywh {95 90 201 20} box THIN_UP_BOX down_box BORDER_BOX labelfont 1 labelsize 11 labelcolor 45 textsize 11 resizable
             code0 {extern Fl_Menu_Item boxmenu[];}
             code1 {o->menu(boxmenu);}
           } {}
-          Fl_Button {} {
+          Fl_Button w_selectcolor {
             label {Select Color}
             callback color2_cb
-            tooltip {The selection color of the widget.} xywh {314 90 90 20} labelsize 11
+            tooltip {The selection color of the widget.} xywh {296 90 90 20} labelsize 11
           }
+          Fl_Menu_Button {} {
+            callback color2_menu_cb open
+            xywh {386 90 18 20}
+            code0 {extern Fl_Menu_Item colormenu[];}
+            code1 {o->menu(colormenu);}
+          } {}
         }
         Fl_Group {} {
           label {Text Font:}
-          callback propagate_load
+          callback propagate_load open
           xywh {95 115 309 20} labelfont 1 labelsize 11 align 4
         } {
           Fl_Choice {} {
             callback textfont_cb open
-            tooltip {The value text style.} xywh {95 115 170 20} box DOWN_BOX down_box BORDER_BOX labelfont 1 labelsize 11 textsize 11 resizable
+            tooltip {The value text style.} xywh {95 115 152 20} box DOWN_BOX down_box BORDER_BOX labelfont 1 labelsize 11 textsize 11 resizable
             code0 {extern Fl_Menu_Item fontmenu[];}
             code1 {o->menu(fontmenu);}
           } {}
           Fl_Value_Input {} {
             callback textsize_cb
-            tooltip {The value text size.} xywh {264 115 50 20} labelsize 11 maximum 100 step 1 value 14 textsize 11
+            tooltip {The value text size.} xywh {246 115 50 20} labelsize 11 maximum 100 step 1 value 14 textsize 11
           }
-          Fl_Button {} {
+          Fl_Button w_textcolor {
             label {Text Color}
             callback textcolor_cb
-            tooltip {The value text color.} xywh {314 115 90 20} labelsize 11
+            tooltip {The value text color.} xywh {296 115 90 20} labelsize 11
           }
+          Fl_Menu_Button {} {
+            callback textcolor_menu_cb open
+            xywh {386 115 18 20}
+            code0 {extern Fl_Menu_Item colormenu[];}
+            code1 {o->menu(colormenu);}
+          } {}
         }
         Fl_Box {} {
           xywh {95 140 300 40} labelsize 11 resizable
@@ -748,7 +772,7 @@ wCallback->do_callback(wCallback, v);} open
           }
           Fl_Box w_when_box {
             label FL_WHEN_NEVER
-            xywh {260 332 145 26} box FLAT_BOX selection_color 1 labelsize 8 align 192
+            xywh {260 332 145 26} box FLAT_BOX selection_color 1 labelsize 8 align 209
           }
         }
       }

--- a/fluid/widget_panel.fl
+++ b/fluid/widget_panel.fl
@@ -40,7 +40,7 @@ Function {make_widget_panel()} {
     } {
       Fl_Group {} {
         label GUI
-        callback propagate_load open
+        callback propagate_load open selected
         xywh {10 30 400 330} labelsize 11 when 0 resizable
       } {
         Fl_Group {} {
@@ -733,9 +733,18 @@ wCallback->do_callback(wCallback, v);} open
           callback propagate_load open
           xywh {95 335 310 20} labelfont 1 labelsize 11 align 4
         } {
-          Fl_Input {} {
-            callback user_data_type_cb
+          Fl_Input_Choice {} {
+            callback user_data_type_cb open
             tooltip {The type of the user data.} xywh {95 335 158 20} labelfont 1 labelsize 11 textfont 4 textsize 11 resizable
+          } {
+            MenuItem {} {
+              label {void*}
+              xywh {0 0 31 20} labelfont 4 labelsize 11
+            }
+            MenuItem {} {
+              label long
+              xywh {0 0 31 20} labelfont 4 labelsize 11
+            }
           }
           Fl_Box w_when_box {
             label FL_WHEN_NEVER
@@ -744,7 +753,7 @@ wCallback->do_callback(wCallback, v);} open
         }
       }
     }
-    Fl_Group {} {open selected
+    Fl_Group {} {open
       xywh {10 370 400 20} labelsize 11
     } {
       Fl_Box {} {

--- a/fluid/widget_panel.fl
+++ b/fluid/widget_panel.fl
@@ -30,7 +30,7 @@ Function {make_widget_panel()} {
   comment {Create a panel that can be used with all known widgets} open
 } {
   Fl_Window {} {
-    comment {Use a Double Window to avoid flickering.} open
+    comment {Use a Double Window to avoid flickering.} open selected
     xywh {500 209 420 400} type Double labelsize 11 align 80 resizable hotspot
     code0 {o->size_range(o->w(), o->h());} size_range {420 400 0 0} visible
   } {
@@ -41,7 +41,7 @@ Function {make_widget_panel()} {
       Fl_Group {} {
         label GUI
         callback propagate_load open
-        xywh {10 30 400 330} labelsize 11 when 0 resizable
+        xywh {10 30 400 330} labelsize 11 when 0 hide resizable
       } {
         Fl_Group {} {
           label {Label:}
@@ -51,7 +51,7 @@ Function {make_widget_panel()} {
           Fl_Input {} {
             callback label_cb
             tooltip {The label text for the widget.
-Use Ctrl-J for newlines.} xywh {95 40 190 20} labelfont 1 labelsize 11 when 1 textsize 11 resizable
+Use Ctrl-J for newlines.} xywh {95 40 190 20} labelfont 1 labelsize 11 when 6 textsize 11 resizable
           }
           Fl_Choice {} {
             callback labeltype_cb open
@@ -287,7 +287,7 @@ w, pw, sw, cw, and i} xywh {215 150 55 20} labelsize 11 align 5 textsize 11
           }
           Fl_Input widget_h_input {
             label {Height:}
-            callback h_cb selected
+            callback h_cb
             tooltip {The height of the widget as a number or formula.
 Formulas can be simple math, including the variables
 h, ph, sh, ch, and i} xywh {275 150 55 20} labelsize 11 align 5 textsize 11
@@ -600,12 +600,12 @@ Use Ctrl-J for newlines.} xywh {95 285 310 20} labelfont 1 labelsize 11 textsize
       }
       Fl_Group {} {
         label {C++}
-        callback propagate_load
-        xywh {10 30 400 330} labelsize 11 when 0 hide
+        callback propagate_load open
+        xywh {10 30 400 330} labelsize 11 when 0
       } {
         Fl_Group {} {
           label {Class:}
-          callback propagate_load
+          callback propagate_load open
           xywh {95 40 310 20} labelfont 1 labelsize 11 align 4
         } {
           Fl_Input {} {
@@ -720,10 +720,10 @@ wCallback->do_callback(wCallback, v);} open
             callback user_data_cb
             tooltip {The user data to pass into the callback code.} xywh {95 310 158 20} labelfont 1 labelsize 11 textfont 4 textsize 11 resizable
           }
-          Fl_Choice {} {
-            label {When:}
+          Fl_Menu_Button {} {
+            label When
             callback when_cb open
-            tooltip {When to call the callback function.} xywh {300 310 105 20} box THIN_UP_BOX down_box BORDER_BOX labelfont 1 labelsize 11 when 1 textsize 11
+            tooltip {When to call the callback function.} xywh {260 310 145 20} box THIN_UP_BOX down_box BORDER_BOX labelfont 1 labelsize 11 when 1 textsize 11
             code0 {extern Fl_Menu_Item whenmenu[];}
             code1 {o->menu(whenmenu);}
           } {}
@@ -737,10 +737,9 @@ wCallback->do_callback(wCallback, v);} open
             callback user_data_type_cb
             tooltip {The type of the user data.} xywh {95 335 158 20} labelfont 1 labelsize 11 textfont 4 textsize 11 resizable
           }
-          Fl_Light_Button {} {
-            label {No Change}
-            callback when_button_cb
-            tooltip {Call the callback even if the value has not changed.} xywh {300 335 105 20} selection_color 1 labelsize 11
+          Fl_Box w_when_box {
+            label FL_WHEN_NEVER
+            xywh {260 332 145 26} box FLAT_BOX selection_color 1 labelsize 8 align 192
           }
         }
       }

--- a/fluid/widget_panel.h
+++ b/fluid/widget_panel.h
@@ -112,10 +112,11 @@ extern Fl_Text_Editor *wComment;
 extern void callback_cb(CodeEditor*, void*);
 extern CodeEditor *wCallback;
 extern void user_data_cb(Fl_Input*, void*);
+#include <FL/Fl_Menu_Button.H>
 extern Fl_Menu_Item whenmenu[];
-extern void when_cb(Fl_Choice*, void*);
+extern void when_cb(Fl_Menu_Button*, void*);
 extern void user_data_type_cb(Fl_Input*, void*);
-extern void when_button_cb(Fl_Light_Button*, void*);
+extern Fl_Box *w_when_box;
 extern void revert_cb(Fl_Button*, void*);
 extern void live_mode_cb(Fl_Button*, void*);
 extern Fl_Button *wLiveMode;

--- a/fluid/widget_panel.h
+++ b/fluid/widget_panel.h
@@ -90,14 +90,24 @@ extern Fl_Menu_Item fontmenu[];
 extern void labelfont_cb(Fl_Choice*, void*);
 extern void labelsize_cb(Fl_Value_Input*, void*);
 extern void labelcolor_cb(Fl_Button*, void*);
+extern Fl_Button *w_labelcolor;
+#include <FL/Fl_Menu_Button.H>
+extern Fl_Menu_Item colormenu[];
+extern void labelcolor_menu_cb(Fl_Menu_Button*, void*);
 extern Fl_Menu_Item boxmenu[];
 extern void box_cb(Fl_Choice*, void*);
 extern void color_cb(Fl_Button*, void*);
+extern Fl_Button *w_color;
+extern void color_menu_cb(Fl_Menu_Button*, void*);
 extern void down_box_cb(Fl_Choice*, void*);
 extern void color2_cb(Fl_Button*, void*);
+extern Fl_Button *w_selectcolor;
+extern void color2_menu_cb(Fl_Menu_Button*, void*);
 extern void textfont_cb(Fl_Choice*, void*);
 extern void textsize_cb(Fl_Value_Input*, void*);
 extern void textcolor_cb(Fl_Button*, void*);
+extern Fl_Button *w_textcolor;
+extern void textcolor_menu_cb(Fl_Menu_Button*, void*);
 extern void subclass_cb(Fl_Input*, void*);
 extern void subtype_cb(Fl_Choice*, void*);
 extern void name_cb(Fl_Input*, void*);
@@ -112,7 +122,6 @@ extern Fl_Text_Editor *wComment;
 extern void callback_cb(CodeEditor*, void*);
 extern CodeEditor *wCallback;
 extern void user_data_cb(Fl_Input*, void*);
-#include <FL/Fl_Menu_Button.H>
 extern Fl_Menu_Item whenmenu[];
 extern void when_cb(Fl_Menu_Button*, void*);
 #include <FL/Fl_Input_Choice.H>

--- a/fluid/widget_panel.h
+++ b/fluid/widget_panel.h
@@ -115,7 +115,8 @@ extern void user_data_cb(Fl_Input*, void*);
 #include <FL/Fl_Menu_Button.H>
 extern Fl_Menu_Item whenmenu[];
 extern void when_cb(Fl_Menu_Button*, void*);
-extern void user_data_type_cb(Fl_Input*, void*);
+#include <FL/Fl_Input_Choice.H>
+extern void user_data_type_cb(Fl_Input_Choice*, void*);
 extern Fl_Box *w_when_box;
 extern void live_mode_cb(Fl_Button*, void*);
 extern Fl_Button *wLiveMode;
@@ -128,4 +129,5 @@ extern Fl_Menu_Item menu_1[];
 extern Fl_Menu_Item menu_Children[];
 extern Fl_Menu_Item menu_2[];
 extern Fl_Menu_Item menu_3[];
+extern Fl_Menu_Item menu_4[];
 #endif

--- a/fluid/widget_panel.h
+++ b/fluid/widget_panel.h
@@ -117,13 +117,11 @@ extern Fl_Menu_Item whenmenu[];
 extern void when_cb(Fl_Menu_Button*, void*);
 extern void user_data_type_cb(Fl_Input*, void*);
 extern Fl_Box *w_when_box;
-extern void revert_cb(Fl_Button*, void*);
 extern void live_mode_cb(Fl_Button*, void*);
 extern Fl_Button *wLiveMode;
 extern void overlay_cb(Fl_Button*, void*);
 #include <FL/Fl_Return_Button.H>
 extern void ok_cb(Fl_Return_Button*, void*);
-extern void cancel_cb(Fl_Button*, void*);
 Fl_Double_Window* make_widget_panel();
 extern Fl_Menu_Item menu_[];
 extern Fl_Menu_Item menu_1[];


### PR DESCRIPTION
This patch contains a bunch of minor fixes for issues that I found nagging, limiting, or surprising.

 * the `when()` attribute is used as a 4 bit bitfield in FLTK, but FLUID had a menu plus a button with limited choices. It now has a pulldown menu that allows for all 16 combinations
 * the **Label:** input field updates immediately, but it used to create undo events on every keystroke. It now creates only one undo event as one would expect
 * some settings in the Widget Panel had no Undo handling at all, or created multiple undo levels when multiple widgets were selected. They all create _one_ undo event now
 * `user_data` is pretty much always `void*` or `long`. I added a menu that allows quick access to those two values while still allowing arbitrary pointer types in the text field
 * when setting a color, it was not clear which colors in the popup color selector are the defaults for background, selection, etc. . Color buttons have now an additional pulldown menu for colors with an additional special meaning to FLTK
 * when editing some text fields in the Widget Panel (all the **extra code** fields for example) and pressing `Ctrl-S` to save, partial changes would not be saved, which surprised me several time. FLUID now makes sure that text field contents is written to the widget data before a project is saved

To test the last issue, open a project, select any widget, select the C++ tab. Enter code in the first code field, select the second code field, enter some code and press `Ctrl-S` (don't change the text filed first, don't press enter or tab first). FLUID will only write the top Code field, but not the second code line. 
 
