### PR TITLE
Protect GL_SILENCE_DEPRECATION from re-definition.

### DIFF
--- a/FL/gl.h
+++ b/FL/gl.h
@@ -55,7 +55,9 @@
 #  endif
 
 #  ifdef __APPLE__ // PORTME: OpenGL path abstraction
-#  define GL_SILENCE_DEPRECATION 1
+#    ifndef GL_SILENCE_DEPRECATION
+#      define GL_SILENCE_DEPRECATION 1
+#    endif
 #    if !defined(__gl3_h_) // make sure OpenGL/gl3.h was not included before
 #      include <OpenGL/gl.h>
 #    endif


### PR DESCRIPTION
If users have already defined GL_SILENCE_DEPRECATION before #including FLTK, they currently get a warning.  This prevents that.