### PR TITLE
Add virtual void Fl_Graphics_Driver::small_circle() to support fl_draw_circle()

### DIFF
--- a/FL/Fl_Graphics_Driver.H
+++ b/FL/Fl_Graphics_Driver.H
@@ -315,6 +315,9 @@ public:
   virtual void arc(double x, double y, double r, double start, double end);
   virtual void arc(int x, int y, int w, int h, double a1, double a2);
   virtual void pie(int x, int y, int w, int h, double a1, double a2);
+  // To support fl_draw_circle(int x, int y, int d, Fl_Color color),
+  // the default implementation is most probably enough.
+  virtual void draw_circle(int x, int y, int d, Fl_Color c);
   virtual void curve(double X0, double Y0, double X1, double Y1, double X2, double Y2, double X3, double Y3);
   virtual void line_style(int style, int width=0, char* dashes=0);
   virtual void color(Fl_Color c);
@@ -472,6 +475,7 @@ protected:
   virtual void arc_unscaled(int x, int y, int w, int h, double a1, double a2);
   void pie(int x, int y, int w, int h, double a1, double a2) FL_OVERRIDE;
   virtual void pie_unscaled(int x, int y, int w, int h, double a1, double a2);
+  void draw_circle(int x, int y, int d, Fl_Color c) FL_OVERRIDE;
   void line_style(int style, int width=0, char* dashes=0) FL_OVERRIDE;
   virtual void line_style_unscaled(int style, int width, char* dashes);
   void draw_image_rescale(void *buf, Fl_Draw_Image_Cb cb, int X, int Y, int W, int H, int D, int L, bool mono);

--- a/FL/fl_draw.H
+++ b/FL/fl_draw.H
@@ -980,7 +980,7 @@ void fl_draw_check(Fl_Rect bb, Fl_Color col);
 FL_EXPORT void fl_draw_arrow(Fl_Rect bb, Fl_Arrow_Type t, Fl_Orientation o, Fl_Color color);
 
 // Draw a potentially small, filled circle
-FL_EXPORT void fl_draw_circle(int x0, int y0, int d, Fl_Color color);
+FL_EXPORT void fl_draw_circle(int x, int y, int d, Fl_Color color);
 
 // images:
 

