### PR TITLE
Fix fluid target added twice when crosscompiling

### DIFF
--- a/CMake/FLTKConfig.cmake.in
+++ b/CMake/FLTKConfig.cmake.in
@@ -38,7 +38,9 @@ if (CMAKE_CROSSCOMPILING)
     PATHS ENV PATH
     NO_CMAKE_FIND_ROOT_PATH
   )
-  add_executable(fluid IMPORTED)
+  if(NOT TARGET fluid)
+    add_executable(fluid IMPORTED)
+  endif()
   set_target_properties(fluid
     PROPERTIES IMPORTED_LOCATION ${FLUID_PATH}
   )


### PR DESCRIPTION
When `CMAKE_CROSSCOMPILING` is true, `fluid` will be added twice by `add_executable,` it will cause the following error:
```
  _add_executable cannot create imported target "fluid" because another
  target with the same name already exists.
```
The following codes are from `FLTK-Targets.cmake` which is generated by `CMake`:
Line 58:
```
# Create imported target fluid
add_executable(fluid IMPORTED)
```