### PR TITLE
Documentation: Improve doc comment for ~Fl_Group()

### DIFF
--- a/src/Fl_Group.cxx
+++ b/src/Fl_Group.cxx
@@ -438,8 +438,8 @@ void Fl_Group::clear() {
 
   If you add static or automatic (local) variables to an Fl_Group, then it
   is your responsibility to remove (or delete) all such static or automatic
-  child widgets \e \b before destroying the group - otherwise the child
-  widgets' destructors would be called twice!
+  child widgets \e \b before destroying the group - otherwise the group will
+  attempt to call delete operator on them leading to undefined behavior!
 */
 Fl_Group::~Fl_Group() {
   if (current_ == this)


### PR DESCRIPTION
Currently docs for ~Fl_Group() say:

> If you add static or automatic (local) variables to an [Fl_Group](https://www.fltk.org/doc-1.4/classFl__Group.html), then it is your responsibility to remove (or delete) all such static or automatic child widgets before destroying the group - **otherwise the child widgets' destructors would be called twice!**

I'm not sure what it means. It's not accurate and it's not true (?)

I propose to rephrase it so that the docs say exactly what will happen:

> [...] otherwise the group will attempt to call delete operator on them leading to undefined behavior!