--- a/src/Fl_Graphics_Driver.cxx
+++ b/src/Fl_Graphics_Driver.cxx
@@ -600,6 +600,14 @@ void Fl_Graphics_Driver::arc(int x, int y, int w, int h, double a1, double a2) {
 /** see fl_pie() */
 void Fl_Graphics_Driver::pie(int x, int y, int w, int h, double a1, double a2) {}
 
+/** see fl_draw_circle() */
+void Fl_Graphics_Driver::draw_circle(int x, int y, int d, Fl_Color c) {
+  Fl_Color current_c = color();
+  if (c != current_c) color(c);
+  pie(x, y, d, d, 0., 360.);
+  if (c != current_c) color(current_c);
+}
+
 /** see fl_line_style() */
 void Fl_Graphics_Driver::line_style(int style, int width, char* dashes) {}
 
@@ -931,6 +939,45 @@ void Fl_Scalable_Graphics_Driver::pie(int x,int y,int w,int h,double a1,double a
   h = floor(y+h) - yy;
   pie_unscaled(xx, yy, w, h, a1, a2);
 }
+
+
+void Fl_Scalable_Graphics_Driver::draw_circle(int x0, int y0, int d, Fl_Color c) {
+  Fl_Color saved = color();
+  color(c);
+
+  // make circles nice on scaled display
+  float s = scale();
+  int scaled_d = (s > 1.0) ? (int)(d * s) : d;
+  
+  // draw the circle
+  switch (scaled_d) {
+      // Larger circles draw fine...
+    default:
+      pie(x0, y0, d, d, 0.0, 360.0);
+      break;
+      
+      // Small circles don't draw well on many systems...
+    case 6:
+      rectf(x0 + 2, y0, d - 4, d);
+      rectf(x0 + 1, y0 + 1, d - 2, d - 2);
+      rectf(x0, y0 + 2, d, d - 4);
+      break;
+      
+    case 5:
+    case 4:
+    case 3:
+      rectf(x0 + 1, y0, d - 2, d);
+      rectf(x0, y0 + 1, d, d - 2);
+      break;
+      
+    case 2:
+    case 1:
+      rectf(x0, y0, d, d);
+      break;
+  }
+  color(saved);
+}
+
 
 void Fl_Scalable_Graphics_Driver::line_style(int style, int width, char* dashes) {
   if (width == 0) line_width_ = int(scale() < 2 ? 0 : scale());

--- a/src/drivers/GDI/Fl_GDI_Graphics_Driver.H
+++ b/src/drivers/GDI/Fl_GDI_Graphics_Driver.H
@@ -209,6 +209,7 @@ public:
   void line_style(int style, int width, char* dashes) FL_OVERRIDE;
   void arc_unscaled(int x, int y, int w, int h, double a1, double a2) FL_OVERRIDE;
   void pie_unscaled(int x, int y, int w, int h, double a1, double a2) FL_OVERRIDE;
+  void draw_circle(int x, int y, int d, Fl_Color c) FL_OVERRIDE;
   void transformed_vertex(double xf, double yf) FL_OVERRIDE;
   void vertex(double x,double y) FL_OVERRIDE;
   void end_points() FL_OVERRIDE;

--- a/src/drivers/GDI/Fl_GDI_Graphics_Driver.cxx
+++ b/src/drivers/GDI/Fl_GDI_Graphics_Driver.cxx
@@ -48,10 +48,9 @@ int Fl_GDIplus_Graphics_Driver::antialias() {
   return active;
 }
 
-#endif
-
-
-#if USE_GDIPLUS
+void Fl_GDIplus_Graphics_Driver::draw_circle(int x, int y, int d, Fl_Color c) {
+  Fl_Graphics_Driver::draw_circle(x, y, d, c);
+}
 
 int Fl_GDIplus_Graphics_Driver::gdiplus_state_ = Fl_GDIplus_Graphics_Driver::STATE_CLOSED;
 ULONG_PTR Fl_GDIplus_Graphics_Driver::gdiplus_token_ = 0;

--- a/src/fl_draw.cxx
+++ b/src/fl_draw.cxx
@@ -592,67 +592,27 @@ void fl_draw_check(Fl_Rect bb, Fl_Color col) {
 } // fl_draw_check()
 
 /**
-  Draw a potentially small, filled circle as a GUI element.
+  Draw a potentially small, filled circle using a given color.
 
-  This method draws a filled circle, using fl_pie() if the given diameter
-  \p d is larger than 6 pixels after scaling with the current screen
-  scaling factor (i.e. "physical" pixels).
+  This function draws using \p color a filled circle bounded by rectangle <tt>(x, y, d, d)</tt>.
+ 
+  This function is the same as <tt>fl_pie(x, y, d, d, 0, 360)</tt> except with some systems
+  that don't draw small circles well. In that situation, the circle diameter \p d is converted
+  from FLTK units to pixels and this function approximates a filled circle by drawing several
+  filled rectangles if the converted diameter is ≤ 6 pixels.
 
-  If the diameter is 6 or smaller after scaling it approximates a filled circle
-  by drawing several filled rectangles, depending on the size because fl_pie()
-  might not draw well on many systems for smaller sizes.
-
-  \param[in]  x0,y0   coordinates of top left of the bounding box
-  \param[in]  d       diameter == width and height of the bounding box
-  \param[in]  color   drawing color
+  \param[in]  x,y      coordinates of top left of the bounding box
+  \param[in]  d           diameter == width and height of the bounding box in FLTK units
+  \param[in]  color  drawing color
 
   \since 1.4.0
-*/
-void fl_draw_circle(int x0, int y0, int d, Fl_Color color) {
-
+ */
+void fl_draw_circle(int x, int y, int d, Fl_Color color) {
 #define DEBUG_DRAW_CIRCLE (0) // bit 1 = draw bounding box (green)
-
-  Fl_Color saved_color = fl_color();
-
 #if (DEBUG_DRAW_CIRCLE & 1)
+  Fl_Color current = fl_color();
   fl_rectf(x0, y0, d, d, FL_GREEN);
+  fl_color(current);
 #endif
-
-  // make circles nice on scaled display
-  // note: we should scale the value up even more for hidpi displays like Apple's Retina
-  float scale = fl_graphics_driver->scale();
-  int scaled_d = (scale > 1.0) ? int(d * scale) : d;
-
-  // draw the circle
-
-  fl_color(color);
-
-  switch (scaled_d) {
-    // Larger circles draw fine...
-    default:
-      fl_pie(x0, y0, d, d, 0.0, 360.0);
-      break;
-
-    // Small circles don't draw well on many systems...
-    case 6:
-      fl_rectf(x0 + 2, y0, d - 4, d);
-      fl_rectf(x0 + 1, y0 + 1, d - 2, d - 2);
-      fl_rectf(x0, y0 + 2, d, d - 4);
-      break;
-
-    case 5:
-    case 4:
-    case 3:
-      fl_rectf(x0 + 1, y0, d - 2, d);
-      fl_rectf(x0, y0 + 1, d, d - 2);
-      break;
-
-    case 2:
-    case 1:
-      fl_rectf(x0, y0, d, d);
-      break;
-  }
-
-  fl_color(saved_color);
-
-} // fl_draw_circle()
+  fl_graphics_driver->draw_circle(x, y, d, color);
+}


### PR DESCRIPTION
I propose to limit the cases when function `fl_draw_circle()` replaces `fl_pie()` by small rectangles to platforms where it is necessary. Platforms that use modern drawing APIs such as Cairo, Quartz and PostScript don't need small circles to be emulated by small rectangles. The new graphics API FLTK uses under Windows, GDI+, doesn't need it either. Only X11 and GDI do. The introduction of a new virtual member function to class `Fl_Graphics_Driver`, called `small_circle()`, allows to implement that. It also removes the unsolved problem mentionned in the source code of `fl_draw_circle()` of supporting HighDPI screens such as retina displays.