### PR TITLE
Fix default color of ATTR_GRAMMAR/ATTR_SPELLING

### DIFF
--- a/src/Fl_Text_Display.cxx
+++ b/src/Fl_Text_Display.cxx
@@ -168,8 +168,8 @@ Fl_Text_Display::Fl_Text_Display(int X, int Y, int W, int H, const char* l)
   textfont_ = FL_HELVETICA;             // textfont()
   textsize_ = FL_NORMAL_SIZE;           // textsize()
   textcolor_ = FL_FOREGROUND_COLOR;     // textcolor()
-  grammar_underline_color_ = FL_RED;
-  spelling_underline_color_ = FL_BLUE;
+  grammar_underline_color_ = FL_BLUE;
+  spelling_underline_color_ = FL_RED;
   secondary_selection_color_ = FL_GRAY;
   mLineNumLeft = 0;             // XXX: UNUSED
   mLineNumWidth = 0;


### PR DESCRIPTION
As the comment tells the color of `ATTR_GRAMMAR` would be **BLUE**, while the color of `ATTR_SPELLING` would be **RED**

https://github.com/fltk/fltk/blob/bb7e1635adb15d685a94e96b015d4bfd09cf2f05/FL/Fl_Text_Display.H#L161-L162