### PR TITLE
make FLTK_SCALING_FACTOR override the auto-detected value

### DIFF
--- a/src/Fl_Screen_Driver.cxx
+++ b/src/Fl_Screen_Driver.cxx
@@ -547,11 +547,12 @@ void Fl_Screen_Driver::use_startup_scale_factor()
 {
   char *p;
   int s_count = screen_count();
-  desktop_scale_factor();
   if ((p = fl_getenv("FLTK_SCALING_FACTOR"))) {
     float factor = 1;
     sscanf(p, "%f", &factor);
-    for (int i = 0; i < s_count; i++)  scale(i, factor * scale(i));
+    for (int i = 0; i < s_count; i++)  scale(i, factor);
+  } else {
+    desktop_scale_factor();
   }
 }
 

--- a/src/Fl_x.cxx
+++ b/src/Fl_x.cxx
@@ -1254,10 +1254,10 @@ int fl_handle(const XEvent& thisevent)
     d->init_workarea();
 #if USE_XFT
     float old_scales[Fl::screen_count()];
-    for (auto i = 0; i < Fl::screen_count(); i++) old_scales[i] = d->scale(i);
+    for (int i = 0; i < Fl::screen_count(); i++) old_scales[i] = d->scale(i);
     d->use_startup_scale_factor();
-    for (auto i = 0; i < Fl::screen_count(); i++) {
-      auto new_scale = d->scale(i);
+    for (int i = 0; i < Fl::screen_count(); i++) {
+      float new_scale = d->scale(i);
       if (old_scales[i] - new_scale < 0.01) continue;
       d->scale(i, old_scales[i]);
       d->rescale_all_windows_from_screen(i, new_scale);

--- a/src/Fl_x.cxx
+++ b/src/Fl_x.cxx
@@ -38,6 +38,7 @@
 #  include <FL/filename.H>
 #  include <stdio.h>
 #  include <stdlib.h>
+#  include <cmath>
 #  include "flstring.h"
 #  include "drivers/X11/Fl_X11_Screen_Driver.H"
 #  include "drivers/X11/Fl_X11_Window_Driver.H"
@@ -1258,7 +1259,7 @@ int fl_handle(const XEvent& thisevent)
     d->use_startup_scale_factor();
     for (int i = 0; i < Fl::screen_count(); i++) {
       float new_scale = d->scale(i);
-      if (old_scales[i] - new_scale < 0.01) continue;
+      if (fabs(old_scales[i] - new_scale) < 0.01) continue;
       d->scale(i, old_scales[i]);
       d->rescale_all_windows_from_screen(i, new_scale);
     }


### PR DESCRIPTION
Currently, FLTK_SCALING_FACTOR doesn't override the existing scaling factor detected from xrdb. This patch fixes that. If the environment variable is detected, it'll override the scaling factor.