### PR TITLE
Add Fl_Scheme_Choice widget

### DIFF
--- a/FL/Fl_Scheme.H
+++ b/FL/Fl_Scheme.H
@@ -1,0 +1,64 @@
+//
+// Scheme header for the Fast Light Tool Kit (FLTK).
+//
+// Copyright 2022-2023 by Bill Spitzak and others.
+//
+// This library is free software. Distribution and use rights are outlined in
+// the file "COPYING" which should have been included with this file.  If this
+// file is missing or damaged, see the license at:
+//
+//     https://www.fltk.org/COPYING.php
+//
+// Please see the following page on how to report bugs and issues:
+//
+//     https://www.fltk.org/bugs.php
+//
+
+#ifndef FL_Fl_Scheme_H_
+#define FL_Fl_Scheme_H_
+
+#include <FL/Fl.H>
+
+class Fl_Scheme {
+
+private:
+
+  static const char **names_;           // registered scheme names
+  static int num_schemes_;              // number of registered schemes
+  static int alloc_size_;               // number of allocated scheme name entries
+
+protected:
+
+  // const char *name_;                 // the scheme's name
+
+  // protected constructor - not yet implemented
+  // Fl_Scheme(const char *name);
+
+public:
+
+  // Static methods.
+
+  // Some of these methods will replace the scheme related methods of class Fl,
+  // for instance Fl::scheme() and Fl::is_scheme().
+  // Backwards compatibility must be kept though.
+
+  static const char **names();
+
+  /**
+    Return the number of currently registered schemes.
+
+    \return  Number of registered schemes.
+  */
+  static int num_schemes() {
+    if (!names_) names(); // force initialization
+    return num_schemes_;
+  }
+
+  // Adding a scheme name must be a public static method in FLTK 1.4.0.
+  // This will later be protected or replaced by another method name.
+
+  static int add_scheme_name(const char *name);
+
+}; // class Fl_Scheme
+
+#endif // FL_Fl_Scheme_H_

--- a/FL/Fl_Scheme_Choice.H
+++ b/FL/Fl_Scheme_Choice.H
@@ -1,0 +1,38 @@
+//
+// Scheme Choice header for the Fast Light Tool Kit (FLTK).
+//
+// Copyright 2022-2023 by Bill Spitzak and others.
+//
+// This library is free software. Distribution and use rights are outlined in
+// the file "COPYING" which should have been included with this file.  If this
+// file is missing or damaged, see the license at:
+//
+//     https://www.fltk.org/COPYING.php
+//
+// Please see the following page on how to report bugs and issues:
+//
+//     https://www.fltk.org/bugs.php
+//
+
+#ifndef FL_Fl_Scheme_Choice_H_
+#define FL_Fl_Scheme_Choice_H_
+
+#include <FL/Fl.H>
+#include <FL/Fl_Scheme.H>
+#include <FL/Fl_Choice.H>
+
+class Fl_Scheme_Choice : public Fl_Choice {
+
+protected:
+  static void scheme_cb_(Fl_Widget *w, void *);
+
+public:
+  Fl_Scheme_Choice(int X, int Y, int W, int H, const char *L = 0);
+  int handle(int event) FL_OVERRIDE;
+
+  // set the current value according to the active scheme
+  virtual void init_value();
+
+}; // class Fl_Scheme_Choice
+
+#endif // FL_Fl_Scheme_Choice_H_

--- a/examples/tree-custom-draw-items.cxx
+++ b/examples/tree-custom-draw-items.cxx
@@ -2,7 +2,7 @@
 //      Demonstrate Fl_Tree custom item draw callback. - erco 11/09/2013
 //
 // Copyright 2013 Greg Ercolano.
-// Copyright 1998-2016 by Bill Spitzak and others.
+// Copyright 1998-2023 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this
@@ -19,6 +19,7 @@
 #include <FL/Fl.H>
 #include <FL/Fl_Double_Window.H>
 #include <FL/Fl_Tree.H>
+#include <FL/Fl_Scheme_Choice.H>
 
 #ifndef MAX
 #define MAX(a,b) ((a)>(b))?(a):(b)
@@ -77,9 +78,11 @@ public:
       }
     }
     // Render the label
