### PR TITLE
Eliminates a few compile warnings. Fixes a couple of potential bugs

### DIFF
--- a/FL/x.H
+++ b/FL/x.H
@@ -82,7 +82,7 @@ typedef ulong Fl_Offscreen;
   fl_push_no_clip()
 #    define fl_end_offscreen() \
   fl_pop_clip(); fl_window = _sw; _ss->set_current(); \
-  if (!_sgc) XFreeGC(fl_display, fl_gc); fl_gc = _sgc
+  if (!_sgc) { XFreeGC(fl_display, fl_gc); } fl_gc = _sgc
 
 extern FL_EXPORT void fl_copy_offscreen(int x, int y, int w, int h, Fl_Offscreen pixmap, int srcx, int srcy);
 #    define fl_delete_offscreen(pixmap) XFreePixmap(fl_display, pixmap)

--- a/src/Fl_Text_Display.cxx
+++ b/src/Fl_Text_Display.cxx
@@ -149,7 +149,7 @@ Fl_Text_Display::Fl_Text_Display(int X, int Y, int W, int H, const char* l)
   mStyleTable = 0;
   mNStyles = 0;
   mNVisibleLines = 1;
-  mLineStarts = new int[mNVisibleLines];
+  mLineStarts = new int[mNVisibleLines+1];
   mLineStarts[0] = 0;
   for (i=1; i<mNVisibleLines; i++)
     mLineStarts[i] = -1;

--- a/src/Fl_x.cxx
+++ b/src/Fl_x.cxx
@@ -1453,39 +1453,14 @@ static long getIncrData(uchar* &data, const XSelectionEvent& selevent, size_t lo
   return (long)total;
 }
 
-/*
-  Internal function to reduce "deprecated" warnings for XKeycodeToKeysym().
-  This way we get at most one warning. The option to use XkbKeycodeToKeysym()
-  instead would not help much - see STR #2913 for more information.
-
-  Update (July 22, 2022): disable "deprecated declaration" warnings in
-  this function for GCC >= 4.6 and clang (all versions) to get rid of
-  these warnings at least for current GCC and clang compilers.
-
-  Note: '#pragma GCC diagnostic push' needs at least GCC 4.6.
-*/
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
-#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 5))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
 static KeySym fl_KeycodeToKeysym(Display *d, KeyCode k, unsigned i) {
-  return XKeycodeToKeysym(d, k, i);
+  KeySym* syms;
+  int returned;
+  syms = XGetKeyboardMapping(d, k, i+1, &returned);
+  KeySym sym = syms[i];
+  XFree(syms);
+  return sym;
 }
-
-#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 5))
-#pragma GCC diagnostic pop
-#endif
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
 int fl_handle(const XEvent& thisevent)
 {

--- a/src/fl_draw.cxx
+++ b/src/fl_draw.cxx
@@ -80,7 +80,7 @@ static const char* expand_text_(const char* from, char*& buf, int maxbuf, double
     if (o > e) {
       if (maxbuf) break; // don't overflow buffer
       l_local_buff += (o - e) + 200; // enlarge buffer
-      buf = (char*)realloc(local_buf, l_local_buff);
+      buf = local_buf = (char*)realloc(local_buf, l_local_buff);
       e = buf + l_local_buff - 4; // update pointers to buffer content
       o = buf + (o - local_buf);
       word_end = buf + (word_end - local_buf);

--- a/src/gl_draw.cxx
+++ b/src/gl_draw.cxx
@@ -117,12 +117,12 @@ void  gl_font(int fontid, int size) {
 }
 
 #ifndef __APPLE__
-static void get_list(int r) {
-  gl_fontsize->glok[r] = 1;
 #if defined(USE_X11)
 # if USE_XFT
 // FIXME
 # else
+static void get_list(int r) {
+  gl_fontsize->glok[r] = 1;
   unsigned int ii = r * 0x400;
   for (int i = 0; i < 0x400; i++) {
     XFontStruct *font = NULL;
@@ -130,17 +130,20 @@ static void get_list(int r) {
     fl_XGetUtf8FontAndGlyph(gl_fontsize->font, ii, &font, &id);
     if (font) glXUseXFont(font->fid, id, 1, gl_fontsize->listbase+ii);
     ii++;
-   }
+  }
+}
 # endif
 #elif defined(WIN32)
+static void get_list(int r) {
+  gl_fontsize->glok[r] = 1;
   unsigned int ii = r * 0x400;
   HFONT oldFid = (HFONT)SelectObject(fl_gc, gl_fontsize->fid);
   wglUseFontBitmapsW(fl_gc, ii, 0x400, gl_fontsize->listbase+ii);
   SelectObject(fl_gc, oldFid);
+}
 #else
 #  error unsupported platform
 #endif
-} // get_list
 #endif
 
 void gl_remove_displaylist_fonts()

--- a/test/icon.cxx
+++ b/test/icon.cxx
@@ -23,17 +23,17 @@ static Fl_Double_Window *win;
 
 void choice_cb(Fl_Widget *, void *v) {
   Fl_Color c = (Fl_Color)(fl_intptr_t)v;
-  uchar buffer[32*32*3];
+  uchar buffer[32*32*3] = {};
   Fl_RGB_Image icon(buffer, 32, 32, 3);
   icon.color_average(c, 0.0);
   win->icon(&icon);
 }
 
 Fl_Menu_Item choices[] = {
-  {"Red",0,choice_cb,(void*)FL_RED},
-  {"Green",0,choice_cb,(void*)FL_GREEN},
-  {"Blue",0,choice_cb,(void*)FL_BLUE},
-  {0}
+  {"Red",0,choice_cb,(void*)FL_RED,0,0,0,0,0},
+  {"Green",0,choice_cb,(void*)FL_GREEN,0,0,0,0,0},
+  {"Blue",0,choice_cb,(void*)FL_BLUE,0,0,0,0,0},
+  {0,0,0,0,0,0,0,0,0}
 };
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Fix use after realloc of local_buf in fl_draw.cxx (bug?)

mLineStarts is a one element array but [0] and [1] are initialized in Fl_Text_Display.cxx  (bug?)

Replace deprecated XKeyCodeToKeysym with XGetKeyboardMapping and remove pragma protection around it in Fl_x.cxx.  Tested on Fedora 37, not sure it covers all cases, other or old environments.

Worked around get_list being defined but not used by moving/duplicating a few lines in gl_draw.cxx 

buffer was used before initialized, and choices initialization was incomplete in icon.cxx
