### PR TITLE
Have libdecor-gtk implement the "GTK Shell" protocol

### DIFF
--- a/libdecor/build/Makefile
+++ b/libdecor/build/Makefile
@@ -18,7 +18,7 @@ include ../../makeinclude
 
 OBJECTS =  fl_libdecor.o libdecor-cairo-blur.o fl_libdecor-plugins.o \
   ../../src/xdg-decoration-protocol.o ../../src/xdg-shell-protocol.o \
-  ../../src/text-input-protocol.o cursor-settings.o os-compatibility.o
+  ../../src/text-input-protocol.o ../../src/gtk-shell-protocol.o cursor-settings.o os-compatibility.o
 
 PROTOCOLS = `pkg-config --variable=pkgdatadir wayland-protocols`
 
@@ -38,7 +38,7 @@ all : $(OBJECTS)
 depend:
 	: echo "libdecor/build: make depend..."
 
-fl_libdecor.o : fl_libdecor.c ../src/libdecor.c ../../src/xdg-shell-protocol.c ../../src/xdg-decoration-protocol.c ../../src/text-input-protocol.c
+fl_libdecor.o : fl_libdecor.c ../src/libdecor.c ../../src/xdg-shell-protocol.c ../../src/xdg-decoration-protocol.c ../../src/text-input-protocol.c ../../src/gtk-shell-protocol.c
 	$(CC) $(CFLAGS) $(CFLAGS_DECOR) -c  fl_libdecor.c -DLIBDECOR_PLUGIN_API_VERSION=1 -DLIBDECOR_PLUGIN_DIR=\"\"
 
 fl_libdecor-plugins.o : fl_libdecor-plugins.c ../src/plugins/cairo/libdecor-cairo.c
@@ -75,10 +75,16 @@ cursor-settings.o : ../src/cursor-settings.c
 	    $(PROTOCOLS)/unstable/text-input/text-input-unstable-v3.xml \
 	    ../../src/text-input-client-protocol.h
 
+../../src/gtk-shell-protocol.c :
+	wayland-scanner private-code \
+	    gtk-shell.xml ../../src/gtk-shell-protocol.c
+	wayland-scanner client-header \
+	    gtk-shell.xml ../../src/gtk-shell-client-protocol.h
+
 install:
 	echo "Nothing to install"
 
 uninstall:
 
 clean:
-	$(RM) *.o ../../src/xdg-*.c ../../src/xdg-*.h ../../src/xdg-*.o ../../src/text-input-*
+	$(RM) *.o ../../src/xdg-*.c ../../src/xdg-*.h ../../src/xdg-*.o ../../src/text-input-* ../../src/gtk-shell-*

--- a/libdecor/build/gtk-shell.xml
+++ b/libdecor/build/gtk-shell.xml
@@ -1,0 +1,109 @@
+<!-- found at: https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gdk/wayland/protocol/gtk-shell.xml -->
+<protocol name="gtk">
+
+  <interface name="gtk_shell1" version="5">
+    <description summary="gtk specific extensions">
+      gtk_shell is a protocol extension providing additional features for
+      clients implementing it.
+    </description>
+
+    <enum name="capability">
+      <entry name="global_app_menu" value="1"/>
+      <entry name="global_menu_bar" value="2"/>
+      <entry name="desktop_icons" value="3"/>
+    </enum>
+
+    <event name="capabilities">
+      <arg name="capabilities" type="uint"/>
+    </event>
+
+    <request name="get_gtk_surface">
+      <arg name="gtk_surface" type="new_id" interface="gtk_surface1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+
+    <request name="set_startup_id">
+      <arg name="startup_id" type="string" allow-null="true"/>
+    </request>
+
+    <request name="system_bell">
+      <arg name="surface" type="object" interface="gtk_surface1" allow-null="true"/>
+    </request>
+
+    <!-- Version 3 additions -->
+    <request name="notify_launch" since="3">
+      <arg name="startup_id" type="string"/>
+    </request>
+  </interface>
+
+  <interface name="gtk_surface1" version="5">
+    <request name="set_dbus_properties">
+      <arg name="application_id" type="string" allow-null="true"/>
+      <arg name="app_menu_path" type="string" allow-null="true"/>
+      <arg name="menubar_path" type="string" allow-null="true"/>
+      <arg name="window_object_path" type="string" allow-null="true"/>
+      <arg name="application_object_path" type="string" allow-null="true"/>
+      <arg name="unique_bus_name" type="string" allow-null="true"/>
+    </request>
+
+    <request name="set_modal"/>
+    <request name="unset_modal"/>
+
+    <request name="present">
+      <arg name="time" type="uint"/>
+    </request>
+
+    <!-- Version 2 additions -->
+
+    <enum name="state">
+      <entry name="tiled" value="1"/>
+
+      <entry name="tiled_top" value="2" since="2" />
+      <entry name="tiled_right" value="3" since="2" />
+      <entry name="tiled_bottom" value="4" since="2" />
+      <entry name="tiled_left" value="5"  since="2" />
+    </enum>
+
+    <enum name="edge_constraint" since="2">
+      <entry name="resizable_top" value="1"/>
+      <entry name="resizable_right" value="2"/>
+      <entry name="resizable_bottom" value="3"/>
+      <entry name="resizable_left" value="4"/>
+    </enum>
+
+    <event name="configure">
+      <arg name="states" type="array"/>
+    </event>
+
+    <event name="configure_edges" since="2">
+      <arg name="constraints" type="array"/>
+    </event>
+
+    <!-- Version 3 additions -->
+    <request name="request_focus" since="3">
+      <arg name="startup_id" type="string" allow-null="true"/>
+    </request>
+
+    <!-- Version 4 additions -->
+    <request name="release" type="destructor" since="4"/>
+
+    <!-- Version 5 additions -->
+    <enum name="gesture" since="5">
+      <entry name="double_click" value="1"/>
+      <entry name="right_click" value="2"/>
+      <entry name="middle_click" value="3"/>
+    </enum>
+
+    <enum name="error" since="5">
+      <entry name="invalid_gesture" value="0"/>
+    </enum>
+
+    <request name="titlebar_gesture" since="5">
+      <arg name="serial" type="uint"/>
+      <arg name="seat" type="object" interface="wl_seat"/>
+      <arg name="gesture" type="uint" enum="gesture"/>
+    </request>
+  </interface>
+
+</protocol>
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -688,6 +688,17 @@ if (UNIX AND OPTION_USE_WAYLAND)
     )
     list (APPEND STATIC_FILES "xdg-decoration-protocol.c")
     list (APPEND SHARED_FILES "xdg-decoration-protocol.c")