+    int dx = Fl::box_dx(prefs().selectbox()) + 1;
+    int dw = Fl::box_dw(prefs().selectbox()) + 2;
     if ( render ) {
       fl_color(fg);
-      if ( label() ) fl_draw(label(), X,Y,W,H, FL_ALIGN_LEFT);
+      if ( label() ) fl_draw(label(), X+dx, Y, W-dw, H, FL_ALIGN_LEFT);
     }
     int lw=0, lh=0;
     if ( label() ) {
@@ -117,12 +120,13 @@ void Timer_CB(void *data) {
 }
 
 int main(int argc, char *argv[]) {
-  Fl::scheme("gtk+");
-  Fl_Double_Window *win = new Fl_Double_Window(350, 400, "Tree Custom Draw Items");
+  Fl::scheme("gtk+"); // default scheme: can be overridden by commandline
+  Fl_Tree *tree = 0;
+  Fl_Double_Window *win = new Fl_Double_Window(350, 450, "Tree Custom Draw Items");
   win->begin();
   {
     // Create the tree
-    Fl_Tree *tree = new Fl_Tree(0, 0, win->w(), win->h());
+    tree = new Fl_Tree(0, 0, win->w(), win->h() - 50);
     tree->showroot(0);                          // don't show root of tree
     tree->selectmode(FL_TREE_SELECT_MULTI);     // multiselect
 
@@ -166,11 +170,23 @@ int main(int argc, char *argv[]) {
     // Start with some items closed
     tree->close("Superjail");
 
+    // Optional: set a "special" selection color (light blue)
+    tree->selection_color(0xcceeff00);
+
+    // Optional: set a "special" box type for the selection box
+
+    tree->selectbox(FL_THIN_UP_BOX);
+
+    // Create the scheme choice box
+
+    new Fl_Scheme_Choice((win->w() - 130) / 2, win->h() - 40, 130, 30, "Scheme: ");
+
     // Set up a timer to keep time in tree updated
     Fl::add_timeout(0.2, Timer_CB, (void*)tree);
   }
   win->end();
-  win->resizable(win);
+  win->resizable(tree);
+  win->size_range(300, 350);
   win->show(argc, argv);
   return(Fl::run());
 }

--- a/fluid/alignment_panel.cxx
+++ b/fluid/alignment_panel.cxx
@@ -179,21 +179,11 @@ nalize labels and tooltips, usually \"gettext_noop\" or \"N_\"");
   } // Fl_Double_Window* project_window
   return project_window;
 }
-void scheme_cb(Fl_Choice *, void *);
+void scheme_cb(Fl_Scheme_Choice *, void *);
 
 Fl_Double_Window *settings_window=(Fl_Double_Window *)0;
 
-Fl_Choice *scheme_choice=(Fl_Choice *)0;
-
-Fl_Menu_Item menu_scheme_choice[] = {
- {"Default", 0,  0, 0, 0, (uchar)FL_NORMAL_LABEL, 0, 14, 0},
- {"None", 0,  0, 0, 0, (uchar)FL_NORMAL_LABEL, 0, 14, 0},
- {"Plastic", 0,  0, 0, 0, (uchar)FL_NORMAL_LABEL, 0, 14, 0},
- {"GTK+", 0,  0, 0, 0, (uchar)FL_NORMAL_LABEL, 0, 14, 0},
- {"Gleam", 0,  0, 0, 0, (uchar)FL_NORMAL_LABEL, 0, 14, 0},
- {"Oxy", 0,  0, 0, 0, (uchar)FL_NORMAL_LABEL, 0, 14, 0},
- {0,0,0,0,0,0,0,0,0}
-};
+Fl_Scheme_Choice *scheme_choice=(Fl_Scheme_Choice *)0;
 
 Fl_Check_Button *tooltips_button=(Fl_Check_Button *)0;
 
