### PR TITLE
Fl_cocoa.mm: fix Apple macro for PPC case

### DIFF
--- a/src/Fl_cocoa.mm
+++ b/src/Fl_cocoa.mm
@@ -92,8 +92,8 @@ static BOOL through_drawRect = NO;
 static BOOL through_Fl_X_flush = NO;
 static BOOL views_use_CA = NO; // YES means views are layer-backed, as on macOS 10.14 when linked with SDK 10.14
 static int im_enabled = -1;
-// OS version-dependent pasteboard type names
-#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_6
+// OS version-dependent pasteboard type names. PPC still supported on 10.6 but lacks some 10.6 features.
+#if (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_6) || defined(__POWERPC__)
 #define NSPasteboardTypeTIFF @"public.tiff"
 #define NSPasteboardTypePDF @"com.adobe.pdf"
 #define NSPasteboardTypeString @"public.utf8-plain-text"


### PR DESCRIPTION
This fixes the build on 10.6 when building for `ppc`. Has no effect on other platforms.