### PR TITLE
Fix coordinates in gl_rect

### DIFF
--- a/src/gl_draw.cxx
+++ b/src/gl_draw.cxx
@@ -221,7 +221,7 @@ void gl_rect(int x, int y, int w, int h) {
   glVertex2i(x+w-1, y);
   glVertex2i(x, y);
   glVertex2i(x, y+h-1);
-  glVertex2i(x+w, y+h-1);
+  glVertex2i(x+w-1, y+h-1);
   glEnd();
 }
 


### PR DESCRIPTION
There is a problem in function `gl_rect`, line 224 in `gl_draw.cxx`:

```
glVertex2i(x+w, y+h-1);
```

The last point will exceed the rectangle.

So this should be `glVertex2i(x+w-1, y+h-1);`. 
