### PR TITLE
Windows: fix memory leak caused by RegisterDragDrop (#569)

### DIFF
--- a/src/drivers/WinAPI/Fl_WinAPI_Window_Driver.cxx
+++ b/src/drivers/WinAPI/Fl_WinAPI_Window_Driver.cxx
@@ -470,6 +470,9 @@ void Fl_WinAPI_Window_Driver::hide() {
     return;
   }
 
+  // Issue #569: undo RegisterDragDrop()
+  RevokeDragDrop((HWND)ip->xid);
+
   // make sure any custom icons get freed
   // icons(NULL, 0); // free_icons() is called by the Fl_Window destructor
   // this little trick keeps the current clipboard alive, even if we are about

--- a/src/fl_dnd_win32.cxx
+++ b/src/fl_dnd_win32.cxx
@@ -58,7 +58,7 @@ class FLDropTarget : public IDropTarget
   DWORD lastEffect;
   int px, py;
 public:
-  FLDropTarget() : m_cRefCount(0) { } // initialize
+  FLDropTarget() : m_cRefCount(1) { } // Issue #569: initialize with 1
   virtual ~FLDropTarget() { }
   HRESULT STDMETHODCALLTYPE QueryInterface( REFIID riid, LPVOID *ppvObject ) {
     if (IID_IUnknown==riid || IID_IDropTarget==riid)


### PR DESCRIPTION
We need to call RevokeDragDrop() to fix the leak but we must also prevent premature deletion of the FLDropTarget object.