+    if (GTK_FOUND AND OPTION_ALLOW_GTK_PLUGIN)
+      add_custom_command(
+        OUTPUT gtk-shell-protocol.c gtk-shell-client-protocol.h
+        COMMAND wayland-scanner private-code ${CMAKE_CURRENT_SOURCE_DIR}/../libdecor/build/gtk-shell.xml gtk-shell-protocol.c
+        COMMAND wayland-scanner client-header ${CMAKE_CURRENT_SOURCE_DIR}/../libdecor/build/gtk-shell.xml gtk-shell-client-protocol.h
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../libdecor/build/gtk-shell.xml
+        VERBATIM
+      )
+      list (APPEND STATIC_FILES "gtk-shell-protocol.c")
+      list (APPEND SHARED_FILES "gtk-shell-protocol.c")
+    endif (GTK_FOUND AND OPTION_ALLOW_GTK_PLUGIN)
   endif (NOT OPTION_USE_SYSTEM_LIBDECOR)
   add_custom_command(
     OUTPUT text-input-protocol.c text-input-client-protocol.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -424,6 +424,7 @@ CFILES_WAYLANDX11 = $(WLCFILES)
 EXTRA_OBJECTS_WAYLAND =  ../libdecor/build/fl_libdecor.o ../libdecor/build/libdecor-cairo-blur.o \
   ../libdecor/build/fl_libdecor-plugins.o \
   xdg-decoration-protocol.o xdg-shell-protocol.o text-input-protocol.o \
+  gtk-shell-protocol.o \
   ../libdecor/build/cursor-settings.o ../libdecor/build/os-compatibility.o
 EXTRA_OBJECTS_WAYLANDX11 = $(EXTRA_OBJECTS_WAYLAND)
 EXTRA_CXXFLAGS_WAYLAND = -I.

--- a/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
+++ b/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
@@ -46,6 +46,7 @@
 #include <string.h> // for strerror()
 extern "C" {
   bool libdecor_get_cursor_settings(char **theme, int *size);
+  void bind_to_gtk_shell(struct wl_registry *, uint32_t);
 }
 
 
@@ -1146,6 +1147,9 @@ static void registry_handle_global(void *user_data, struct wl_registry *wl_regis
   } else if (strcmp(interface, "gtk_shell1") == 0) {
     Fl_Wayland_Screen_Driver::compositor = Fl_Wayland_Screen_Driver::MUTTER;
     //fprintf(stderr, "Running the Mutter compositor\n");
+    if ( version >= 5) {
+      bind_to_gtk_shell(wl_registry, id);
+    }
   } else if (strcmp(interface, "weston_desktop_shell") == 0) {
     Fl_Wayland_Screen_Driver::compositor = Fl_Wayland_Screen_Driver::WESTON;
     //fprintf(stderr, "Running the Weston compositor\n");

--- a/src/drivers/Wayland/Fl_Wayland_Window_Driver.cxx
+++ b/src/drivers/Wayland/Fl_Wayland_Window_Driver.cxx
@@ -45,6 +45,7 @@ struct cursor_image { // as in wayland-cursor.c of the Wayland project source co
 extern "C" {
 # include "../../../libdecor/src/libdecor-plugin.h"
   uchar *fl_libdecor_titlebar_buffer(struct libdecor_frame *frame, int *w, int *h, int *stride);
+  void use_FLTK_pointer_button(struct libdecor_frame *);
 }
 
 #define fl_max(a,b) ((a) > (b) ? (a) : (b))
@@ -853,7 +854,7 @@ static void handle_configure(struct libdecor_frame *frame,
 #ifdef LIBDECOR_MR131
   if (is_1st_run) use_FLTK_toplevel_configure_cb(frame);
 #endif
-
+  use_FLTK_pointer_button(frame);
   struct wl_output *wl_output = NULL;
   if (window->fl_win->fullscreen_active()) {
     if (!(window->state & LIBDECOR_WINDOW_STATE_FULLSCREEN)) {


### PR DESCRIPTION
The "GTK Shell" protocol is an external Wayland protocol implemented only by the Mutter compositor. It allows FLTK Wayland windows to behave like GTK windows as far as the "Titlebar Actions" section of the `gnome-tweaks` application is concerned. Any of these actions
<img width="215" alt="image" src="https://github.com/fltk/fltk/assets/41016272/8314874f-fbd6-4c54-99be-9ca60b880d1b">
except "Toggle Shade", can be assigned to middle click, right click or double click on the titlebar.

This commit has no effect with Wayland compositors other than Mutter. 