### PR TITLE
Fix Fl_Terminal::handle_unknown_char()

### DIFF
--- a/FL/Fl_Terminal.H
+++ b/FL/Fl_Terminal.H
@@ -1027,6 +1027,7 @@ public:
   void append(const char *s, int len=-1);
 protected:
   int handle_unknown_char(void);
+  int handle_unknown_char(int drow, int dcol);
   // Drawing
   void draw_row_bg(int grow, int X, int Y) const;
   void draw_row(int grow, int Y) const;
@@ -1170,6 +1171,9 @@ public:
   // API: Show unknown/unprintable chars
   bool  show_unknown(void) const;
   void  show_unknown(bool val);
+protected:
+  static const char *unknown_char; ///< "unknown" replacement character
+public:
   // API: ANSI sequences
   bool  ansi(void) const;
   void  ansi(bool val);


### PR DESCRIPTION
I'm opening this PR for myself and for review by @erco77. I intend to push this myself with necessary modifications after review, e.g. remove the mods of the demo program, and see question below.

**_Problem:_** see screenshot and details below:
![Fl_Terminal_unknown](https://github.com/fltk/fltk/assets/26235500/bfb70cff-f950-4bc1-8d1b-8b8f0604d9b2)

The red marks show what's wrong, the green mark shows the same after the patch (correct).

The old code called `Fl_Terminal::handle_unknown_char()` when `Fl_Terminal::plot_char()` encountered an illegal UTF-8 character which put the "unknown" char in the normal output stream rather than at the requested position (if `show_unknown()` was enabled). I fixed this issue in my patch by adding an overridden method with `(drow,dcol)` arguments:
```diff
   int handle_unknown_char(void);
+  int handle_unknown_char(int drow, int dcol);
```

I believe this approach is correct - so far (see screenshot).

The implementation is as follows:
```C++
int Fl_Terminal::handle_unknown_char(int drow, int dcol) {
  if (!show_unknown_) return 0;
#if (0)
  escseq.reset();               // disable any pending esc seq to prevent eating unknown char
#endif
  int len = (int)strlen(unknown_char);
  Utf8Char *u8c = u8c_disp_row(drow) + dcol;
  u8c->text_utf8(unknown_char, len, *current_style_);
  return 1;
}
```

@erco77 **_My question:_** do we need (want?) to call `escseq.reset();` here which is currently disabled in my patch?

The reason why I disabled it (as opposed to the "other" `handle_unknown_char()` method) is that `plot_char()` generates IMHO "out of band" data and should not interfere with the current output stream which may have left a partial escape sequence. However, this is debatable, and that's why I'm asking you, Greg. What do you think?

Thanks for reading and looking into it. If you agree I will remove the '#if (0) ... #endif' block entirely before rebasing and pushing.

Note 1: while I was at it I made related documentation changes, minor reformatting, and I added a protected static class variable `const char *Fl_Terminal::unknown_char = "¿";` (this is the initalization in the C++ file) - basically to avoid redundant code. In the future we might want to add public getter and setter methods so users can fine tune the "unknown character".

Note 2: this PR includes the modified demo program `test/handle_keys.cxx` which generates the above shown output. Run this with the old or new code...
