### PR TITLE
Suppress (GitHub CI/wayland) compiler warning

### DIFF
--- a/src/Fl_Text_Display.cxx
+++ b/src/Fl_Text_Display.cxx
@@ -97,6 +97,8 @@ static int scroll_x = 0;
 Fl_Text_Display::Fl_Text_Display(int X, int Y, int W, int H, const char* l)
 : Fl_Group(X, Y, W, H, l) {
 
+#define VISIBLE_LINES_INIT 1 // allow compiler to remove unused code (PR #582)
+
   // Member initialization: same order as declared in .H file
   //    Any Fl_Text_Display methods should only be called /after/ all
   //    members initialized; avoids methods referencing uninitialized values.
@@ -109,7 +111,7 @@ Fl_Text_Display::Fl_Text_Display(int X, int Y, int W, int H, const char* l)
   mCursorToHint = NO_HINT;
   mCursorStyle = NORMAL_CURSOR;
   mCursorPreferredXPos = -1;
-  mNVisibleLines = 1;
+  mNVisibleLines = VISIBLE_LINES_INIT;
   mNBufferLines = 0;
   mBuffer = NULL;
   mStyleBuffer = NULL;
@@ -118,9 +120,11 @@ Fl_Text_Display::Fl_Text_Display(int X, int Y, int W, int H, const char* l)
   mContinuousWrap = 0;
   mWrapMarginPix = 0;
   mLineStarts = new int[mNVisibleLines];
-  { // This code unused unless mNVisibleLines is ever initialized >1
+#if VISIBLE_LINES_INIT > 1
+  { // Note: this code is unused unless mNVisibleLines is ever initialized > 1
     for (int i=1; i<mNVisibleLines; i++) mLineStarts[i] = -1;
   }
+#endif
   mLineStarts[0] = 0;
   mTopLineNum = 1;
   mAbsTopLineNum = 1;


### PR DESCRIPTION
[ 15%] Building CXX object src/CMakeFiles/fltk.dir/Fl_Text_Display.cxx.o .../fltk/src/Fl_Text_Display.cxx: In constructor ‘Fl_Text_Display::Fl_Text_Display(int, int, int, int, const char*)’: .../fltk/src/Fl_Text_Display.cxx:122:57: warning: ‘void* __builtin_memset(void*, int, long unsigned int)’ writing between 4 and 8589934584 bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
  122 |     for (int i=1; i<mNVisibleLines; i++) mLineStarts[i] = -1;
      |                                          ~~~~~~~~~~~~~~~^~~~
.../fltk/src/Fl_Text_Display.cxx:120:39: note: at offset 4 into destination object of size 4 allocated by ‘operator new []’
  120 |   mLineStarts = new int[mNVisibleLines];
      |                                       ^

This warning is IMHO obsolete because the code in question should not be executed at all (mNVisibleLines == 1). However, the compiler seems to substitute this with '__builtin_memset(...)' and analyzes "correctly" that memory at offset 4 would be overwritten.

The "fix" uses a compiler macro and #if to clarify that this code must not be executed and should not be compiled (see comment why this code exists).