### PR TITLE
Fix two mis-use of cairo

### DIFF
--- a/src/Fl_x.cxx
+++ b/src/Fl_x.cxx
@@ -1215,24 +1215,15 @@ static void react_to_screen_reconfiguration() {
 
 #if USE_XFT
 static void after_display_rescale(float *p_current_xft_dpi) {
-  FILE *pipe = popen("xrdb -query", "r");
-  if (!pipe) return;
-  char line[100];
-  while (fgets(line, sizeof(line), pipe) != NULL) {
-    if (memcmp(line, "Xft.dpi:", 8)) continue;
-    float dpi;
-    if (sscanf(line+8, "%f", &dpi) == 1) {
-      //fprintf(stderr," previous=%g dpi=%g \n", *p_current_xft_dpi, dpi);
-      if (fabs(dpi - *p_current_xft_dpi) > 0.01) {
-        *p_current_xft_dpi = dpi;
-        float f = dpi/96.;
-        for (int i = 0; i < Fl::screen_count(); i++)
-          Fl::screen_driver()->rescale_all_windows_from_screen(i, f);
-      }
-    }
-    break;
+  float old_dpi = *p_current_xft_dpi;
+  *p_current_xft_dpi = 0.;
+  Fl::screen_driver()->desktop_scale_factor();
+
+  if (fabs(*p_current_xft_dpi - old_dpi) > 0.01) {
+    float s = *p_current_xft_dpi/96.;
+    for (int i = 0; i < Fl::screen_count(); i++)
+      Fl::screen_driver()->rescale_all_windows_from_screen(i, s);
   }
-  pclose(pipe);
 }
 #endif // USE_XFT
 

--- a/src/drivers/Cairo/Fl_Cairo_Graphics_Driver.cxx
+++ b/src/drivers/Cairo/Fl_Cairo_Graphics_Driver.cxx
@@ -127,6 +127,7 @@ void Fl_Cairo_Graphics_Driver::set_cairo(cairo_t *cr, float s) {
     dummy_cairo_ = NULL;
  }
   cairo_ = cr;
+  if (cr == NULL) return;
   cairo_restore(cairo_);
   line_style(0);
   cairo_save(cairo_);

--- a/src/drivers/X11/Fl_X11_Screen_Driver.cxx
+++ b/src/drivers/X11/Fl_X11_Screen_Driver.cxx
@@ -429,7 +429,7 @@ extern void fl_fix_focus(); // in Fl.cxx
 void Fl_X11_Screen_Driver::grab(Fl_Window* win)
 {
   const char *p;
-  static bool using_kde = 
+  static bool using_kde =
     ( p = getenv("XDG_CURRENT_DESKTOP") , (p && (strcmp(p, "KDE") == 0)) );
   Fl_Window *fullscreen_win = NULL;
   for (Fl_Window *W = Fl::first_window(); W; W = Fl::next_window(W)) {
@@ -1369,7 +1369,9 @@ static void* value_of_key_in_schema(const char **known, const char *schema, cons
 void Fl_X11_Screen_Driver::desktop_scale_factor()
 {
   if (this->current_xft_dpi == 0.) { // Try getting the Xft.dpi resource value
-    char *s = XGetDefault(fl_display, "Xft", "dpi");
+    // Always get the up to date value
+    Display *new_dpy = XOpenDisplay(0);
+    char *s = XGetDefault(new_dpy, "Xft", "dpi");
     if (s && sscanf(s, "%f", &(this->current_xft_dpi)) == 1) {
       float factor = this->current_xft_dpi / 96.;
       // checks to prevent potential crash (factor <= 0) or very large factors
@@ -1377,6 +1379,7 @@ void Fl_X11_Screen_Driver::desktop_scale_factor()
       else if (factor > 10.0) factor = 10.0;
       for (int i = 0; i < screen_count(); i++)  scale(i, factor);
     }
+    XCloseDisplay(new_dpy);
   }
 }
 

--- a/src/drivers/X11/Fl_X11_Screen_Driver.cxx
+++ b/src/drivers/X11/Fl_X11_Screen_Driver.cxx
@@ -1370,7 +1370,7 @@ void Fl_X11_Screen_Driver::desktop_scale_factor()
 {
   if (this->current_xft_dpi == 0.) { // Try getting the Xft.dpi resource value
     // Always get the up to date value
-    Display *new_dpy = XOpenDisplay(0);
+    Display *new_dpy = XOpenDisplay(XDisplayString(fl_display));
     char *s = XGetDefault(new_dpy, "Xft", "dpi");
     if (s && sscanf(s, "%f", &(this->current_xft_dpi)) == 1) {
       float factor = this->current_xft_dpi / 96.;

--- a/src/drivers/X11/Fl_X11_Window_Driver.H
+++ b/src/drivers/X11/Fl_X11_Window_Driver.H
@@ -101,6 +101,7 @@ public:
   // --- window management
   void makeWindow() FL_OVERRIDE;
   void take_focus() FL_OVERRIDE;
+  void flush() FL_OVERRIDE;
   void flush_double() FL_OVERRIDE;
   void flush_overlay() FL_OVERRIDE;
   void draw_begin() FL_OVERRIDE;

--- a/src/drivers/X11/Fl_X11_Window_Driver.cxx
+++ b/src/drivers/X11/Fl_X11_Window_Driver.cxx
@@ -450,6 +450,12 @@ void Fl_X11_Window_Driver::hide() {
   delete ip;
 }
 
+void Fl_X11_Window_Driver::flush() {
+  Fl_Window_Driver::flush();
+  if (cairo_)
+    cairo_surface_flush(cairo_get_target(cairo_));
+}
+
 
 void Fl_X11_Window_Driver::map() {
   XMapWindow(fl_display, fl_xid(pWindow)); // extra map calls are harmless


### PR DESCRIPTION
The first patch fixes a use-after-free of cairo context, which can cause clipping fails.

The second patch makes sure we call `cairo_surface_flush()`, which is required by cairo. Although currently, it does not seem to affect anything, but in the future, this might change.