### PR TITLE
using xlib to query the new DPI (old #910)

### DIFF
--- a/src/Fl_x.cxx
+++ b/src/Fl_x.cxx
@@ -1215,24 +1215,15 @@ static void react_to_screen_reconfiguration() {
 
 #if USE_XFT
 static void after_display_rescale(float *p_current_xft_dpi) {
-  FILE *pipe = popen("xrdb -query", "r");
-  if (!pipe) return;
-  char line[100];
-  while (fgets(line, sizeof(line), pipe) != NULL) {
-    if (memcmp(line, "Xft.dpi:", 8)) continue;
-    float dpi;
-    if (sscanf(line+8, "%f", &dpi) == 1) {
-      //fprintf(stderr," previous=%g dpi=%g \n", *p_current_xft_dpi, dpi);
-      if (fabs(dpi - *p_current_xft_dpi) > 0.01) {
-        *p_current_xft_dpi = dpi;
-        float f = dpi/96.;
-        for (int i = 0; i < Fl::screen_count(); i++)
-          Fl::screen_driver()->rescale_all_windows_from_screen(i, f);
-      }
-    }
-    break;
+  float old_dpi = *p_current_xft_dpi;
+  *p_current_xft_dpi = 0.;
+  Fl::screen_driver()->desktop_scale_factor();
+
+  if (fabs(*p_current_xft_dpi - old_dpi) > 0.01) {
+    float s = *p_current_xft_dpi/96.;
+    for (int i = 0; i < Fl::screen_count(); i++)
+      Fl::screen_driver()->rescale_all_windows_from_screen(i, s);
   }
-  pclose(pipe);
 }
 #endif // USE_XFT
 

--- a/src/drivers/X11/Fl_X11_Screen_Driver.cxx
+++ b/src/drivers/X11/Fl_X11_Screen_Driver.cxx
@@ -429,7 +429,7 @@ extern void fl_fix_focus(); // in Fl.cxx
 void Fl_X11_Screen_Driver::grab(Fl_Window* win)
 {
   const char *p;
-  static bool using_kde = 
+  static bool using_kde =
     ( p = getenv("XDG_CURRENT_DESKTOP") , (p && (strcmp(p, "KDE") == 0)) );
   Fl_Window *fullscreen_win = NULL;
   for (Fl_Window *W = Fl::first_window(); W; W = Fl::next_window(W)) {
@@ -1369,7 +1369,9 @@ static void* value_of_key_in_schema(const char **known, const char *schema, cons
 void Fl_X11_Screen_Driver::desktop_scale_factor()
 {
   if (this->current_xft_dpi == 0.) { // Try getting the Xft.dpi resource value
-    char *s = XGetDefault(fl_display, "Xft", "dpi");
+    // Always get the up to date value
+    Display *new_dpy = XOpenDisplay(0);
+    char *s = XGetDefault(new_dpy, "Xft", "dpi");
     if (s && sscanf(s, "%f", &(this->current_xft_dpi)) == 1) {
       float factor = this->current_xft_dpi / 96.;
       // checks to prevent potential crash (factor <= 0) or very large factors
@@ -1377,6 +1379,7 @@ void Fl_X11_Screen_Driver::desktop_scale_factor()
       else if (factor > 10.0) factor = 10.0;
       for (int i = 0; i < screen_count(); i++)  scale(i, factor);
     }
+    XCloseDisplay(new_dpy);
   }
 }
 

--- a/src/drivers/X11/Fl_X11_Screen_Driver.cxx
+++ b/src/drivers/X11/Fl_X11_Screen_Driver.cxx
@@ -1370,7 +1370,7 @@ void Fl_X11_Screen_Driver::desktop_scale_factor()
 {
   if (this->current_xft_dpi == 0.) { // Try getting the Xft.dpi resource value
     // Always get the up to date value
-    Display *new_dpy = XOpenDisplay(0);
+    Display *new_dpy = XOpenDisplay(XDisplayString(fl_display));
     char *s = XGetDefault(new_dpy, "Xft", "dpi");
     if (s && sscanf(s, "%f", &(this->current_xft_dpi)) == 1) {
       float factor = this->current_xft_dpi / 96.;


### PR DESCRIPTION
Always open up a new display when current DPI isn't available.

In the main loop, we reuse desktop_scale_factor() function.

This PR now makes sure we open the same display as `fl_display`.