### PR TITLE
Fix Terminal character position and interactive selection

### DIFF
--- a/FL/Fl_Terminal.H
+++ b/FL/Fl_Terminal.H
@@ -658,30 +658,34 @@ private:
   // Class to manage mouse selection
   //
   class FL_EXPORT Selection {
+    Fl_Terminal *terminal_;
     int srow_, scol_, erow_, ecol_;     // selection start/end. NOTE: start *might* be > end
     int push_row_, push_col_;           // global row/col for last FL_PUSH
+    bool push_char_right_;
     Fl_Color selectionbgcolor_;
     Fl_Color selectionfgcolor_;
     int state_ ;                        // 0=none, 1=started, 2=extended, 3=done
     bool is_selection_;                 // false: no selection
   public:
-    Selection(void);
+    Selection(Fl_Terminal *terminal);
     int srow(void) const { return srow_; }
     int scol(void) const { return scol_; }
     int erow(void) const { return erow_; }
     int ecol(void) const { return ecol_; }
-    void push_clear() { push_row_ = push_col_ = -1; }
-    void push_rowcol(int row,int col) { push_row_ = row; push_col_ = col; }
-    void start_push() { start(push_row_, push_col_); }
-    bool dragged_off(int row,int col) { return (push_row_ != row) || (push_col_ != col); }
+    void push_clear() { push_row_ = push_col_ = -1; push_char_right_ = false; }
+    void push_rowcol(int row,int col,bool char_right) {
+      push_row_ = row; push_col_ = col; push_char_right_ = char_right; }
+    void start_push() { start(push_row_, push_col_, push_char_right_); }
+    bool dragged_off(int row,int col,bool char_right) {
+      return (push_row_ != row) || (push_col_+push_char_right_ != col+char_right); }
     void selectionfgcolor(Fl_Color val) { selectionfgcolor_ = val; }
     void selectionbgcolor(Fl_Color val) { selectionbgcolor_ = val; }
     Fl_Color selectionfgcolor(void) const { return selectionfgcolor_; }
     Fl_Color selectionbgcolor(void) const { return selectionbgcolor_; }
     bool is_selection(void) const { return is_selection_; }
     bool get_selection(int &srow,int &scol,int &erow,int &ecol) const; // guarantees return (start < end)
-    bool start(int row, int col);
-    bool extend(int row, int col);
+    bool start(int row, int col, bool char_right);
+    bool extend(int row, int col, bool char_right);
     void end(void);
     void select(int srow, int scol, int erow, int ecol);
     bool clear(void);
@@ -871,8 +875,8 @@ protected:
   const CharStyle& current_style(void) const;
   void current_style(const CharStyle& sty);
 private:
-  int  x_to_glob_col(int X, int grow, int &gcol) const;
-  int  xy_to_glob_rowcol(int X, int Y, int &grow, int &gcol) const;
+  int  x_to_glob_col(int X, int grow, int &gcol, bool &gcr) const;
+  int  xy_to_glob_rowcol(int X, int Y, int &grow, int &gcol, bool &gcr) const;
 protected:
   int  w_to_col(int W) const;
   int  h_to_row(int H) const;

--- a/FL/Fl_Terminal.H
+++ b/FL/Fl_Terminal.H
@@ -899,6 +899,8 @@ protected:
   const char* selection_text(void) const;
   void clear_mouse_selection(void);
   bool selection_extend(int X,int Y);
+  void select_word(int grow, int gcol);
+  void select_line(int grow);
   void scroll(int rows);
   void insert_rows(int count);
   void delete_rows(int count);

--- a/src/Fl_Terminal.cxx
+++ b/src/Fl_Terminal.cxx
@@ -2083,7 +2083,7 @@ bool Fl_Terminal::selection_extend(int X,int Y) {
 }
 
 /**
- Select the word around the given row and colum.
+ Select the word around the given row and column.
  */
 void Fl_Terminal::select_word(int grow, int gcol) {
   int i, c0, c1;
@@ -3636,7 +3636,7 @@ int Fl_Terminal::handle_selection(int e) {
       } else {                                          // Start a new selection
         select_.push_rowcol(grow, gcol, gcr);
         if (select_.clear()) redraw();                  // clear prev selection
-        if (is_rowcol > 0) {
+        if (is_rowcol) {
           switch (Fl::event_clicks()) {
             case 1: select_word(grow, gcol); break;
             case 2: select_line(grow); break;

--- a/src/Fl_Terminal.cxx
+++ b/src/Fl_Terminal.cxx
@@ -3584,16 +3584,17 @@ int Fl_Terminal::handle_selection(int e) {
                    ? true : false;
   switch (e) {
     case FL_PUSH: {
-      select_.push_rowcol(grow, gcol, gcr);
       // SHIFT-LEFT-CLICK? Extend or start new
       if (Fl::event_state(FL_SHIFT)) {
         if (is_selection()) {                           // extend if select in progress
           selection_extend(Fl::event_x(), Fl::event_y());
+          redraw();
           return 1;                                     // express interest in FL_DRAG
         }
       } else {                                          // Start a new selection
+        select_.push_rowcol(grow, gcol, gcr);
         if (select_.clear()) redraw();                  // clear prev selection
-        if (is_rowcol) return 1;                        // express interest in FL_DRAG
+        if (is_rowcol > 0) return 1;                    // express interest in FL_DRAG
       }
       // Left-Click outside terminal area?
       if (!Fl::event_state(FL_SHIFT)) {
@@ -3618,7 +3619,6 @@ int Fl_Terminal::handle_selection(int e) {
       return 1;
     }
     case FL_RELEASE: {
-      select_.push_clear();
       select_.end();
       // middlemouse gets immediate copy of selection
       if (is_selection()) {

--- a/src/Fl_Terminal.cxx
+++ b/src/Fl_Terminal.cxx
@@ -3564,11 +3564,7 @@ void Fl_Terminal::draw(void) {
   This is used by the constructor to size the row/cols to fit the widget size.
 */
 int Fl_Terminal::w_to_col(int W) const {
-#if 0
-  return int((float(W) / current_style_->charwidth()) + 0.0);    // +.5 overshoots
-#else
   return W / current_style_->charwidth();
-#endif
 }
 
 /**
@@ -3576,11 +3572,7 @@ int Fl_Terminal::w_to_col(int W) const {
   This is used by the constructor to size the row/cols to fit the widget size.
 */
 int Fl_Terminal::h_to_row(int H) const {
-#if 0
-  return int((float(H) / current_style_->fontheight()) + -0.0);  // +.5 overshoots
-#else
   return H / current_style_->fontheight();
-#endif
 }
 
 /**

--- a/src/Fl_Terminal.cxx
+++ b/src/Fl_Terminal.cxx
@@ -3447,8 +3447,11 @@ void Fl_Terminal::draw_row(int grow, int Y) const {
   int  disp_top = (disp_srow() - scrollval);              // top row we need to view
   int  drow = grow - disp_top;                            // disp row
   bool inside_display = is_disp_ring_row(grow);           // row inside 'display'?
-  int  strikeout_y = baseline - (current_style_->fontheight() / 4);
-  int  underline_y = baseline + (current_style_->fontheight() / 5);
+// This looks better on macOS, but too low for X. Maybe we can get better results using fl_text_extents()?
+//  int  strikeout_y = baseline - (current_style_->fontheight() / 4);
+//  int  underline_y = baseline + (current_style_->fontheight() / 5);
+  int  strikeout_y = baseline - (current_style_->fontheight() / 3);
+  int  underline_y = baseline;
   const Utf8Char *u8c = u8c_ring_row(grow);
   uchar lastattr = -1;
   bool  is_cursor;


### PR DESCRIPTION
This patch fixes the vertical character position, so that characters are rendered starting in the top left corner. The current code uses the character baseline and character Y position interchangeably, which offsets the selection box vertically. This can be tested by selecting text by clicking into the bottom half of a character, which selects the character one row too low.

This patch fixes the horizontal selection offset which did not take the frame width of the widget into account.

This patch adds code that expands character selection when the mouse crosses the middle of a character horizontally., not the left or right edge. This mimics Fl_Input and other common GUIs.

This patch adds code to select a word or a line on double or tripple click respectively. It's not perfect as it does not handle dragging after multi-clicks very well, but it's better than before. I may add the missing code later in another patch.

This patch fixes the "overshoot" in calculating the vertical number of rows depending on the window height because the vertical position is now more precise.