@@ -258,16 +248,20 @@ static void cb_Close1(Fl_Button*, void*) {
 
 Fl_Double_Window* make_settings_window() {
   { Fl_Double_Window* o = settings_window = new Fl_Double_Window(360, 355, "GUI Settings");
-    { scheme_choice = new Fl_Choice(140, 10, 115, 25, "Scheme: ");
+    { scheme_choice = new Fl_Scheme_Choice(140, 10, 115, 25, "Scheme: ");
+      scheme_choice->box(FL_FLAT_BOX);
       scheme_choice->down_box(FL_BORDER_BOX);
+      scheme_choice->color(FL_BACKGROUND_COLOR);
+      scheme_choice->selection_color(FL_SELECTION_COLOR);
+      scheme_choice->labeltype(FL_NORMAL_LABEL);
       scheme_choice->labelfont(1);
+      scheme_choice->labelsize(14);
+      scheme_choice->labelcolor(FL_FOREGROUND_COLOR);
       scheme_choice->callback((Fl_Callback*)scheme_cb);
-      scheme_choice->menu(menu_scheme_choice);
-      int s;
-      fluid_prefs.get("scheme", s, 0);
-      scheme_choice->value(s);
-      scheme_cb(0, 0);
-    } // Fl_Choice* scheme_choice
+      scheme_choice->align(Fl_Align(FL_ALIGN_LEFT));
+      scheme_choice->when(FL_WHEN_RELEASE);
+      init_scheme();
+    } // Fl_Scheme_Choice* scheme_choice
     { Fl_Group* o = new Fl_Group(20, 43, 330, 161);
       o->labelfont(1);
       o->align(Fl_Align(FL_ALIGN_CENTER));

--- a/fluid/alignment_panel.fl
+++ b/fluid/alignment_panel.fl
@@ -38,6 +38,9 @@ decl {\#include <FL/Fl_Text_Display.H>} {public local
 decl {\#include <FL/filename.H>} {public local
 }
 
+decl {\#include <FL/Fl_Scheme_Choice.H>} {public local
+}
+
 decl {\#include <FL/Fl_Preferences.H>} {private global
 }
 
@@ -47,11 +50,14 @@ decl {\#include <FL/fl_ask.H>} {private global
 decl {\#include <string.h>} {private global
 }
 
+decl {void init_scheme(void);} {
+  comment {// initialize the scheme from preferences} selected public global
+}
+
 decl {extern struct Fl_Menu_Item *dbmanager_item;} {public local
 }
 
-Function {make_project_window()} {open
-} {
+Function {make_project_window()} {} {
   Fl_Window project_window {
     label {Project Settings} open
     xywh {472 246 399 298} type Double hide
@@ -168,50 +174,23 @@ set_modflag(-1, -1);}
 decl {extern void i18n_cb(Fl_Choice *,void *);} {public local
 }
 
-decl {void scheme_cb(Fl_Choice *, void *);} {public local
+decl {void scheme_cb(Fl_Scheme_Choice *, void *);} {public local
 }
 
 Function {make_settings_window()} {open
 } {
   Fl_Window settings_window {
-    label {GUI Settings}
-    xywh {442 538 360 355} type Double hide resizable
+    label {GUI Settings} open
+    xywh {701 666 360 355} type Double hide resizable
     code0 {o->size_range(o->w(), o->h());} non_modal
   } {
     Fl_Choice scheme_choice {
       label {Scheme: }
       callback scheme_cb open
       xywh {140 10 115 25} down_box BORDER_BOX labelfont 1
-      code0 {int s;}
-      code1 {fluid_prefs.get("scheme", s, 0);}
-      code2 {scheme_choice->value(s);}
-      code3 {scheme_cb(0, 0);}
-    } {
-      MenuItem {} {
-        label Default
-        xywh {0 0 35 25}
-      }
-      MenuItem {} {
-        label None
-        xywh {0 0 35 25}
-      }
-      MenuItem {} {
-        label Plastic
-        xywh {0 0 35 25}
-      }
-      MenuItem {} {
-        label {GTK+}
-        xywh {10 10 35 25}
-      }
-      MenuItem {} {
-        label Gleam
-        xywh {20 20 35 25}
-      }
-      MenuItem {} {
-        label Oxy
-        xywh {30 30 35 25}
-      }
-    }
+      code0 {init_scheme();}
+      class Fl_Scheme_Choice
+    } {}
     Fl_Group {} {open
       xywh {20 43 330 161} labelfont 1 align 0
     } {
@@ -327,7 +306,7 @@ Function {make_shell_window()} {open
         tooltip {save the design to the .fl file before running the command} xywh {82 39 136 19} down_box DOWN_BOX labelsize 12
       }
       Fl_Check_Button shell_writecode_button {
-        label {save source code} selected
+        label {save source code}
         tooltip {generate the source code and header file before running the command} xywh {82 59 120 19} down_box DOWN_BOX labelsize 12
       }
       Fl_Check_Button shell_writemsgs_button {

--- a/fluid/alignment_panel.h
+++ b/fluid/alignment_panel.h
@@ -25,6 +25,11 @@
 #include <FL/Fl_Text_Buffer.H>
 #include <FL/Fl_Text_Display.H>
 #include <FL/filename.H>
+#include <FL/Fl_Scheme_Choice.H>
+/**
+ // initialize the scheme from preferences
+*/
+void init_scheme(void);
 extern struct Fl_Menu_Item *dbmanager_item;
 #include <FL/Fl_Double_Window.H>
 #include <FL/Fl_Preferences.H>
@@ -63,10 +68,10 @@ extern Fl_Input *i18n_static_function_input;
 Fl_Double_Window* make_project_window();
 extern Fl_Menu_Item menu_i18n_type_chooser[];
 extern void i18n_cb(Fl_Choice *,void *);
-extern void scheme_cb(Fl_Choice *, void *);
+extern void scheme_cb(Fl_Scheme_Choice *, void *);
 extern Fl_Double_Window *settings_window;
-extern void scheme_cb(Fl_Choice*, void*);
-extern Fl_Choice *scheme_choice;
+extern void scheme_cb(Fl_Scheme_Choice*, void*);
+extern Fl_Scheme_Choice *scheme_choice;
 extern Fl_Check_Button *tooltips_button;
 extern Fl_Check_Button *completion_button;
 extern Fl_Check_Button *openlast_button;
@@ -77,7 +82,6 @@ extern Fl_Spinner *recent_spinner;
 extern Fl_Check_Button *use_external_editor_button;
 extern Fl_Input *editor_command_input;
 Fl_Double_Window* make_settings_window();
-extern Fl_Menu_Item menu_scheme_choice[];
 extern Fl_Double_Window *shell_window;
 extern Fl_Input *shell_command_input;
 extern Fl_Check_Button *shell_savefl_button;

--- a/fluid/fluid.cxx
+++ b/fluid/fluid.cxx
@@ -1475,34 +1475,80 @@ Fl_Menu_Item Main_Menu[] = {
 
 /**
  Change the app's and hence preview the design's scheme.
- The scheme setting is stored inthe app preferences.
+
+ The scheme setting is stored in the app preferences
+ - in key \p 'scheme_name' since 1.4.0
+ - in key \p 'scheme' (index: 0 - 4) in 1.3.x
+
+ This callback is triggered by changing the scheme in the
+ Fl_Scheme_Choice widget (\p Edit/GUI Settings).
+
+ \see init_scheme() for choice values and backwards compatibility
  */
-void scheme_cb(Fl_Choice *, void *) {
+void scheme_cb(Fl_Scheme_Choice *choice, void *) {
   if (batch_mode)
     return;
 
-  switch (scheme_choice->value()) {
-    case 0 : // Default
-      Fl::scheme(NULL);
-      break;
-    case 1 : // None
-      Fl::scheme("none");
-      break;
-    case 2 : // Plastic
-      Fl::scheme("plastic");
-      break;
-    case 3 : // GTK+
-      Fl::scheme("gtk+");
-      break;
-    case 4 : // Gleam
-      Fl::scheme("gleam");
-      break;
-    case 5 : // Oxy
-      Fl::scheme("oxy");
-      break;
-  }
+  // set the new scheme only if the scheme was changed
+  const char *new_scheme = choice->text(choice->value());
 
-  fluid_prefs.set("scheme", scheme_choice->value());
+  if (Fl::is_scheme(new_scheme))
+    return;
+
+  Fl::scheme(new_scheme);
+  fluid_prefs.set("scheme_name", new_scheme);
+
+  // Backwards compatibility: store 1.3 scheme index (1-4).
+  // We assume that index 0-3 (base, plastic, gtk+, gleam) are in the
+  // same order as in 1.3.x (index 1-4), higher values are ignored
+
+  int scheme_index = scheme_choice->value();
+  if (scheme_index <= 3)                          // max. index for 1.3.x (Gleam)
+    fluid_prefs.set("scheme", scheme_index + 1);  // compensate for different indexing
+}
+
+/**
+  Read Fluid's scheme preferences and set the app's scheme.
+
+  Since FLTK 1.4.0 the scheme \b name is stored as a character string
+  with key "scheme_name" in the preference database.
+
+  In FLTK 1.3.x the scheme preference was stored as an integer index
+  with key "scheme" in the database. The known schemes were hardcoded in
+  Fluid's sources (here for reference):
+
+    | Index | 1.3 Scheme Name | Choice | 1.4 Scheme Name |
+    |-------|-----------------|-------|-----------------|
+    | 0 | Default (same as None) | n/a | n/a |
+    | 1 | None (same as Default) | 0 | base |
+    | 2 | Plastic | 1 | plastic |
+    | 3 | GTK+ | 2 | gtk+ |
+    | 4 | Gleam | 3 | gleam |
+    | n/a | n/a | 4 | oxy |
+
+  The new Fluid tries to keep backwards compatibility and reads both
+  keys (\p scheme and \p scheme_name). If the latter is defined, it is used.
+  If not the old \p scheme (index) is used - but we need to subtract one to
+  get the new Fl_Scheme_Choice index (column "Choice" above).
+*/
+void init_scheme() {
+  int scheme_index = 0;                     // scheme index for backwards compatibility (1.3.x)
+  char *scheme_name;                        // scheme name since 1.4.0
+  fluid_prefs.get("scheme_name", scheme_name, "XXX"); // XXX means: not set => fallback 1.3.x
+  if (!strcmp(scheme_name, "XXX")) {
+    fluid_prefs.get("scheme", scheme_index, 0);
+    if (scheme_index > 0) {
+      scheme_index--;
+      scheme_choice->value(scheme_index);   // set the choice value
+    }
+    if (scheme_index < 0)
+      scheme_index = 0;
+    else if (scheme_index > scheme_choice->size() - 1)
+      scheme_index = 0;
+    scheme_name = const_cast<char *>(scheme_choice->text(scheme_index));
+    fluid_prefs.set("scheme_name", scheme_name);
+  }
+  Fl::scheme(scheme_name);
 }
 
 /**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,7 @@ set (CPPFILES
   Fl_Return_Button.cxx
   Fl_Roller.cxx
   Fl_Round_Button.cxx
+  Fl_Scheme.cxx
   Fl_Screen_Driver.cxx
   Fl_Scroll.cxx
   Fl_Scrollbar.cxx

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,7 @@ set (CPPFILES
   Fl_Roller.cxx
   Fl_Round_Button.cxx
   Fl_Scheme.cxx
+  Fl_Scheme_Choice.cxx
   Fl_Screen_Driver.cxx
   Fl_Scroll.cxx
   Fl_Scrollbar.cxx

--- a/src/Fl_Scheme.cxx
+++ b/src/Fl_Scheme.cxx
@@ -1,0 +1,149 @@
+//
+// Scheme implementation for the Fast Light Tool Kit (FLTK).
+//
+// Copyright 2022-2023 by Bill Spitzak and others.
+//
+// This library is free software. Distribution and use rights are outlined in
+// the file "COPYING" which should have been included with this file.  If this
+// file is missing or damaged, see the license at:
+//
+//     https://www.fltk.org/COPYING.php
+//
+// Please see the following page on how to report bugs and issues:
+//
+//     https://www.fltk.org/bugs.php
+//
+
+#include <FL/Fl.H>
+#include <FL/Fl_Window.H>
+#include <FL/Fl_Scheme.H>
+#include <FL/fl_string_functions.h> // fl_strdup
+
+#include <stdlib.h>         // malloc, realloc
+
+const char **Fl_Scheme::names_ = NULL;
+int Fl_Scheme::num_schemes_    = 0;
+int Fl_Scheme::alloc_size_     = 0;
+
+/**
+  Return a list of all known scheme names.
+
+  This list is only valid until a new scheme is added or one is removed.
+  It is possible that scheme names are appended to the list during the
+  runtime of the program but schemes can't be removed.
+
+  Getting the list of known schemes can be useful to populate a menu of
+  scheme choices to let the user select a scheme. You should process the
+  names immediately and you should never store a pointer to the list or
+  any individual name for later reference because the location of the
+  list can be changed (reallocated) when schemes are added.
+
+  The list of scheme names is nul-terminated.
+
+  \note
+    Currently (in FLTK 1.4.0) schemes can only be added to the list and
+    not removed from the list. This may change in a later version.
+
+  \return  List of currently known scheme names.
+*/
+
+const char **Fl_Scheme::names() {
+  if (names_)
+    return names_;
+
+  alloc_size_ = 8;
+  names_ = (const char **)malloc(alloc_size_ * sizeof(const char *));
+
+  // FIXME: register "known" scheme names ...
+
+  add_scheme_name("base");
+  add_scheme_name("plastic");
+  add_scheme_name("gtk+");
+  add_scheme_name("gleam");
+  add_scheme_name("oxy");
+
+  return names_;
+}
+
+/**
+  Add a scheme name to the list of known schemes.
+
+  This method is public in FLTK 1.4.0 because derived classes of Fl_Scheme
+  are not yet implemented. Thus, users implementing their own schemes can
+  use this method to add the scheme name to the list of known schemes
+  which is for instance used in Fl_Scheme::names().
+
+  \note \b Attention!
+    In a future version, when subclasses of Fl_Scheme will be implemented,
+    this method will either be replaced by another \p protected method or
+    it will no longer do anything (kept only for ABI reasons).
+
+  The new scheme name must consist of valid ASCII characters as described
+  below:
+  - lowercase letters \p 'a' - \p 'z'
+  - numbers \p '0' - \p '9'
+  - any character in \p "$+_." (w/o the quotes).
+
+  The name must not be longer than 12 ASCII characters (bytes).
+  The new scheme name is added to the \b end of the \b unordered list.
+
+  \note Call this method only once for each scheme name. If the returned
+    value is \<= 0 you should check the scheme name.
+
+  The given scheme \p name is copied and may be freed directly after the
+  call to add_scheme_name().
+
+  \param[in]  name  New scheme name
+
+  \returns  The new number of schemes if the name was successfully added.
+            This is the same as the index of the scheme + 1.
+  \retval   0   Scheme \p name already exists
+  \retval  -1   Invalid character(s) in \p name
+  \retval  -2   The \p name is too long
+
+  \since 1.4.0
+*/
+int Fl_Scheme::add_scheme_name(const char *name) {
+
+  static const char valid_chars[] = "$+_.";
+
+  // test if the scheme name is valid
+
+  int nlen = static_cast<int>(strlen(name));
+
+  if (nlen > 12)
+    return (-2);
+
+  for (int i = 0; i < nlen; i++) {
+    if ((name[i] >= 'a' && name[i] <= 'z') ||
+        (name[i] >= '0' && name[i] <= '9'))
+      continue;
+    if (!strchr(valid_chars, name[i]))
+      return (-1);
+  }
+
+  // Test if the scheme name already exists.
+  // We know already that it consists only of valid characters,
+  // hence we can use the faster strcmp() for comparison.
+
+  const char **s = names();
+  for (int i = 0; i < num_schemes_; i++) {
+    if (strcmp(name, s[i]) == 0)
+      return 0;
+  }
+
+  // The scheme name is OK, we can add it. Take care that we need
+  // a null pointer at the end of the list.
+
+  num_schemes_++;
+
+  if (num_schemes_ + 1 > alloc_size_) { // overflow, extend the list
+    alloc_size_ += 8;
+    names_ = (const char **)realloc(names_, alloc_size_ * sizeof(const char *));
+  }
+
+  names_[num_schemes_-1] = fl_strdup(name);
+  names_[num_schemes_] = NULL;
+
+  return num_schemes_;
+}

--- a/src/Fl_Scheme_Choice.cxx
+++ b/src/Fl_Scheme_Choice.cxx
@@ -1,0 +1,131 @@
+//
+// Scheme Choice widget for the Fast Light Tool Kit (FLTK).
+//
+// Copyright 2022 by Bill Spitzak and others.
+//
+// This library is free software. Distribution and use rights are outlined in
+// the file "COPYING" which should have been included with this file.  If this
+// file is missing or damaged, see the license at:
+//
+//     https://www.fltk.org/COPYING.php
+//
+// Please see the following page on how to report bugs and issues:
+//
+//     https://www.fltk.org/bugs.php
+//
+
+#include <FL/Fl.H>
+#include <FL/Fl_Window.H>
+#include <FL/Fl_Scheme_Choice.H>
+
+
+/**
+  The constructor initializes the Fl_Scheme_Choice object with all known schemes.
+
+  \param[in]  X,Y   Widget coordinates
+  \param[in]  W,H   Widget size (width, height)
+  \param[in]  L     Widget label (default: NULL, no label)
+*/
+Fl_Scheme_Choice::Fl_Scheme_Choice(int X, int Y, int W, int H, const char *L)
+  : Fl_Choice(X, Y, W, H, L) {
+
+  const char * const *names = Fl_Scheme::names();
+
+  // Add all known schemes in the order defined by the list of scheme names
+  while (*names) {
+    add(*names);
+    names++;
+  }
+
+  callback(scheme_cb_);   // internal callback
+  init_value();           // set choice value to current scheme
+}
+
+/**
+  Public method to initialize the value of the Fl_Scheme_Choice widget.
+
+  Normally you don't need to call this unless you change the current scheme
+  by calling Fl::scheme(const char *).
+
+  The Fl_Scheme_Choice widget does this automatically when the widget is
+  shown (when receiving the FL_SHOW event) which should always be after
+  Fl_Window::show(argc, argv) which may set the current scheme by interpreting
+  the commandline.
+
+  \since 1.4.0
+*/
+void Fl_Scheme_Choice::init_value() {
+  const char *current = Fl::scheme();
+
+  value(0);
+  if (!current)
+    return;
+
+  const char * const * names = Fl_Scheme::names();
+  int i = 0;
+  while (names[i]) {
+    if (!strcmp(current, names[i])) {
+      value(i);
+      break;
+    }
+    i++;
+  }
+} // init_value()
+
+
+/**
+  Internal Fl_Scheme_Choice callback function (protected).
+
+  You don't need to set a callback for this widget. The default callback
+  changes the scheme (Fl::scheme()) and redraws all open windows.
+
+  You may override the callback if changing the scheme shall redraw other
+  windows or don't redraw the window at all.
+
+  \param[in]  w   The Fl_Scheme_Choice widget
+*/
+void Fl_Scheme_Choice::scheme_cb_(Fl_Widget *w, void *) {
+  Fl_Choice *c = reinterpret_cast<Fl_Choice *>(w);
+  // set the new scheme only if the scheme was changed
+  const char *new_scheme = c->text(c->value());
+  if (!Fl::is_scheme(new_scheme)) {
+    Fl::scheme(new_scheme);
+  }
+}
+
+/**
+  \brief Handle FLTK events.
+
+  This widget uses FL_SHOW and some other events to initialize its value()
+  according to the current scheme.
+
+  All events are also handled by the base class Fl_Choice.
+
+  \param[in]  event
+  \return     1 if the event was used, 0 otherwise
+
+  \internal
+    Usually the FL_SHOW event is used to initialize the value, and this should
+    in most cases be sufficient. However, if the scheme is changed after show()
+    the widget doesn't "know" this and can't update itself. Therefore the enter
+    and push events are also used to update the displayed value.
+
+    In the future we will be able to register a callback that will be triggered
+    when the scheme is changed. This will make the special handling of FL_PUSH
+    and FL_ENTER obsolete, but FL_SHOW is still required.
+*/
+int Fl_Scheme_Choice::handle(int event) {
+  int ret = 0;
+  switch (event) {
+    case FL_SHOW:
+    case FL_PUSH:
+    case FL_ENTER:
+      init_value();
+      ret = 1;
+      break;
+    default:
+      break;
+  }
+  ret |= Fl_Choice::handle(event);
+  return ret;
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -76,6 +76,7 @@ CPPFILES = \
 	Fl_Roller.cxx \
 	Fl_Round_Button.cxx \
 	Fl_Screen_Driver.cxx \
+	Fl_Scheme.cxx \
 	Fl_Scroll.cxx \
 	Fl_Scrollbar.cxx \
 	Fl_Shared_Image.cxx \

--- a/src/Makefile
+++ b/src/Makefile
@@ -77,6 +77,7 @@ CPPFILES = \
 	Fl_Round_Button.cxx \
 	Fl_Screen_Driver.cxx \
 	Fl_Scheme.cxx \
+	Fl_Scheme_Choice.cxx \
 	Fl_Scroll.cxx \
 	Fl_Scrollbar.cxx \
 	Fl_Shared_Image.cxx \

--- a/test/boxtype.cxx
+++ b/test/boxtype.cxx
@@ -19,6 +19,7 @@
 #include <FL/Fl.H>
 #include <FL/Fl_Double_Window.H>
 #include <FL/Fl_Box.H>
+#include <FL/Fl_Scheme_Choice.H>
 #include <FL/fl_draw.H>
 
 int N = 0;
@@ -176,6 +177,7 @@ int main(int argc, char ** argv) {
   bt("FL_GTK_ROUND_DOWN_BOX",FL_GTK_ROUND_DOWN_BOX);
   bg->end();
   window->resizable(window);
+  Fl_Scheme_Choice scheme_choice(610, 10, 150, 30, "Scheme:");
   window->end();
   window->show();
   return Fl::run();

--- a/test/buttons.cxx
+++ b/test/buttons.cxx
@@ -22,16 +22,28 @@
 #include <FL/Fl_Check_Button.H>
 #include <FL/Fl_Light_Button.H>
 #include <FL/Fl_Round_Button.H>
+#include <FL/Fl_Scheme_Choice.H>
 
 int main(int argc, char **argv) {
-  Fl_Window *window = new Fl_Window(320, 130);
-  Fl_Button *b = new Fl_Button(10, 10, 130, 30, "Fl_Button");
-  b->tooltip("This is a Tooltip.");
-  new Fl_Return_Button(150, 10, 160, 30, "Fl_Return_Button");
-  new Fl_Repeat_Button(10, 50, 130, 30, "Fl_Repeat_Button");
-  new Fl_Round_Button(150, 50, 160, 30, "Fl_Round_Button");
-  new Fl_Light_Button(10, 90, 130, 30, "Fl_Light_Button");
-  new Fl_Check_Button(150, 90, 160, 30, "Fl_Check_Button");
+  Fl_Window *window = new Fl_Window(320, 170);
+  Fl_Button *b1 = new Fl_Button(10, 10, 130, 30, "Fl_Button");
+  b1->tooltip("Fl_Button");
+  Fl_Button *b2 = new Fl_Return_Button(150, 10, 160, 30, "Fl_Return_Button");
+  b2->tooltip("Fl_Return_Button");
+  Fl_Button *b3 = new Fl_Repeat_Button(10, 50, 130, 30, "Fl_Repeat_Button");
+  b3->tooltip("Fl_Repeat_Button");
+  Fl_Button *b4 = new Fl_Round_Button(150, 50, 160, 30, "Fl_Round_Button");
+  b4->tooltip("Fl_Round_Button");
+  Fl_Button *b5 = new Fl_Light_Button(10, 90, 130, 30, "Fl_Light_Button");
+  b5->tooltip("Fl_Light_Button");
+  Fl_Button *b6 = new Fl_Check_Button(150, 90, 160, 30, "Fl_Check_Button");
+  b6->tooltip("Fl_Check_Button");
+
+  // Add a scheme choice widget for easier testing. Position the widget at
+  // the right window border so the menu popup doesn't cover the check boxes etc.
+  Fl_Scheme_Choice *scheme_choice = new Fl_Scheme_Choice(180, 130, 130, 30, "Active FLTK Scheme:");
+  scheme_choice->tooltip("Fl_Scheme_Choice");
+
   window->end();
   window->resizable(window);
   window->size_range(320, 130);

--- a/test/demo.cxx
+++ b/test/demo.cxx
@@ -78,7 +78,7 @@
 #include <FL/Fl_Box.H>
 #include <FL/Fl_Button.H>
 #include <FL/Fl_Menu_Button.H>      // right click popup menu
-#include <FL/Fl_Choice.H>
+#include <FL/Fl_Scheme_Choice.H>
 #include <FL/Fl_Simple_Terminal.H>  // tty
 #include <FL/filename.H>
 #include <FL/platform.H>
@@ -95,13 +95,11 @@
 void doexit(Fl_Widget *, void *);
 void doback(Fl_Widget *, void *);
 void dobut(Fl_Widget *, long);
-void doscheme(Fl_Choice *c, void *) {
-  Fl::scheme(c->text(c->value()));
-}
 
 Fl_Double_Window *form = 0;
 Fl_Group *demogrp = 0;
 Fl_Simple_Terminal *tty = 0;
+Fl_Scheme_Choice *scheme_choice = 0;
 Fl_Button *but[9];
 Fl_Button *exit_button;
 
@@ -185,21 +183,8 @@ void create_the_forms() {
   obj = new Fl_Box(FL_FRAME_BOX, 10, 65, 330, 330, 0);
   obj->color(FL_GRAY-8);
 
-  Fl_Choice *choice = new Fl_Choice(90, 405, 100, 25, "Scheme:");
-  choice->labelfont(FL_HELVETICA_BOLD);
-  choice->add("none");
-  choice->add("gtk+");
-  choice->add("gleam");
-  choice->add("oxy");
-  choice->add("plastic");
-  choice->callback((Fl_Callback *)doscheme);
-  Fl::scheme(NULL);
-  if (!Fl::scheme())                         choice->value(0);
-  else if (!strcmp(Fl::scheme(), "gtk+"))    choice->value(1);
-  else if (!strcmp(Fl::scheme(), "gleam"))   choice->value(2);
-  else if (!strcmp(Fl::scheme(), "oxy"))     choice->value(3);
-  else if (!strcmp(Fl::scheme(), "plastic")) choice->value(4);
-  else choice->value(0);
+  scheme_choice = new Fl_Scheme_Choice(90, 405, 100, 25, "Scheme:");
+  scheme_choice->labelfont(FL_HELVETICA_BOLD);
 
   exit_button = new Fl_Button(280, 405, 60, 25, "Exit");
   exit_button->callback(doexit);
@@ -638,6 +623,17 @@ int main(int argc, char **argv) {
 
   // set size_range() after show() so the window can be resizable (Win + macOS)
   form->size_range(FORM_W, FORM_H, FORM_W, FORM_H);
+
+#if (0) // DEBUG (remove after testing)
+  {
+    const char *const *scheme_names = Fl_Scheme_Choice::scheme_names();
+    int ni = 0;
+    while (scheme_names[ni]) {
+      printf("scheme[%2d] = '%s'\n", ni, scheme_names[ni]);
+      ni++;
+    }
+  }
+#endif // End of debug and test statements
 
   Fl::run();
   return 0;

--- a/test/menubar.cxx
+++ b/test/menubar.cxx
@@ -23,7 +23,7 @@
 #include <FL/Fl_Sys_Menu_Bar.H>
 #include <FL/Fl_Toggle_Button.H>
 #include <FL/Fl_Menu_Button.H>
-#include <FL/Fl_Choice.H>
+#include <FL/Fl_Scheme_Choice.H>
 #include <FL/Fl_Value_Slider.H>
 #include <stdio.h>
 #include <stdlib.h>
@@ -229,6 +229,9 @@ int main(int argc, char **argv) {
     hugemenu[i].text = fl_strdup(buf);
   }
   Fl_Double_Window window(WIDTH,400+TERMINAL_HEIGHT);
+
+  Fl_Scheme_Choice scheme_choice(300, 50, 100, 25, "&scheme");
+
   G_tty = new Fl_Simple_Terminal(0,400,WIDTH,TERMINAL_HEIGHT);
 
   window.callback(window_cb);

--- a/test/unittest_schemes.cxx
+++ b/test/unittest_schemes.cxx
@@ -18,7 +18,7 @@
 
 #include "unittests.h"
 
-#include <FL/Fl_Choice.H>
+#include <FL/Fl_Scheme_Choice.H>
 
 // needed by Edmanuel's test layout
 #include <FL/Fl_Button.H>
@@ -45,16 +45,7 @@
 #include <FL/Fl_Radio_Round_Button.H>
 
 class Ut_Schemes_Test : public Fl_Group {
-  Fl_Choice *scheme_choice_;
-
-  static void scheme_choice_cb(Fl_Widget*,void *data) {
-    Ut_Schemes_Test *st = (Ut_Schemes_Test*)data;
-    const char *name = st->scheme_choice_->text();
-    if ( name ) {
-      Fl::scheme(name);         // change scheme
-      st->window()->redraw();   // redraw window
-    }
-  } // SchemeChoice_CB()
+  Fl_Scheme_Choice *scheme_choice_;
 
   static void activate_subwin(Fl_Widget *w, void *data) {
     Fl_Window *win = (Fl_Window *)data;
@@ -82,22 +73,9 @@ public:
   }
   Ut_Schemes_Test(int X,int Y,int W,int H)
     : Fl_Group(X,Y,W,H) {
-    scheme_choice_ = new Fl_Choice(X+125,Y,140,25,"FLTK Scheme");
-    scheme_choice_->add("none");
-    scheme_choice_->add("plastic");
-    scheme_choice_->add("gtk+");
-    scheme_choice_->add("gleam");
-    scheme_choice_->add("oxy");
-    scheme_choice_->value(0);
+
+    scheme_choice_ = new Fl_Scheme_Choice(X+125,Y,140,25,"FLTK Scheme");
     scheme_choice_->labelfont(FL_HELVETICA_BOLD);
-    const char *name = Fl::scheme();
-    if ( name ) {
-           if ( strcmp(name, "plastic") == 0) { scheme_choice_->value(1); }
-      else if ( strcmp(name, "gtk+")    == 0) { scheme_choice_->value(2); }
-      else if ( strcmp(name, "gleam")   == 0) { scheme_choice_->value(3); }
-      else if ( strcmp(name, "oxy")     == 0) { scheme_choice_->value(4); }
-    }
-    scheme_choice_->callback(scheme_choice_cb, (void*)this);
 
     Fl_Light_Button *active = new Fl_Light_Button(X + 300, Y, 100, 25, "active");
     active->value(1);


### PR DESCRIPTION
This widget offers the choice of all known FLTK schemes as a simple widget based on `Fl_Choice`.

Note: initial version, needs more work (WIP)

Todo:
 - [x] redraw all open windows when the scheme is changed
 - [ ] add feature to add new schemes -- postponed --
 - [ ] update status (value) when the scheme is changed by `Fl::scheme("...")` -- postponed --
 - [x] update `Fluid`: replace `Fl_Choice` with `Fl_Scheme_Choice` to remove hardcoded scheme names
 - [x] make sure `Fluid` doesn't open the display in batch mode
 - [x] provide a list of known scheme names (suggested by @erco77 below)

Future:
 - [ ] register schemes to auto-update `Fl_Scheme_Choice` widget
 - [ ] maybe more...

Edit (Jan 04, 2023): I changed the simple lists (bullets) to task lists and edited some items for clarity.
