### PR TITLE
wayland: basic handling of touch inputs

### DIFF
--- a/src/drivers/Wayland/Fl_Wayland_Screen_Driver.H
+++ b/src/drivers/Wayland/Fl_Wayland_Screen_Driver.H
@@ -43,6 +43,7 @@ public:
   struct seat {
     struct wl_seat *wl_seat;
     struct wl_pointer *wl_pointer;
+    struct wl_touch *wl_touch;
     struct wl_keyboard *wl_keyboard;
     uint32_t keyboard_enter_serial;
     struct wl_surface *keyboard_surface;

--- a/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
+++ b/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
@@ -359,6 +359,51 @@ static struct wl_pointer_listener pointer_listener = {
   pointer_axis
 };
 
+
+static void touch_down(void *data,
+         struct wl_touch *wl_touch,
+         uint32_t serial,
+         uint32_t time,
+         wl_surface *surface,
+         int id,
+         wl_fixed_t x,
+         wl_fixed_t y)
+{
+  if (id != 0) return;
+  Fl_Window *win = event_coords_from_surface(surface, x, y);
+  if (!win) return;
+  struct Fl_Wayland_Screen_Driver::seat *seat = (struct Fl_Wayland_Screen_Driver::seat*)data;
+  seat->pointer_focus = surface;
+  pointer_button(data, NULL, serial, time, BTN_LEFT, WL_POINTER_BUTTON_STATE_PRESSED);
+}
+
+
+void touch_up(void* data, wl_touch* wl_touch, uint serial, uint time, int id) {
+  if (id != 0) return;
+  pointer_button(data, NULL, serial, time, BTN_LEFT, WL_POINTER_BUTTON_STATE_RELEASED);
+}
+
+
+void touch_motion(void* data, wl_touch* wl_touch, uint time, int id,
+                  wl_fixed_t x, wl_fixed_t y) {
+  if (id != 0) return;
+  pointer_motion(data, NULL, time, x, y);
+}
+
+
+void touch_frame(void* data, wl_touch* wl_touch) { }
+void touch_cancel(void* data, wl_touch* wl_touch) { }
+
+
+static struct wl_touch_listener touch_listener = {
+  touch_down,
+  touch_up,
+  touch_motion,
+  touch_frame,
+  touch_cancel,
+};
+
+
 static const char *proxy_tag = "FLTK for Wayland";
 
 bool Fl_Wayland_Screen_Driver::own_output(struct wl_output *output)
@@ -903,6 +948,14 @@ static void seat_capabilities(void *data, struct wl_seat *wl_seat, uint32_t capa
     wl_pointer_release(seat->wl_pointer);
     seat->wl_pointer = NULL;
   }
+  
+  if ((capabilities & WL_SEAT_CAPABILITY_TOUCH) && !seat->wl_touch) {
+      seat->wl_touch = wl_seat_get_touch(wl_seat);
+      wl_touch_add_listener(seat->wl_touch, &touch_listener, seat);
+    } else if (!(capabilities & WL_SEAT_CAPABILITY_TOUCH) && seat->wl_touch) {
+      wl_touch_release(seat->wl_touch);
+      seat->wl_touch = NULL;
+    }
 
   bool have_keyboard = seat->xkb_context && (capabilities & WL_SEAT_CAPABILITY_KEYBOARD);
   if (have_keyboard && seat->wl_keyboard == NULL) {


### PR DESCRIPTION
When trying to use fltk's wayland backend with phosh on a pinephone, the touchscreen inputs aren't registered.  It seems that no pointer events are sent for the touchscreen, and the only way to get them is to use the touch event api.  There is a lot more that could be done (supporting gestures, multitouch, etc), but this at least brings basic UI functionality for devices like that (and allow fltk to be used for phone apps!)

I'm not very familiar with FLTK code, or at all with wayland, so this probably needs a lot of work, but I can work through the demos/tests without crashing.