### PR TITLE
Solved: STR 2145: Fix box types and focus frames.

### DIFF
--- a/FL/Enumerations.H
+++ b/FL/Enumerations.H
@@ -591,12 +591,6 @@ enum Fl_Callback_Reason {
 
     This enum defines the standard box types included with FLTK.
 
-   \note The documented \p enum \p Fl_Boxtype contains some values (names)
-      with leading underscores, e.g. \p \b _FL_SHADOW_BOX. This is due to
-      technical reasons - please use the same values (names) without the
-      leading underscore in your code! Enum values with leading underscores
-      are reserved for internal use and subject to change without notice!
-
     FL_NO_BOX means nothing is drawn at all, so whatever is already
     on the screen remains. The FL_..._FRAME types only draw their edges,
     leaving the interior unchanged. The blue color in the image below
@@ -617,12 +611,6 @@ enum Fl_Callback_Reason {
     \brief FLTK standard box types
 
     This enum defines the standard box types included with FLTK.
-
-   \note The documented \p enum \p Fl_Boxtype contains some values (names)
-      with leading underscores, e.g. \p \b _FL_SHADOW_BOX. This is due to
-      technical reasons - please use the same values (names) without the
-      leading underscore in your code! Enum values with leading underscores
-      are reserved for internal use and subject to change without notice!
 */
 enum Fl_Boxtype { // boxtypes (if you change these you must also change fl_boxtype.cxx):
 
@@ -641,133 +629,62 @@ enum Fl_Boxtype { // boxtypes (if you change these you must also change fl_boxty
   FL_ENGRAVED_FRAME,            ///< see figure [Standard Box Types](@ref boxTypesImage)
   FL_EMBOSSED_FRAME,            ///< see figure [Standard Box Types](@ref boxTypesImage)
   FL_BORDER_BOX,                ///< see figure [Standard Box Types](@ref boxTypesImage)
-  _FL_SHADOW_BOX,               ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_SHADOW_BOX
+  FL_SHADOW_BOX,                ///< see figure [Standard Box Types](@ref boxTypesImage)
   FL_BORDER_FRAME,              ///< see figure [Standard Box Types](@ref boxTypesImage)
-  _FL_SHADOW_FRAME,             ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_SHADOW_FRAME
-  _FL_ROUNDED_BOX,              ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_ROUNDED_BOX
-  _FL_RSHADOW_BOX,              ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_RSHADOW_BOX
-  _FL_ROUNDED_FRAME,            ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_ROUNDED_FRAME
-  _FL_RFLAT_BOX,                ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_RFLAT_BOX
-  _FL_ROUND_UP_BOX,             ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_ROUND_UP_BOX
-  _FL_ROUND_DOWN_BOX,           ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_ROUND_DOWN_BOX
-  _FL_DIAMOND_UP_BOX,           ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_DIAMOND_UP_BOX
-  _FL_DIAMOND_DOWN_BOX,         ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_DIAMOND_DOWN_BOX
-  _FL_OVAL_BOX,                 ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_OVAL_BOX
-  _FL_OSHADOW_BOX,              ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_OSHADOW_BOX
-  _FL_OVAL_FRAME,               ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_OVAL_FRAME
-  _FL_OFLAT_BOX,                ///< see figure [Standard Box Types](@ref boxTypesImage), use FL_OFLAT_BOX
-  _FL_PLASTIC_UP_BOX,           ///< plastic version of FL_UP_BOX, use FL_PLASTIC_UP_BOX
-  _FL_PLASTIC_DOWN_BOX,         ///< plastic version of FL_DOWN_BOX, use FL_PLASTIC_DOWN_BOX
-  _FL_PLASTIC_UP_FRAME,         ///< plastic version of FL_UP_FRAME, use FL_PLASTIC_UP_FRAME
-  _FL_PLASTIC_DOWN_FRAME,       ///< plastic version of FL_DOWN_FRAME, use FL_PLASTIC_DOWN_FRAME
-  _FL_PLASTIC_THIN_UP_BOX,      ///< plastic version of FL_THIN_UP_BOX, use FL_PLASTIC_THIN_UP_BOX
-  _FL_PLASTIC_THIN_DOWN_BOX,    ///< plastic version of FL_THIN_DOWN_BOX, use FL_PLASTIC_THIN_DOWN_BOX
-  _FL_PLASTIC_ROUND_UP_BOX,     ///< plastic version of FL_ROUND_UP_BOX, use FL_PLASTIC_ROUND_UP_BOX
-  _FL_PLASTIC_ROUND_DOWN_BOX,   ///< plastic version of FL_ROUND_DOWN_BOX, use FL_PLASTIC_ROUND_DOWN_BOX
-  _FL_GTK_UP_BOX,               ///< gtk+ version of FL_UP_BOX, use FL_GTK_UP_BOX
-  _FL_GTK_DOWN_BOX,             ///< gtk+ version of FL_DOWN_BOX, use FL_GTK_DOWN_BOX
-  _FL_GTK_UP_FRAME,             ///< gtk+ version of FL_UP_FRAME, use FL_GTK_UP_FRAME
-  _FL_GTK_DOWN_FRAME,           ///< gtk+ version of FL_DOWN_FRAME, use FL_GTK_DOWN_FRAME
-  _FL_GTK_THIN_UP_BOX,          ///< gtk+ version of FL_THIN_UP_BOX, use FL_GTK_THIN_UP_BOX
-  _FL_GTK_THIN_DOWN_BOX,        ///< gtk+ version of FL_THIN_DOWN_BOX, use FL_GTK_THIN_DOWN_BOX
-  _FL_GTK_THIN_UP_FRAME,        ///< gtk+ version of FL_THIN_UP_FRAME, use FL_GTK_THIN_UP_FRAME
-  _FL_GTK_THIN_DOWN_FRAME,      ///< gtk+ version of FL_THIN_DOWN_FRAME, use FL_GTK_THIN_DOWN_FRAME
-  _FL_GTK_ROUND_UP_BOX,         ///< gtk+ version of FL_ROUND_UP_BOX, use FL_GTK_ROUND_UP_BOX
-  _FL_GTK_ROUND_DOWN_BOX,       ///< gtk+ version of FL_ROUND_DOWN_BOX, use FL_GTK_ROUND_DOWN_BOX
-  _FL_GLEAM_UP_BOX,             ///< gleam version of FL_UP_BOX, use FL_GLEAM_UP_BOX
-  _FL_GLEAM_DOWN_BOX,           ///< gleam version of FL_DOWN_BOX, use FL_GLEAM_DOWN_BOX
-  _FL_GLEAM_UP_FRAME,           ///< gleam version of FL_UP_FRAME, use FL_GLEAM_UP_FRAME
-  _FL_GLEAM_DOWN_FRAME,         ///< gleam version of FL_DOWN_FRAME, use FL_GLEAM_DOWN_FRAME
-  _FL_GLEAM_THIN_UP_BOX,        ///< gleam version of FL_THIN_UP_BOX, use FL_GLEAM_THIN_UP_BOX
-  _FL_GLEAM_THIN_DOWN_BOX,      ///< gleam version of FL_THIN_DOWN_BOX, use FL_GLEAM_THIN_DOWN_BOX
-  _FL_GLEAM_ROUND_UP_BOX,       ///< gleam version of FL_ROUND_UP_BOX, use FL_GLEAM_ROUND_UP_BOX
-  _FL_GLEAM_ROUND_DOWN_BOX,     ///< gleam version of FL_ROUND_DOWN_BOX, use FL_GLEAM_ROUND_DOWN_BOX
-  _FL_OXY_UP_BOX,               ///< oxy version of FL_UP_BOX, use FL_OXY_UP_BOX
-  _FL_OXY_DOWN_BOX,             ///< oxy version of FL_DOWN_BOX, use FL_OXY_DOWN_BOX
-  _FL_OXY_UP_FRAME,             ///< oxy version of FL_UP_FRAME, use FL_OXY_UP_FRAME
-  _FL_OXY_DOWN_FRAME,           ///< oxy version of FL_DOWN_FRAME, use FL_OXY_DOWN_FRAME
-  _FL_OXY_THIN_UP_BOX,          ///< oxy version of FL_THIN_UP_BOX, use FL_OXY_THIN_UP_BOX
-  _FL_OXY_THIN_DOWN_BOX,        ///< oxy version of FL_THIN_DOWN_BOX, use FL_OXY_THIN_DOWN_BOX
-  _FL_OXY_THIN_UP_FRAME,        ///< oxy version of FL_THIN_UP_FRAME, use FL_OXY_THIN_UP_FRAME
-  _FL_OXY_THIN_DOWN_FRAME,      ///< oxy version of FL_THIN_DOWN_FRAME, use FL_OXY_THIN_DOWN_FRAME
-  _FL_OXY_ROUND_UP_BOX,         ///< oxy version of FL_ROUND_UP_BOX, use FL_OXY_ROUND_UP_BOX
-  _FL_OXY_ROUND_DOWN_BOX,       ///< oxy version of FL_ROUND_DOWN_BOX, use FL_OXY_ROUND_DOWN_BOX
-  _FL_OXY_BUTTON_UP_BOX,        ///< FL_OXY_BUTTON_UP_BOX (new boxtype ?), use FL_OXY_BUTTON_UP_BOX
-  _FL_OXY_BUTTON_DOWN_BOX,      ///< FL_OXY_BUTTON_DOWN_BOX (new boxtype ?), use FL_OXY_BUTTON_DOWN_BOX
-  FL_FREE_BOXTYPE               ///< the first free box type for creation of new box types
+  FL_SHADOW_FRAME,              ///< see figure [Standard Box Types](@ref boxTypesImage)
+  FL_ROUNDED_BOX,               ///< see figure [Standard Box Types](@ref boxTypesImage)
+  FL_RSHADOW_BOX,               ///< see figure [Standard Box Types](@ref boxTypesImage)
+  FL_ROUNDED_FRAME,             ///< see figure [Standard Box Types](@ref boxTypesImage)
+  FL_RFLAT_BOX,                 ///< see figure [Standard Box Types](@ref boxTypesImage)
+  FL_ROUND_UP_BOX,              ///< see figure [Standard Box Types](@ref boxTypesImage)
+  FL_ROUND_DOWN_BOX,            ///< see figure [Standard Box Types](@ref boxTypesImage)
+  FL_DIAMOND_UP_BOX,            ///< see figure [Standard Box Types](@ref boxTypesImage)
+  FL_DIAMOND_DOWN_BOX,          ///< see figure [Standard Box Types](@ref boxTypesImage)
+  FL_OVAL_BOX,                  ///< see figure [Standard Box Types](@ref boxTypesImage)
+  FL_OSHADOW_BOX,               ///< see figure [Standard Box Types](@ref boxTypesImage)
+  FL_OVAL_FRAME,                ///< see figure [Standard Box Types](@ref boxTypesImage)
+  FL_OFLAT_BOX,                 ///< see figure [Standard Box Types](@ref boxTypesImage)
+  FL_PLASTIC_UP_BOX,            ///< plastic version of FL_UP_BOX
+  FL_PLASTIC_DOWN_BOX,          ///< plastic version of FL_DOWN_BOX
+  FL_PLASTIC_UP_FRAME,          ///< plastic version of FL_UP_FRAME
+  FL_PLASTIC_DOWN_FRAME,        ///< plastic version of FL_DOWN_FRAME
+  FL_PLASTIC_THIN_UP_BOX,       ///< plastic version of FL_THIN_UP_BOX
+  FL_PLASTIC_THIN_DOWN_BOX,     ///< plastic version of FL_THIN_DOWN_BOX
+  FL_PLASTIC_ROUND_UP_BOX,      ///< plastic version of FL_ROUND_UP_BOX
+  FL_PLASTIC_ROUND_DOWN_BOX,    ///< plastic version of FL_ROUND_DOWN_BOX
+  FL_GTK_UP_BOX,                ///< gtk+ version of FL_UP_BOX
+  FL_GTK_DOWN_BOX,              ///< gtk+ version of FL_DOWN_BOX
+  FL_GTK_UP_FRAME,              ///< gtk+ version of FL_UP_FRAME
+  FL_GTK_DOWN_FRAME,            ///< gtk+ version of FL_DOWN_FRAME
+  FL_GTK_THIN_UP_BOX,           ///< gtk+ version of FL_THIN_UP_BOX
+  FL_GTK_THIN_DOWN_BOX,         ///< gtk+ version of FL_THIN_DOWN_BOX
+  FL_GTK_THIN_UP_FRAME,         ///< gtk+ version of FL_THIN_UP_FRAME
+  FL_GTK_THIN_DOWN_FRAME,       ///< gtk+ version of FL_THIN_DOWN_FRAME
+  FL_GTK_ROUND_UP_BOX,          ///< gtk+ version of FL_ROUND_UP_BOX
+  FL_GTK_ROUND_DOWN_BOX,        ///< gtk+ version of FL_ROUND_DOWN_BOX
+  FL_GLEAM_UP_BOX,              ///< gleam version of FL_UP_BOX
+  FL_GLEAM_DOWN_BOX,            ///< gleam version of FL_DOWN_BOX
+  FL_GLEAM_UP_FRAME,            ///< gleam version of FL_UP_FRAME
+  FL_GLEAM_DOWN_FRAME,          ///< gleam version of FL_DOWN_FRAME
+  FL_GLEAM_THIN_UP_BOX,         ///< gleam version of FL_THIN_UP_BOX
+  FL_GLEAM_THIN_DOWN_BOX,       ///< gleam version of FL_THIN_DOWN_BOX
+  FL_GLEAM_ROUND_UP_BOX,        ///< gleam version of FL_ROUND_UP_BOX
+  FL_GLEAM_ROUND_DOWN_BOX,      ///< gleam version of FL_ROUND_DOWN_BOX
+  FL_OXY_UP_BOX,                ///< oxy version of FL_UP_BOX
+  FL_OXY_DOWN_BOX,              ///< oxy version of FL_DOWN_BOX
+  FL_OXY_UP_FRAME,              ///< oxy version of FL_UP_FRAME
+  FL_OXY_DOWN_FRAME,            ///< oxy version of FL_DOWN_FRAME
+  FL_OXY_THIN_UP_BOX,           ///< oxy version of FL_THIN_UP_BOX
+  FL_OXY_THIN_DOWN_BOX,         ///< oxy version of FL_THIN_DOWN_BOX
+  FL_OXY_THIN_UP_FRAME,         ///< oxy version of FL_THIN_UP_FRAME
+  FL_OXY_THIN_DOWN_FRAME,       ///< oxy version of FL_THIN_DOWN_FRAME
+  FL_OXY_ROUND_UP_BOX,          ///< oxy version of FL_ROUND_UP_BOX
+  FL_OXY_ROUND_DOWN_BOX,        ///< oxy version of FL_ROUND_DOWN_BOX
+  FL_OXY_BUTTON_UP_BOX,         ///< FL_OXY_BUTTON_UP_BOX (new boxtype ?)
+  FL_OXY_BUTTON_DOWN_BOX,       ///< FL_OXY_BUTTON_DOWN_BOX (new boxtype ?)
+  FL_FREE_BOXTYPE,              ///< the first free box type for creation of new box types
+  FL_MAX_BOXTYPE = 255          ///< highest legal index for a box type
 };
-
-#ifndef FL_DOXYGEN
-
-extern FL_EXPORT Fl_Boxtype fl_define_FL_ROUND_UP_BOX();
-#define FL_ROUND_UP_BOX fl_define_FL_ROUND_UP_BOX()
-#define FL_ROUND_DOWN_BOX (Fl_Boxtype)(fl_define_FL_ROUND_UP_BOX()+1)
-extern FL_EXPORT Fl_Boxtype fl_define_FL_SHADOW_BOX();
-#define FL_SHADOW_BOX fl_define_FL_SHADOW_BOX()
-#define FL_SHADOW_FRAME (Fl_Boxtype)(fl_define_FL_SHADOW_BOX()+2)
-extern FL_EXPORT Fl_Boxtype fl_define_FL_ROUNDED_BOX();
-#define FL_ROUNDED_BOX fl_define_FL_ROUNDED_BOX()
-#define FL_ROUNDED_FRAME (Fl_Boxtype)(fl_define_FL_ROUNDED_BOX()+2)
-extern FL_EXPORT Fl_Boxtype fl_define_FL_RFLAT_BOX();
-#define FL_RFLAT_BOX fl_define_FL_RFLAT_BOX()
-extern FL_EXPORT Fl_Boxtype fl_define_FL_RSHADOW_BOX();
-#define FL_RSHADOW_BOX fl_define_FL_RSHADOW_BOX()
-extern FL_EXPORT Fl_Boxtype fl_define_FL_DIAMOND_BOX();
-#define FL_DIAMOND_UP_BOX fl_define_FL_DIAMOND_BOX()
-#define FL_DIAMOND_DOWN_BOX (Fl_Boxtype)(fl_define_FL_DIAMOND_BOX()+1)
-extern FL_EXPORT Fl_Boxtype fl_define_FL_OVAL_BOX();
-#define FL_OVAL_BOX fl_define_FL_OVAL_BOX()
-#define FL_OSHADOW_BOX (Fl_Boxtype)(fl_define_FL_OVAL_BOX()+1)
-#define FL_OVAL_FRAME (Fl_Boxtype)(fl_define_FL_OVAL_BOX()+2)
-#define FL_OFLAT_BOX (Fl_Boxtype)(fl_define_FL_OVAL_BOX()+3)
-
-extern FL_EXPORT Fl_Boxtype fl_define_FL_PLASTIC_UP_BOX();
-#define FL_PLASTIC_UP_BOX fl_define_FL_PLASTIC_UP_BOX()
-#define FL_PLASTIC_DOWN_BOX (Fl_Boxtype)(fl_define_FL_PLASTIC_UP_BOX()+1)
-#define FL_PLASTIC_UP_FRAME (Fl_Boxtype)(fl_define_FL_PLASTIC_UP_BOX()+2)
-#define FL_PLASTIC_DOWN_FRAME (Fl_Boxtype)(fl_define_FL_PLASTIC_UP_BOX()+3)
-#define FL_PLASTIC_THIN_UP_BOX (Fl_Boxtype)(fl_define_FL_PLASTIC_UP_BOX()+4)
-#define FL_PLASTIC_THIN_DOWN_BOX (Fl_Boxtype)(fl_define_FL_PLASTIC_UP_BOX()+5)
-#define FL_PLASTIC_ROUND_UP_BOX (Fl_Boxtype)(fl_define_FL_PLASTIC_UP_BOX()+6)
-#define FL_PLASTIC_ROUND_DOWN_BOX (Fl_Boxtype)(fl_define_FL_PLASTIC_UP_BOX()+7)
-
-extern FL_EXPORT Fl_Boxtype fl_define_FL_GTK_UP_BOX();
-#define FL_GTK_UP_BOX fl_define_FL_GTK_UP_BOX()
-#define FL_GTK_DOWN_BOX (Fl_Boxtype)(fl_define_FL_GTK_UP_BOX()+1)
-#define FL_GTK_UP_FRAME (Fl_Boxtype)(fl_define_FL_GTK_UP_BOX()+2)
-#define FL_GTK_DOWN_FRAME (Fl_Boxtype)(fl_define_FL_GTK_UP_BOX()+3)
-#define FL_GTK_THIN_UP_BOX (Fl_Boxtype)(fl_define_FL_GTK_UP_BOX()+4)
-#define FL_GTK_THIN_DOWN_BOX (Fl_Boxtype)(fl_define_FL_GTK_UP_BOX()+5)
-#define FL_GTK_THIN_UP_FRAME (Fl_Boxtype)(fl_define_FL_GTK_UP_BOX()+6)
-#define FL_GTK_THIN_DOWN_FRAME (Fl_Boxtype)(fl_define_FL_GTK_UP_BOX()+7)
-#define FL_GTK_ROUND_UP_BOX (Fl_Boxtype)(fl_define_FL_GTK_UP_BOX()+8)
-#define FL_GTK_ROUND_DOWN_BOX (Fl_Boxtype)(fl_define_FL_GTK_UP_BOX()+9)
-
-extern FL_EXPORT Fl_Boxtype fl_define_FL_GLEAM_UP_BOX();
-#define FL_GLEAM_UP_BOX fl_define_FL_GLEAM_UP_BOX()
-#define FL_GLEAM_DOWN_BOX (Fl_Boxtype)(fl_define_FL_GLEAM_UP_BOX()+1)
-#define FL_GLEAM_UP_FRAME (Fl_Boxtype)(fl_define_FL_GLEAM_UP_BOX()+2)
-#define FL_GLEAM_DOWN_FRAME (Fl_Boxtype)(fl_define_FL_GLEAM_UP_BOX()+3)
-#define FL_GLEAM_THIN_UP_BOX (Fl_Boxtype)(fl_define_FL_GLEAM_UP_BOX()+4)
-#define FL_GLEAM_THIN_DOWN_BOX (Fl_Boxtype)(fl_define_FL_GLEAM_UP_BOX()+5)
-#define FL_GLEAM_ROUND_UP_BOX (Fl_Boxtype)(fl_define_FL_GLEAM_UP_BOX()+6)
-#define FL_GLEAM_ROUND_DOWN_BOX (Fl_Boxtype)(fl_define_FL_GLEAM_UP_BOX()+7)
-
-extern FL_EXPORT Fl_Boxtype fl_define_FL_OXY_UP_BOX();
-#define FL_OXY_UP_BOX fl_define_FL_OXY_UP_BOX()
-#define FL_OXY_DOWN_BOX (Fl_Boxtype)(fl_define_FL_OXY_UP_BOX()+1)
-#define FL_OXY_UP_FRAME (Fl_Boxtype)(fl_define_FL_OXY_UP_BOX()+2)
-#define FL_OXY_DOWN_FRAME (Fl_Boxtype)(fl_define_FL_OXY_UP_BOX()+3)
-#define FL_OXY_THIN_UP_BOX (Fl_Boxtype)(fl_define_FL_OXY_UP_BOX()+4)
-#define FL_OXY_THIN_DOWN_BOX (Fl_Boxtype)(fl_define_FL_OXY_UP_BOX()+5)
-#define FL_OXY_THIN_UP_FRAME (Fl_Boxtype)(fl_define_FL_OXY_UP_BOX()+6)
-#define FL_OXY_THIN_DOWN_FRAME (Fl_Boxtype)(fl_define_FL_OXY_UP_BOX()+7)
-#define FL_OXY_ROUND_UP_BOX (Fl_Boxtype)(fl_define_FL_OXY_UP_BOX()+8)
-#define FL_OXY_ROUND_DOWN_BOX (Fl_Boxtype)(fl_define_FL_OXY_UP_BOX()+9)
-#define FL_OXY_BUTTON_UP_BOX (Fl_Boxtype)(fl_define_FL_OXY_UP_BOX()+10)
-#define FL_OXY_BUTTON_DOWN_BOX (Fl_Boxtype)(fl_define_FL_OXY_UP_BOX()+11)
-
-#endif // ! FL_DOXYGEN
 
 // conversions of box types to other boxtypes:
 /**

--- a/FL/Fl.H
+++ b/FL/Fl.H
@@ -88,6 +88,9 @@ typedef void (Fl_Label_Measure_F)(const Fl_Label *label, int &width, int &height
 /** Signature of some box drawing functions passed as parameters */
 typedef void (Fl_Box_Draw_F)(int x, int y, int w, int h, Fl_Color color);
 
+/** Signature of some box drawing functions passed as parameters */
+typedef void (Fl_Box_Draw_Focus_F)(Fl_Boxtype bt, int x, int y, int w, int h, Fl_Color fg, Fl_Color bg);
+
 /** Signature of timeout callback functions passed as parameters.
   Please see Fl::add_timeout() for details.
 */
@@ -1215,7 +1218,8 @@ public:
 
   // boxtypes:
   static Fl_Box_Draw_F *get_boxtype(Fl_Boxtype);
-  static void set_boxtype(Fl_Boxtype, Fl_Box_Draw_F*,uchar,uchar,uchar,uchar);
+  static void set_boxtype(Fl_Boxtype, Fl_Box_Draw_F*,
+                          uchar, uchar, uchar, uchar, Fl_Box_Draw_Focus_F* =NULL);
   static void set_boxtype(Fl_Boxtype, Fl_Boxtype from);
   static int box_dx(Fl_Boxtype);
   static int box_dy(Fl_Boxtype);

--- a/FL/fl_draw.H
+++ b/FL/fl_draw.H
@@ -976,6 +976,7 @@ FL_EXPORT void fl_draw(const char *str, int x, int y, int w, int h, Fl_Align ali
 FL_EXPORT void fl_frame(const char *s, int x, int y, int w, int h);
 FL_EXPORT void fl_frame2(const char *s, int x, int y, int w, int h);
 FL_EXPORT void fl_draw_box(Fl_Boxtype, int x, int y, int w, int h, Fl_Color);
+FL_EXPORT void fl_draw_box_focus(Fl_Boxtype, int x, int y, int w, int h, Fl_Color, Fl_Color);
 
 // basic GUI objects (check marks, arrows, more to come ...):
 

--- a/fluid/Fl_Widget_Type.cxx
+++ b/fluid/Fl_Widget_Type.cxx
@@ -3582,10 +3582,10 @@ void Fl_Widget_Type::read_property(Fd_Project_Reader &f, const char *c) {
 Fl_Menu_Item boxmenu1[] = {
   // these extra ones are for looking up fdesign saved strings:
   {"NO_FRAME",          0,0,(void *)FL_NO_BOX},
-  {"ROUNDED3D_UPBOX",   0,0,(void *)_FL_ROUND_UP_BOX},
-  {"ROUNDED3D_DOWNBOX", 0,0,(void *)_FL_ROUND_DOWN_BOX},
-  {"OVAL3D_UPBOX",      0,0,(void *)_FL_ROUND_UP_BOX},
-  {"OVAL3D_DOWNBOX",    0,0,(void *)_FL_ROUND_DOWN_BOX},
+  {"ROUNDED3D_UPBOX",   0,0,(void *)FL_ROUND_UP_BOX},
+  {"ROUNDED3D_DOWNBOX", 0,0,(void *)FL_ROUND_DOWN_BOX},
+  {"OVAL3D_UPBOX",      0,0,(void *)FL_ROUND_UP_BOX},
+  {"OVAL3D_DOWNBOX",    0,0,(void *)FL_ROUND_DOWN_BOX},
   {"0",                 0,0,(void *)ZERO_ENTRY},
   {"1",                 0,0,(void *)FL_UP_BOX},
   {"2",                 0,0,(void *)FL_DOWN_BOX},

--- a/fluid/Fl_Window_Type.cxx
+++ b/fluid/Fl_Window_Type.cxx
@@ -153,7 +153,7 @@ void Overlay_Window::draw() {
   const int CHECKSIZE = 8;
   // see if box is clear or a frame or rounded:
   if ((damage()&FL_DAMAGE_ALL) &&
-      (!box() || (box()>=4&&!(box()&2)) || box()>=_FL_ROUNDED_BOX)) {
+      (!box() || (box()>=4&&!(box()&2)) || box()>=FL_ROUNDED_BOX)) {
     // if so, draw checkerboard so user can see what areas are clear:
     for (int Y = 0; Y < h(); Y += CHECKSIZE)
       for (int X = 0; X < w(); X += CHECKSIZE) {

--- a/src/Fl_Dial.cxx
+++ b/src/Fl_Dial.cxx
@@ -37,7 +37,7 @@ void Fl_Dial::draw(int X, int Y, int W, int H) {
   double angle = (a2-a1)*(value()-minimum())/(maximum()-minimum()) + a1;
   if (type() == FL_FILL_DIAL) {
     // foo: draw this nicely in certain round box types
-    int foo = (box() > _FL_ROUND_UP_BOX && Fl::box_dx(box()));
+    int foo = (box() > FL_ROUND_UP_BOX && Fl::box_dx(box()));
     if (foo) {X--; Y--; W+=2; H+=2;}
     if (active_r()) fl_color(color());
     else fl_color(fl_inactive(color()));

--- a/src/Fl_Light_Button.cxx
+++ b/src/Fl_Light_Button.cxx
@@ -60,8 +60,8 @@ void Fl_Light_Button::draw() {
     switch (down_box()) {
       case FL_DOWN_BOX :
       case FL_UP_BOX :
-      case _FL_PLASTIC_DOWN_BOX :
-      case _FL_PLASTIC_UP_BOX :
+      case FL_PLASTIC_DOWN_BOX :
+      case FL_PLASTIC_UP_BOX :
         // Check box...
         draw_box(down_box(), cx, cy, W, W, FL_BACKGROUND2_COLOR);
         if (value()) {
@@ -73,8 +73,8 @@ void Fl_Light_Button::draw() {
           fl_draw_check(Fl_Rect(cx, cy, cw, cw), check_color);
         }
         break;
-      case _FL_ROUND_DOWN_BOX :
-      case _FL_ROUND_UP_BOX :
+      case FL_ROUND_DOWN_BOX :
+      case FL_ROUND_UP_BOX :
         // Radio button...
         draw_box(down_box(), x()+dx, y()+dy, W, W, FL_BACKGROUND2_COLOR);
         if (value()) {

--- a/src/Fl_Scroll.cxx
+++ b/src/Fl_Scroll.cxx
@@ -163,11 +163,11 @@ void Fl_Scroll::draw_clip(void* v,int X, int Y, int W, int H) {
     case FL_ENGRAVED_FRAME :
     case FL_EMBOSSED_FRAME :
     case FL_BORDER_FRAME :
-    case _FL_SHADOW_FRAME :
-    case _FL_ROUNDED_FRAME :
-    case _FL_OVAL_FRAME :
-    case _FL_PLASTIC_UP_FRAME :
-    case _FL_PLASTIC_DOWN_FRAME :
+    case FL_SHADOW_FRAME :
+    case FL_ROUNDED_FRAME :
+    case FL_OVAL_FRAME :
+    case FL_PLASTIC_UP_FRAME :
+    case FL_PLASTIC_DOWN_FRAME :
         if (s->parent() == (Fl_Group *)s->window() && Fl::scheme_bg_) {
           Fl::scheme_bg_->draw(X-(X%((Fl_Tiled_Image *)Fl::scheme_bg_)->image()->w()),
                                Y-(Y%((Fl_Tiled_Image *)Fl::scheme_bg_)->image()->h()),

--- a/src/Fl_Tree_Item.cxx
+++ b/src/Fl_Tree_Item.cxx
@@ -800,27 +800,6 @@ Fl_Tree_Item *Fl_Tree_Item::find_clicked(const Fl_Tree_Prefs &prefs, int yonly) 
          static_cast<const Fl_Tree_Item &>(*this).find_clicked(prefs, yonly)));
 }
 
-static void draw_item_focus(Fl_Boxtype B, Fl_Color fg, Fl_Color bg, int X, int Y, int W, int H) {
-  // Pasted from Fl_Widget::draw_focus(); we don't have access to this method
-  if (!Fl::visible_focus()) return;
-  switch (B) {
-    case FL_DOWN_BOX:
-    case FL_DOWN_FRAME:
-    case FL_THIN_DOWN_BOX:
-    case FL_THIN_DOWN_FRAME:
-      X ++;
-      Y ++;
-    default:
-      break;
-  }
-  X += Fl::box_dx(B);
-  Y += Fl::box_dy(B);
-  W -= Fl::box_dw(B)+1;
-  H -= Fl::box_dh(B)+1;
-  fl_color(fl_contrast(fg, bg));
-  fl_focus_rect(X, Y, W, H);
-}
-
 /// Return the item's 'visible' height. Takes into account the item's:
 ///    - visibility (if !is_visible(), returns 0)
 ///    - labelfont() height: if label() != NULL
@@ -1137,7 +1116,7 @@ void Fl_Tree_Item::draw(int X, int &Y, int W, Fl_Tree_Item *itemfocus,
            Fl::visible_focus() &&
            Fl::focus() == tree() &&
            prefs.selectmode() != FL_TREE_SELECT_NONE ) {
-        draw_item_focus(FL_NO_BOX,fg,bg,label_x()+1,label_y()+1,label_w()-1,label_h()-1);
+        fl_draw_box_focus(FL_NO_BOX, label_x()+1, label_y()+1, label_w()-1, label_h()-1, fg, bg);
       }
     }                   // end drawthis
   }                     // end clipped

--- a/src/Fl_Widget.cxx
+++ b/src/Fl_Widget.cxx
@@ -211,27 +211,8 @@ Fl_Widget::~Fl_Widget() {
   \see Fl_Widget::draw_focus(Fl_Boxtype, int, int, int, int) const
 */
 void Fl_Widget::draw_focus(Fl_Boxtype bt, int X, int Y, int W, int H, Fl_Color bg) const {
-  if (!Fl::visible_focus()) return;
   if (!visible_focus()) return;
-  switch (bt) {
-    case FL_DOWN_BOX:
-    case FL_DOWN_FRAME:
-    case FL_THIN_DOWN_BOX:
-    case FL_THIN_DOWN_FRAME:
-      X ++;
-      Y ++;
-    default:
-      break;
-  }
-  X += Fl::box_dx(bt);
-  Y += Fl::box_dy(bt);
-  W -= Fl::box_dw(bt)+1;
-  H -= Fl::box_dh(bt)+1;
-
-  Fl_Color savecolor = fl_color();
-  fl_color(fl_contrast(FL_BLACK, bg));
-  fl_focus_rect(X, Y, W, H);
-  fl_color(savecolor);
+  fl_draw_box_focus(bt, X, Y, W, H, FL_BLACK, bg);
 }
 
 void Fl_Widget::activate() {

--- a/src/Fl_get_system_colors.cxx
+++ b/src/Fl_get_system_colors.cxx
@@ -144,6 +144,7 @@ extern void     fl_thin_up_box(int, int, int, int, Fl_Color);
 extern void     fl_thin_down_box(int, int, int, int, Fl_Color);
 extern void     fl_round_up_box(int, int, int, int, Fl_Color);
 extern void     fl_round_down_box(int, int, int, int, Fl_Color);
+extern void     fl_round_focus(Fl_Boxtype, int, int, int, int, Fl_Color, Fl_Color);
 
 extern void     fl_up_frame(int, int, int, int, Fl_Color);
 extern void     fl_down_frame(int, int, int, int, Fl_Color);
@@ -275,8 +276,8 @@ int Fl::reload_scheme() {
     set_boxtype(FL_DOWN_BOX,        FL_PLASTIC_DOWN_BOX);
     set_boxtype(FL_THIN_UP_BOX,     FL_PLASTIC_THIN_UP_BOX);
     set_boxtype(FL_THIN_DOWN_BOX,   FL_PLASTIC_THIN_DOWN_BOX);
-    set_boxtype(_FL_ROUND_UP_BOX,   FL_PLASTIC_ROUND_UP_BOX);
-    set_boxtype(_FL_ROUND_DOWN_BOX, FL_PLASTIC_ROUND_DOWN_BOX);
+    set_boxtype(FL_ROUND_UP_BOX,    FL_PLASTIC_ROUND_UP_BOX);
+    set_boxtype(FL_ROUND_DOWN_BOX,  FL_PLASTIC_ROUND_DOWN_BOX);
 
     // Use standard size scrollbars...
     Fl::scrollbar_size(16);
@@ -296,8 +297,8 @@ int Fl::reload_scheme() {
     set_boxtype(FL_DOWN_BOX,        FL_GTK_DOWN_BOX);
     set_boxtype(FL_THIN_UP_BOX,     FL_GTK_THIN_UP_BOX);
     set_boxtype(FL_THIN_DOWN_BOX,   FL_GTK_THIN_DOWN_BOX);
-    set_boxtype(_FL_ROUND_UP_BOX,   FL_GTK_ROUND_UP_BOX);
-    set_boxtype(_FL_ROUND_DOWN_BOX, FL_GTK_ROUND_DOWN_BOX);
+    set_boxtype(FL_ROUND_UP_BOX,    FL_GTK_ROUND_UP_BOX);
+    set_boxtype(FL_ROUND_DOWN_BOX,  FL_GTK_ROUND_DOWN_BOX);
 
     // Use slightly thinner scrollbars...
     Fl::scrollbar_size(15);
@@ -317,8 +318,8 @@ int Fl::reload_scheme() {
     set_boxtype(FL_DOWN_BOX,        FL_GLEAM_DOWN_BOX);
     set_boxtype(FL_THIN_UP_BOX,     FL_GLEAM_THIN_UP_BOX);
     set_boxtype(FL_THIN_DOWN_BOX,   FL_GLEAM_THIN_DOWN_BOX);
-    set_boxtype(_FL_ROUND_UP_BOX,   FL_GLEAM_ROUND_UP_BOX);
-    set_boxtype(_FL_ROUND_DOWN_BOX, FL_GLEAM_ROUND_DOWN_BOX);
+    set_boxtype(FL_ROUND_UP_BOX,    FL_GLEAM_ROUND_UP_BOX);
+    set_boxtype(FL_ROUND_DOWN_BOX,  FL_GLEAM_ROUND_DOWN_BOX);
 
     // Use slightly thinner scrollbars...
     Fl::scrollbar_size(15);
@@ -338,8 +339,8 @@ int Fl::reload_scheme() {
     set_boxtype(FL_DOWN_BOX,        FL_OXY_DOWN_BOX);
     set_boxtype(FL_THIN_UP_BOX,     FL_OXY_THIN_UP_BOX);
     set_boxtype(FL_THIN_DOWN_BOX,   FL_OXY_THIN_DOWN_BOX);
-    set_boxtype(_FL_ROUND_UP_BOX,   FL_OXY_ROUND_UP_BOX);
-    set_boxtype(_FL_ROUND_DOWN_BOX, FL_OXY_ROUND_DOWN_BOX);
+    set_boxtype(FL_ROUND_UP_BOX,    FL_OXY_ROUND_UP_BOX);
+    set_boxtype(FL_ROUND_DOWN_BOX,  FL_OXY_ROUND_DOWN_BOX);
 
     // Use slightly thinner scrollbars...
     Fl::scrollbar_size(15);
@@ -359,8 +360,8 @@ int Fl::reload_scheme() {
     set_boxtype(FL_DOWN_BOX,        fl_down_box, D1, D1, D2, D2);
     set_boxtype(FL_THIN_UP_BOX,     fl_thin_up_box, 1, 1, 2, 2);
     set_boxtype(FL_THIN_DOWN_BOX,   fl_thin_down_box, 1, 1, 2, 2);
-    set_boxtype(_FL_ROUND_UP_BOX,   fl_round_up_box, 3, 3, 6, 6);
-    set_boxtype(_FL_ROUND_DOWN_BOX, fl_round_down_box, 3, 3, 6, 6);
+    set_boxtype(FL_ROUND_UP_BOX,    fl_round_up_box, 3, 3, 6, 6, fl_round_focus);
+    set_boxtype(FL_ROUND_DOWN_BOX,  fl_round_down_box, 3, 3, 6, 6, fl_round_focus);
 
     // Use standard size scrollbars...
     Fl::scrollbar_size(16);

--- a/src/fl_boxtype.cxx
+++ b/src/fl_boxtype.cxx
@@ -284,12 +284,84 @@ void fl_border_frame(int x, int y, int w, int h, Fl_Color c) {
 
 ////////////////////////////////////////////////////////////////
 
+// implemented in fl_shadow_box.cxx
+extern void fl_shadow_box(int, int, int, int, Fl_Color);
+extern void fl_shadow_frame(int, int, int, int, Fl_Color);
+
+// implemented in fl_rounded_box.cxx
+extern void fl_rounded_box(int, int, int, int, Fl_Color);
+extern void fl_rshadow_box(int, int, int, int, Fl_Color);
+extern void fl_rounded_frame(int, int, int, int, Fl_Color);
+extern void fl_rflat_box(int, int, int, int, Fl_Color);
+extern void fl_rounded_focus(Fl_Boxtype, int, int, int, int, Fl_Color, Fl_Color);
+
+// implemented in fl_round_box.cxx
+extern void fl_round_up_box(int, int, int, int, Fl_Color);
+extern void fl_round_down_box(int, int, int, int, Fl_Color);
+extern void fl_round_focus(Fl_Boxtype, int, int, int, int, Fl_Color, Fl_Color);
+
+// implemented in fl_diamond_box.cxx
+extern void fl_diamond_up_box(int, int, int, int, Fl_Color);
+extern void fl_diamond_down_box(int, int, int, int, Fl_Color);
+extern void fl_diamond_focus(Fl_Boxtype, int, int, int, int, Fl_Color, Fl_Color);
+
+// implemented in fl_oval_box.cxx
+extern void fl_oval_box(int, int, int, int, Fl_Color);
+extern void fl_oval_shadow_box(int, int, int, int, Fl_Color);
+extern void fl_oval_frame(int, int, int, int, Fl_Color);
+extern void fl_oval_flat_box(int, int, int, int, Fl_Color);
+extern void fl_oval_focus(Fl_Boxtype, int, int, int, int, Fl_Color, Fl_Color);
+
+// implemented in fl_plastic.cxx
+extern void fl_plastic_up_frame(int, int, int, int, Fl_Color);
+extern void fl_plastic_thin_up_box(int, int, int, int, Fl_Color);
+extern void fl_plastic_up_box(int, int, int, int, Fl_Color);
+extern void fl_plastic_up_round(int, int, int, int, Fl_Color);
+extern void fl_plastic_down_frame(int, int, int, int, Fl_Color);
+extern void fl_plastic_down_box(int, int, int, int, Fl_Color);
+extern void fl_plastic_down_round(int, int, int, int, Fl_Color);
+
+// implemented in fl_gtk.cxx
+extern void fl_gtk_up_box(int, int, int, int, Fl_Color);
+extern void fl_gtk_down_box(int, int, int, int, Fl_Color);
+extern void fl_gtk_up_frame(int, int, int, int, Fl_Color);
+extern void fl_gtk_down_frame(int, int, int, int, Fl_Color);
+extern void fl_gtk_thin_up_box(int, int, int, int, Fl_Color);
+extern void fl_gtk_thin_down_box(int, int, int, int, Fl_Color);
+extern void fl_gtk_thin_up_frame(int, int, int, int, Fl_Color);
+extern void fl_gtk_thin_down_frame(int, int, int, int, Fl_Color);
+extern void fl_gtk_round_up_box(int, int, int, int, Fl_Color);
+extern void fl_gtk_round_down_box(int, int, int, int, Fl_Color);
+
+// implemented in fl_gleam.cxx
+extern void fl_gleam_up_box(int, int, int, int, Fl_Color);
+extern void fl_gleam_down_box(int, int, int, int, Fl_Color);
+extern void fl_gleam_up_frame(int, int, int, int, Fl_Color);
+extern void fl_gleam_down_frame(int, int, int, int, Fl_Color);
+extern void fl_gleam_thin_up_box(int, int, int, int, Fl_Color);
+extern void fl_gleam_thin_down_box(int, int, int, int, Fl_Color);
+
+// implemented in fl_oxy.cxx
+extern void fl_oxy_up_box(int, int, int, int, Fl_Color);
+extern void fl_oxy_down_box(int, int, int, int, Fl_Color);
+extern void fl_oxy_up_frame(int, int, int, int, Fl_Color);
+extern void fl_oxy_down_frame(int, int, int, int, Fl_Color);
+extern void fl_oxy_thin_up_box(int, int, int, int, Fl_Color);
+extern void fl_oxy_thin_down_box(int, int, int, int, Fl_Color);
+extern void fl_oxy_thin_up_frame(int, int, int, int, Fl_Color);
+extern void fl_oxy_thin_down_frame(int, int, int, int, Fl_Color);
+extern void fl_oxy_round_up_box(int, int, int, int, Fl_Color);
+extern void fl_oxy_round_down_box(int, int, int, int, Fl_Color);
+extern void fl_oxy_button_up_box(int, int, int, int, Fl_Color);
+extern void fl_oxy_button_down_box(int, int, int, int, Fl_Color);
+
 static struct {
   Fl_Box_Draw_F *f;
   uchar dx, dy, dw, dh;
   int set;
-} fl_box_table[256] = {
-// must match list in Enumerations.H!!!
+  Fl_Box_Draw_Focus_F *ff;
+} fl_box_table[FL_MAX_BOXTYPE+1] = {
+  // must match list in Enumerations.H!!!
   {fl_no_box,           0,0,0,0,1},
   {fl_flat_box,         0,0,0,0,1}, // FL_FLAT_BOX
   {fl_up_box,           D1,D1,D2,D2,1},
@@ -305,59 +377,64 @@ static struct {
   {fl_engraved_frame,   2,2,4,4,1},
   {fl_embossed_frame,   2,2,4,4,1},
   {fl_border_box,       1,1,2,2,1},
-  {fl_border_box,       1,1,5,5,0}, // _FL_SHADOW_BOX
+  {fl_shadow_box,       1,1,5,5,0}, // FL_SHADOW_BOX
   {fl_border_frame,     1,1,2,2,1},
-  {fl_border_frame,     1,1,5,5,0}, // _FL_SHADOW_FRAME
-  {fl_border_box,       1,1,2,2,0}, // _FL_ROUNDED_BOX
-  {fl_border_box,       1,1,2,2,0}, // _FL_RSHADOW_BOX
-  {fl_border_frame,     1,1,2,2,0}, // _FL_ROUNDED_FRAME
-  {fl_flat_box,         0,0,0,0,0}, // _FL_RFLAT_BOX
-  {fl_up_box,           3,3,6,6,0}, // _FL_ROUND_UP_BOX
-  {fl_down_box,         3,3,6,6,0}, // _FL_ROUND_DOWN_BOX
-  {fl_up_box,           0,0,0,0,0}, // _FL_DIAMOND_UP_BOX
-  {fl_down_box,         0,0,0,0,0}, // _FL_DIAMOND_DOWN_BOX
-  {fl_border_box,       1,1,2,2,0}, // _FL_OVAL_BOX
-  {fl_border_box,       1,1,2,2,0}, // _FL_OVAL_SHADOW_BOX
-  {fl_border_frame,     1,1,2,2,0}, // _FL_OVAL_FRAME
-  {fl_flat_box,         0,0,0,0,0}, // _FL_OVAL_FLAT_BOX
-  {fl_up_box,           2,2,4,4,0}, // _FL_PLASTIC_UP_BOX
-  {fl_down_box,         2,2,4,4,0}, // _FL_PLASTIC_DOWN_BOX
-  {fl_up_frame,         2,2,4,4,0}, // _FL_PLASTIC_UP_FRAME
-  {fl_down_frame,       2,2,4,4,0}, // _FL_PLASTIC_DOWN_FRAME
-  {fl_up_box,           2,2,4,4,0}, // _FL_PLASTIC_THIN_UP_BOX
-  {fl_down_box,         2,2,4,4,0}, // _FL_PLASTIC_THIN_DOWN_BOX
-  {fl_up_box,           2,2,4,4,0}, // _FL_PLASTIC_ROUND_UP_BOX
-  {fl_down_box,         2,2,4,4,0}, // _FL_PLASTIC_ROUND_DOWN_BOX
-  {fl_up_box,           2,2,4,4,0}, // _FL_GTK_UP_BOX
-  {fl_down_box,         2,2,4,4,0}, // _FL_GTK_DOWN_BOX
-  {fl_up_frame,         2,2,4,4,0}, // _FL_GTK_UP_FRAME
-  {fl_down_frame,       2,2,4,4,0}, // _FL_GTK_DOWN_FRAME
-  {fl_up_frame,         1,1,2,2,0}, // _FL_GTK_THIN_UP_FRAME
-  {fl_down_frame,       1,1,2,2,0}, // _FL_GTK_THIN_DOWN_FRAME
-  {fl_up_box,           1,1,2,2,0}, // _FL_GTK_THIN_ROUND_UP_BOX
-  {fl_down_box,         1,1,2,2,0}, // _FL_GTK_THIN_ROUND_DOWN_BOX
-  {fl_up_box,           2,2,4,4,0}, // _FL_GTK_ROUND_UP_BOX
-  {fl_down_box,         2,2,4,4,0}, // _FL_GTK_ROUND_DOWN_BOX
-  {fl_up_box,           2,2,4,4,0}, // _FL_GLEAM_UP_BOX
-  {fl_down_box,         2,2,4,4,0}, // _FL_GLEAM_DOWN_BOX
-  {fl_up_frame,         2,2,4,4,0}, // _FL_GLEAM_UP_FRAME
-  {fl_down_frame,       2,2,4,4,0}, // _FL_GLEAM_DOWN_FRAME
-  {fl_up_box,           2,2,4,4,0}, // _FL_GLEAM_THIN_UP_BOX
-  {fl_down_box,         2,2,4,4,0}, // _FL_GLEAM_THIN_DOWN_BOX
-  {fl_up_box,           2,2,4,4,0}, // _FL_GLEAM_ROUND_UP_BOX
-  {fl_down_box,         2,2,4,4,0}, // _FL_GLEAM_ROUND_DOWN_BOX
-  {fl_up_box,           2,2,4,4,0}, // _FL_OXY_UP_BOX,
-  {fl_down_box,         2,2,4,4,0}, // _FL_OXY_DOWN_BOX,
-  {fl_up_frame,         2,2,4,4,0}, // _FL_OXY_UP_FRAME,
-  {fl_down_frame,       2,2,4,4,0}, // _FL_OXY_DOWN_FRAME,
-  {fl_thin_up_box,      1,1,2,2,0}, // _FL_OXY_THIN_UP_BOX,
-  {fl_thin_down_box,    1,1,2,2,0}, // _FL_OXY_THIN_DOWN_BOX,
-  {fl_thin_up_frame,    1,1,2,2,0}, // _FL_OXY_THIN_UP_FRAME,
-  {fl_thin_down_frame,  1,1,2,2,0}, // _FL_OXY_THIN_DOWN_FRAME,
-  {fl_up_box,           2,2,4,4,0}, // _FL_OXY_ROUND_UP_BOX,
-  {fl_down_box,         2,2,4,4,0}, // _FL_OXY_ROUND_DOWN_BOX,
-  {fl_up_box,           2,2,4,4,0}, // _FL_OXY_BUTTON_UP_BOX,
-  {fl_down_box,         2,2,4,4,0}, // _FL_OXY_BUTTON_DOWN_BOX,
+  {fl_shadow_frame,     1,1,5,5,0}, // FL_SHADOW_FRAME
+  {fl_rounded_box,      1,1,2,2,0, fl_rounded_focus}, // FL_ROUNDED_BOX
+  {fl_rshadow_box,      1,1,2,2,0, fl_rounded_focus}, // FL_RSHADOW_BOX
+  {fl_rounded_frame,    1,1,2,2,0, fl_rounded_focus}, // FL_ROUNDED_FRAME
+  {fl_rflat_box,        0,0,0,0,0, fl_rounded_focus}, // FL_RFLAT_BOX
+  {fl_round_up_box,     3,3,6,6,0, fl_round_focus}, // FL_ROUND_UP_BOX
+  {fl_round_down_box,   3,3,6,6,0, fl_round_focus}, // FL_ROUND_DOWN_BOX
+  {fl_diamond_up_box,   0,0,0,0,0, fl_diamond_focus}, // FL_DIAMOND_UP_BOX
+  {fl_diamond_down_box, 0,0,0,0,0, fl_diamond_focus}, // FL_DIAMOND_DOWN_BOX
+  {fl_oval_box,         1,1,2,2,0, fl_oval_focus}, // FL_OVAL_BOX
+  {fl_oval_shadow_box,  1,1,2,2,0, fl_oval_focus}, // FL_OVAL_SHADOW_BOX
+  {fl_oval_frame,       1,1,2,2,0, fl_oval_focus}, // FL_OVAL_FRAME
+  {fl_oval_flat_box,    0,0,0,0,0, fl_oval_focus}, // FL_OVAL_FLAT_BOX
+
+  {fl_plastic_up_box,       2,2,4,4,0}, // FL_PLASTIC_UP_BOX
+  {fl_plastic_down_box,     2,2,4,4,0}, // FL_PLASTIC_DOWN_BOX
+  {fl_plastic_up_frame,     2,2,4,4,0}, // FL_PLASTIC_UP_FRAME
+  {fl_plastic_down_frame,   2,2,4,4,0}, // FL_PLASTIC_DOWN_FRAME
+  {fl_plastic_thin_up_box,  2,2,4,4,0}, // FL_PLASTIC_THIN_UP_BOX
+  {fl_plastic_down_box,     2,2,4,4,0}, // FL_PLASTIC_THIN_DOWN_BOX
+  {fl_plastic_up_round,     2,2,4,4,0, fl_rounded_focus}, // FL_PLASTIC_ROUND_UP_BOX
+  {fl_plastic_down_round,   2,2,4,4,0, fl_rounded_focus}, // FL_PLASTIC_ROUND_DOWN_BOX
+
+  {fl_gtk_up_box,           2,2,4,4,0}, // FL_GTK_UP_BOX
+  {fl_gtk_down_box,         2,2,4,4,0}, // FL_GTK_DOWN_BOX
+  {fl_gtk_up_frame,         2,2,4,4,0}, // FL_GTK_UP_FRAME
+  {fl_gtk_down_frame,       2,2,4,4,0}, // FL_GTK_DOWN_FRAME
+  {fl_gtk_thin_up_box,      1,1,2,2,0}, // FL_GTK_THIN_UP_BOX
+  {fl_gtk_thin_down_box,    1,1,2,2,0}, // FL_GTK_THIN_DOWN_BOX
+  {fl_gtk_thin_up_frame,    1,1,2,2,0}, // FL_GTK_THIN_UP_FRAME
+  {fl_gtk_thin_down_frame,  1,1,2,2,0}, // FL_GTK_THIN_DOWN_FRAME
+  {fl_gtk_round_up_box,     2,2,4,4,0, fl_rounded_focus}, // FL_GTK_ROUND_UP_BOX
+  {fl_gtk_round_down_box,   2,2,4,4,0, fl_rounded_focus}, // FL_GTK_ROUND_DOWN_BOX
+
+  {fl_gleam_up_box,         2,2,4,4,0}, // FL_GLEAM_UP_BOX
+  {fl_gleam_down_box,       2,2,4,4,0}, // FL_GLEAM_DOWN_BOX
+  {fl_gleam_up_frame,       2,2,4,4,0}, // FL_GLEAM_UP_FRAME
+  {fl_gleam_down_frame,     2,2,4,4,0}, // FL_GLEAM_DOWN_FRAME
+  {fl_gleam_thin_up_box,    2,2,4,4,0}, // FL_GLEAM_THIN_UP_BOX
+  {fl_gleam_thin_down_box,  2,2,4,4,0}, // FL_GLEAM_THIN_DOWN_BOX
+  {fl_gleam_up_box,         2,2,4,4,0}, // FL_GLEAM_ROUND_UP_BOX
+  {fl_gleam_down_box,       2,2,4,4,0}, // FL_GLEAM_ROUND_DOWN_BOX
+
+  {fl_oxy_up_box,           2,2,4,4,0}, // FL_OXY_UP_BOX,
+  {fl_oxy_down_box,         2,2,4,4,0}, // FL_OXY_DOWN_BOX,
+  {fl_oxy_up_frame,         2,2,4,4,0}, // FL_OXY_UP_FRAME,
+  {fl_oxy_down_frame,       2,2,4,4,0}, // FL_OXY_DOWN_FRAME,
+  {fl_oxy_thin_up_box,      1,1,2,2,0}, // FL_OXY_THIN_UP_BOX,
+  {fl_oxy_thin_down_box,    1,1,2,2,0}, // FL_OXY_THIN_DOWN_BOX,
+  {fl_oxy_thin_up_frame,    1,1,2,2,0}, // FL_OXY_THIN_UP_FRAME,
+  {fl_oxy_thin_down_frame,  1,1,2,2,0}, // FL_OXY_THIN_DOWN_FRAME,
+  {fl_oxy_round_up_box,     2,2,4,4,0, fl_rounded_focus}, // FL_OXY_ROUND_UP_BOX,
+  {fl_oxy_round_down_box,   2,2,4,4,0, fl_rounded_focus}, // FL_OXY_ROUND_DOWN_BOX,
+  {fl_oxy_button_up_box,    2,2,4,4,0}, // FL_OXY_BUTTON_UP_BOX,
+  {fl_oxy_button_down_box,  2,2,4,4,0}, // FL_OXY_BUTTON_DOWN_BOX,
+
   {fl_up_box,           3,3,6,6,0}, // FL_FREE_BOX+0
   {fl_down_box,         3,3,6,6,0}, // FL_FREE_BOX+1
   {fl_up_box,           3,3,6,6,0}, // FL_FREE_BOX+2
@@ -415,10 +492,12 @@ int Fl::box_dh(Fl_Boxtype t) {return fl_box_table[t].dh;}
   Sets the drawing function for a given box type.
   \param[in] t box type
   \param[in] f box drawing function
+  \param[in] ff optional box focus rectangle drawing function
 */
-void fl_internal_boxtype(Fl_Boxtype t, Fl_Box_Draw_F* f) {
+void fl_internal_boxtype(Fl_Boxtype t, Fl_Box_Draw_F* f, Fl_Box_Draw_Focus_F* ff) {
   if (!fl_box_table[t].set) {
     fl_box_table[t].f   = f;
+    fl_box_table[t].ff  = ff;
     fl_box_table[t].set = 1;
   }
 }
@@ -427,15 +506,28 @@ void fl_internal_boxtype(Fl_Boxtype t, Fl_Box_Draw_F* f) {
 Fl_Box_Draw_F *Fl::get_boxtype(Fl_Boxtype t) {
   return fl_box_table[t].f;
 }
-/** Sets the function to call to draw a specific boxtype. */
+
+/** 
+ Sets the function to call to draw a specific box type.
+
+ \param[in] t  index of the box type between 0 (FL_NO_BOX) and up to and
+               including FL_MAX_BOXTYPE
+ \param[in] f  callback function that draws the box
+ \param[in] dx, dy top left frame width, distance in pixels to box contents
+ \param[in] dw, dh left plus right frame width, top plus bottom frame width
+ \param[in] ff optional callback that draws the box focus, defaults
+               to a rectangle, inset by dx, dy, dw, dh
+ */
 void Fl::set_boxtype(Fl_Boxtype t, Fl_Box_Draw_F* f,
-                     uchar a, uchar b, uchar c, uchar d) {
+                     uchar dx, uchar dy, uchar dw, uchar dh,
+                     Fl_Box_Draw_Focus_F* ff) {
   fl_box_table[t].f   = f;
   fl_box_table[t].set = 1;
-  fl_box_table[t].dx  = a;
-  fl_box_table[t].dy  = b;
-  fl_box_table[t].dw  = c;
-  fl_box_table[t].dh  = d;
+  fl_box_table[t].dx  = dx;
+  fl_box_table[t].dy  = dy;
+  fl_box_table[t].dw  = dw;
+  fl_box_table[t].dh  = dh;
+  fl_box_table[t].ff  = ff;
 }
 /** Copies the from boxtype. */
 void Fl::set_boxtype(Fl_Boxtype to, Fl_Boxtype from) {
@@ -450,6 +542,41 @@ void Fl::set_boxtype(Fl_Boxtype to, Fl_Boxtype from) {
 */
 void fl_draw_box(Fl_Boxtype t, int x, int y, int w, int h, Fl_Color c) {
   if (t && fl_box_table[t].f) fl_box_table[t].f(x,y,w,h,c);
+}
+
+/**
+ Draws the focus rectangle inside a box using given type, position, size and color.
+ Boxes can set their own focus drawing callback. The focus frame does not
+ need to be a rectangle at all, but should fit inside the shape of the box.
+ \param[in] bt box type
+ \param[in] x, y, w, h position and size
+ \param[in] fg, bg foreground and background color
+ */
+void fl_draw_box_focus(Fl_Boxtype bt, int x, int y, int w, int h, Fl_Color fg, Fl_Color bg) {
+  if (!Fl::visible_focus()) return;
+  if ((bt >= 0) && (bt <= FL_MAX_BOXTYPE) && (fl_box_table[bt].ff)) {
+    fl_box_table[bt].ff(bt, x, y, w, h, fg, bg);
+    return;
+  }
+  switch (bt) {
+    case FL_DOWN_BOX:
+    case FL_DOWN_FRAME:
+    case FL_THIN_DOWN_BOX:
+    case FL_THIN_DOWN_FRAME:
+      x++;
+      y++;
+    default:
+      break;
+  }
+  x += Fl::box_dx(bt);
+  y += Fl::box_dy(bt);
+  w -= Fl::box_dw(bt)+1;
+  h -= Fl::box_dh(bt)+1;
+
+  Fl_Color savecolor = fl_color();
+  fl_color(fl_contrast(fg, bg));
+  fl_focus_rect(x, y, w, h);
+  fl_color(savecolor);
 }
 
 /** Draws the widget box according its box style */

--- a/src/fl_diamond_box.cxx
+++ b/src/fl_diamond_box.cxx
@@ -25,7 +25,7 @@
 
 extern const uchar* fl_gray_ramp();
 
-static void fl_diamond_up_box(int x,int y,int w,int h,Fl_Color bgcolor) {
+void fl_diamond_up_box(int x,int y,int w,int h,Fl_Color bgcolor) {
   w &= -2;
   h &= -2;
   int x1 = x+w/2;
@@ -42,7 +42,7 @@ static void fl_diamond_up_box(int x,int y,int w,int h,Fl_Color bgcolor) {
   fl_color(g[(int)'A']); fl_loop(x, y1, x1, y, x+w, y1, x1, y+h);
 }
 
-static void fl_diamond_down_box(int x,int y,int w,int h,Fl_Color bgcolor) {
+void fl_diamond_down_box(int x,int y,int w,int h,Fl_Color bgcolor) {
   w &= -2;
   h &= -2;
   int x1 = x+w/2;
@@ -59,9 +59,19 @@ static void fl_diamond_down_box(int x,int y,int w,int h,Fl_Color bgcolor) {
   fl_color(g[(int)'A']); fl_loop(x+3, y1, x1, y+3, x+w-3, y1, x1, y+h-3);
 }
 
-extern void fl_internal_boxtype(Fl_Boxtype, Fl_Box_Draw_F*);
-Fl_Boxtype fl_define_FL_DIAMOND_BOX() {
-  fl_internal_boxtype(_FL_DIAMOND_DOWN_BOX, fl_diamond_down_box);
-  fl_internal_boxtype(_FL_DIAMOND_UP_BOX,fl_diamond_up_box);
-  return _FL_DIAMOND_UP_BOX;
+void fl_diamond_focus(Fl_Boxtype bt, int x, int y, int w, int h, Fl_Color fg, Fl_Color bg) {
+  w &= -2;
+  h &= -2;
+  x += Fl::box_dx(bt)+4;
+  y += Fl::box_dy(bt)+4;
+  w -= Fl::box_dw(bt)+8;
+  h -= Fl::box_dh(bt)+8;
+  int x1 = x+w/2;
+  int y1 = y+h/2;
+  Fl_Color savecolor = fl_color();
+  fl_color(fl_contrast(fg, bg));
+  fl_line_style(FL_DOT);
+  fl_loop(x,y1, x1,y, x+w,y1, x1,y+h);
+  fl_line_style(FL_SOLID);
+  fl_color(savecolor);
 }

--- a/src/fl_gleam.cxx
+++ b/src/fl_gleam.cxx
@@ -136,44 +136,30 @@ static void frame_rect_down(int x, int y, int w, int h, Fl_Color bc, Fl_Color lc
 
 // Draw the different box types. These are the actual box drawing functions.
 
-static void up_frame(int x, int y, int w, int h, Fl_Color c) {
+void fl_gleam_up_frame(int x, int y, int w, int h, Fl_Color c) {
   frame_rect_up(x, y, w, h, c, fl_color_average(c, FL_WHITE, .25f), .55f, .05f);
 }
 
-static void up_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_gleam_up_box(int x, int y, int w, int h, Fl_Color c) {
   shade_rect_top_bottom_up(x, y, w, h, c, .15f);
   frame_rect_up(x, y, w, h, c, fl_color_average(c, FL_WHITE, .05f), .15f, .05f);
 }
 
-static void thin_up_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_gleam_thin_up_box(int x, int y, int w, int h, Fl_Color c) {
   shade_rect_top_bottom_up(x, y, w, h, c, .25f);
   frame_rect_up(x, y, w, h, c, fl_color_average(c, FL_WHITE, .45f), .25f, .15f);
 }
 
-static void down_frame(int x, int y, int w, int h, Fl_Color c) {
+void fl_gleam_down_frame(int x, int y, int w, int h, Fl_Color c) {
   frame_rect_down(x, y, w, h, fl_darker(c), fl_darker(c), .25f, .95f);
 }
 
-static void down_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_gleam_down_box(int x, int y, int w, int h, Fl_Color c) {
   shade_rect_top_bottom_down(x, y, w, h, c, .65f);
   frame_rect_down(x, y, w, h, c, fl_color_average(c, FL_BLACK, .05f), .05f, .95f);
 }
 
-static void thin_down_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_gleam_thin_down_box(int x, int y, int w, int h, Fl_Color c) {
   shade_rect_top_bottom_down(x, y, w, h, c, .85f);
   frame_rect_down(x, y, w, h, c, fl_color_average(c, FL_BLACK, .45f), .35f, 0.85f);
-}
-
-extern void fl_internal_boxtype(Fl_Boxtype, Fl_Box_Draw_F*);
-
-Fl_Boxtype fl_define_FL_GLEAM_UP_BOX() {
-  fl_internal_boxtype(_FL_GLEAM_UP_BOX, up_box);
-  fl_internal_boxtype(_FL_GLEAM_DOWN_BOX, down_box);
-  fl_internal_boxtype(_FL_GLEAM_UP_FRAME, up_frame);
-  fl_internal_boxtype(_FL_GLEAM_DOWN_FRAME, down_frame);
-  fl_internal_boxtype(_FL_GLEAM_THIN_UP_BOX, thin_up_box);
-  fl_internal_boxtype(_FL_GLEAM_THIN_DOWN_BOX, thin_down_box);
-  fl_internal_boxtype(_FL_GLEAM_ROUND_UP_BOX, up_box);
-  fl_internal_boxtype(_FL_GLEAM_ROUND_DOWN_BOX, down_box);
-  return _FL_GLEAM_UP_BOX;
 }

--- a/src/fl_gtk.cxx
+++ b/src/fl_gtk.cxx
@@ -24,14 +24,14 @@
 #include <FL/Fl.H>
 #include <FL/fl_draw.H>
 
-extern void fl_internal_boxtype(Fl_Boxtype, Fl_Box_Draw_F*);
+extern void fl_internal_boxtype(Fl_Boxtype, Fl_Box_Draw_F*, Fl_Box_Draw_Focus_F* =NULL);
 
 
 static void gtk_color(Fl_Color c) {
   Fl::set_box_color(c);
 }
 
-static void gtk_up_frame(int x, int y, int w, int h, Fl_Color c) {
+void fl_gtk_up_frame(int x, int y, int w, int h, Fl_Color c) {
   gtk_color(fl_color_average(FL_WHITE, c, 0.5));
   fl_xyline(x + 2, y + 1, x + w - 3);
   fl_yxline(x + 1, y + 2, y + h - 3);
@@ -50,8 +50,8 @@ static void gtk_up_frame(int x, int y, int w, int h, Fl_Color c) {
 }
 
 
-static void gtk_up_box(int x, int y, int w, int h, Fl_Color c) {
-  gtk_up_frame(x, y, w, h, c);
+void fl_gtk_up_box(int x, int y, int w, int h, Fl_Color c) {
+  fl_gtk_up_frame(x, y, w, h, c);
 
   gtk_color(fl_color_average(FL_WHITE, c, 0.4f));
   fl_xyline(x + 2, y + 2, x + w - 3);
@@ -71,7 +71,7 @@ static void gtk_up_box(int x, int y, int w, int h, Fl_Color c) {
 }
 
 
-static void gtk_down_frame(int x, int y, int w, int h, Fl_Color c) {
+void fl_gtk_down_frame(int x, int y, int w, int h, Fl_Color c) {
   gtk_color(fl_color_average(FL_BLACK, c, 0.5));
   fl_begin_loop();
     fl_vertex(x, y + 2);
@@ -93,8 +93,8 @@ static void gtk_down_frame(int x, int y, int w, int h, Fl_Color c) {
 }
 
 
-static void gtk_down_box(int x, int y, int w, int h, Fl_Color c) {
-  gtk_down_frame(x, y, w, h, c);
+void fl_gtk_down_box(int x, int y, int w, int h, Fl_Color c) {
+  fl_gtk_down_frame(x, y, w, h, c);
 
   gtk_color(c);
   fl_rectf(x + 3, y + 3, w - 5, h - 4);
@@ -102,7 +102,7 @@ static void gtk_down_box(int x, int y, int w, int h, Fl_Color c) {
 }
 
 
-static void gtk_thin_up_frame(int x, int y, int w, int h, Fl_Color c) {
+void fl_gtk_thin_up_frame(int x, int y, int w, int h, Fl_Color c) {
   gtk_color(fl_color_average(FL_WHITE, c, 0.6f));
   fl_xyline(x + 1, y, x + w - 2);
   fl_yxline(x, y + 1, y + h - 2);
@@ -113,8 +113,8 @@ static void gtk_thin_up_frame(int x, int y, int w, int h, Fl_Color c) {
 }
 
 
-static void gtk_thin_up_box(int x, int y, int w, int h, Fl_Color c) {
-  gtk_thin_up_frame(x, y, w, h, c);
+void fl_gtk_thin_up_box(int x, int y, int w, int h, Fl_Color c) {
+  fl_gtk_thin_up_frame(x, y, w, h, c);
 
   gtk_color(fl_color_average(FL_WHITE, c, 0.4f));
   fl_xyline(x + 1, y + 1, x + w - 2);
@@ -133,7 +133,7 @@ static void gtk_thin_up_box(int x, int y, int w, int h, Fl_Color c) {
 }
 
 
-static void gtk_thin_down_frame(int x, int y, int w, int h, Fl_Color c) {
+void fl_gtk_thin_down_frame(int x, int y, int w, int h, Fl_Color c) {
   gtk_color(fl_color_average(FL_BLACK, c, 0.4f));
   fl_xyline(x + 1, y, x + w - 2);
   fl_yxline(x, y + 1, y + h - 2);
@@ -144,8 +144,8 @@ static void gtk_thin_down_frame(int x, int y, int w, int h, Fl_Color c) {
 }
 
 
-static void gtk_thin_down_box(int x, int y, int w, int h, Fl_Color c) {
-  gtk_thin_down_frame(x, y, w, h, c);
+void fl_gtk_thin_down_box(int x, int y, int w, int h, Fl_Color c) {
+  fl_gtk_thin_down_frame(x, y, w, h, c);
 
   gtk_color(c);
   fl_rectf(x + 1, y + 1, w - 2, h - 2);
@@ -202,7 +202,7 @@ static void draw(int which, int x,int y,int w,int h, int inset)
   }
 }
 
-static void gtk_round_up_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_gtk_round_up_box(int x, int y, int w, int h, Fl_Color c) {
   gtk_color(c);
   draw(FILL,        x,   y, w,   h, 2);
 
@@ -233,7 +233,7 @@ static void gtk_round_up_box(int x, int y, int w, int h, Fl_Color c) {
   draw(CLOSED,      x,   y, w,   h, 0);
 }
 
-static void gtk_round_down_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_gtk_round_down_box(int x, int y, int w, int h, Fl_Color c) {
   gtk_color(c);
   draw(FILL,        x,   y, w,   h, 2);
 
@@ -260,7 +260,7 @@ static void gtk_round_down_box(int x, int y, int w, int h, Fl_Color c) {
 
 #else
 
-static void gtk_round_up_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_gtk_round_up_box(int x, int y, int w, int h, Fl_Color c) {
   gtk_color(c);
   fl_pie(x, y, w, h, 0.0, 360.0);
   gtk_color(fl_color_average(FL_WHITE, c, 0.5f));
@@ -272,7 +272,7 @@ static void gtk_round_up_box(int x, int y, int w, int h, Fl_Color c) {
 }
 
 
-static void gtk_round_down_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_gtk_round_down_box(int x, int y, int w, int h, Fl_Color c) {
   gtk_color(c);
   fl_pie(x, y, w, h, 0.0, 360.0);
   gtk_color(fl_color_average(FL_BLACK, c, 0.2));
@@ -283,17 +283,3 @@ static void gtk_round_down_box(int x, int y, int w, int h, Fl_Color c) {
 
 #endif
 
-Fl_Boxtype fl_define_FL_GTK_UP_BOX() {
-  fl_internal_boxtype(_FL_GTK_UP_BOX, gtk_up_box);
-  fl_internal_boxtype(_FL_GTK_DOWN_BOX, gtk_down_box);
-  fl_internal_boxtype(_FL_GTK_UP_FRAME, gtk_up_frame);
-  fl_internal_boxtype(_FL_GTK_DOWN_FRAME, gtk_down_frame);
-  fl_internal_boxtype(_FL_GTK_THIN_UP_BOX, gtk_thin_up_box);
-  fl_internal_boxtype(_FL_GTK_THIN_DOWN_BOX, gtk_thin_down_box);
-  fl_internal_boxtype(_FL_GTK_THIN_UP_FRAME, gtk_thin_up_frame);
-  fl_internal_boxtype(_FL_GTK_THIN_DOWN_FRAME, gtk_thin_down_frame);
-  fl_internal_boxtype(_FL_GTK_ROUND_UP_BOX, gtk_round_up_box);
-  fl_internal_boxtype(_FL_GTK_ROUND_DOWN_BOX, gtk_round_down_box);
-
-  return _FL_GTK_UP_BOX;
-}

--- a/src/fl_oval_box.cxx
+++ b/src/fl_oval_box.cxx
@@ -25,31 +25,35 @@
 //  BW = box shadow width
 #define BW (Fl::box_shadow_width())
 
-static void fl_oval_flat_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_oval_flat_box(int x, int y, int w, int h, Fl_Color c) {
   Fl::set_box_color(c);
   fl_pie(x, y, w, h, 0, 360);
 }
 
-static void fl_oval_frame(int x, int y, int w, int h, Fl_Color c) {
+void fl_oval_frame(int x, int y, int w, int h, Fl_Color c) {
   Fl::set_box_color(c);
   fl_arc(x, y, w, h, 0, 360);
 }
 
-static void fl_oval_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_oval_box(int x, int y, int w, int h, Fl_Color c) {
   fl_oval_flat_box(x,y,w,h,c);
   fl_oval_frame(x,y,w,h,FL_BLACK);
 }
 
-static void fl_oval_shadow_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_oval_shadow_box(int x, int y, int w, int h, Fl_Color c) {
   fl_oval_flat_box(x+BW,y+BW,w,h,FL_DARK3);
   fl_oval_box(x,y,w,h,c);
 }
 
-extern void fl_internal_boxtype(Fl_Boxtype, Fl_Box_Draw_F*);
-Fl_Boxtype fl_define_FL_OVAL_BOX() {
-  fl_internal_boxtype(_FL_OSHADOW_BOX,fl_oval_shadow_box);
-  fl_internal_boxtype(_FL_OVAL_FRAME,fl_oval_frame);
-  fl_internal_boxtype(_FL_OFLAT_BOX,fl_oval_flat_box);
-  fl_internal_boxtype(_FL_OVAL_BOX,fl_oval_box);
-  return _FL_OVAL_BOX;
+void fl_oval_focus(Fl_Boxtype bt, int x, int y, int w, int h, Fl_Color fg, Fl_Color bg) {
+  x += Fl::box_dx(bt)+1;
+  y += Fl::box_dy(bt)+1;
+  w -= Fl::box_dw(bt)+2;
+  h -= Fl::box_dh(bt)+2;
+  Fl_Color savecolor = fl_color();
+  fl_color(fl_contrast(fg, bg));
+  fl_line_style(FL_DOT);
+  fl_arc(x, y, w, h, 0, 360);
+  fl_line_style(FL_SOLID);
+  fl_color(savecolor);
 }

--- a/src/fl_oxy.cxx
+++ b/src/fl_oxy.cxx
@@ -242,7 +242,7 @@ static void oxy_draw(int x, int y, int w, int h, Fl_Color col, int typebox, bool
   int X, Y, W, H, X1, Y1;
 
   // draw bg
-  if (typebox != _FL_OXY_UP_FRAME && typebox != _FL_OXY_DOWN_FRAME) {
+  if (typebox != FL_OXY_UP_FRAME && typebox != FL_OXY_DOWN_FRAME) {
 
     X = x + 1;
     Y = y + 1;
@@ -250,24 +250,24 @@ static void oxy_draw(int x, int y, int w, int h, Fl_Color col, int typebox, bool
     H = h - 2;
 
     switch (typebox) {
-      case _FL_OXY_UP_BOX: {
+      case FL_OXY_UP_BOX: {
         _oxy_up_box_(X, Y, W, H, oxy_color(col));
         break;
       }
-      case _FL_OXY_DOWN_BOX: {
+      case FL_OXY_DOWN_BOX: {
         _oxy_down_box_(X, Y, W, H, oxy_color(col));
         break;
       }
-      case _FL_OXY_BUTTON_UP_BOX: {
+      case FL_OXY_BUTTON_UP_BOX: {
         _oxy_button_up_box_(X, Y, W, H, oxy_color(col));
         break;
       }
-      case _FL_OXY_BUTTON_DOWN_BOX: {
+      case FL_OXY_BUTTON_DOWN_BOX: {
         _oxy_button_down_box_(X, Y, W, H, oxy_color(col));
         break;
       }
-      case _FL_OXY_ROUND_UP_BOX:
-      case _FL_OXY_ROUND_DOWN_BOX:
+      case FL_OXY_ROUND_UP_BOX:
+      case FL_OXY_ROUND_DOWN_BOX:
         _oxy_rounded_box_(x, y, w, h, oxy_color(fl_color_average(col, FL_WHITE, 0.82f)));
         break;
       default: { break; }
@@ -276,31 +276,31 @@ static void oxy_draw(int x, int y, int w, int h, Fl_Color col, int typebox, bool
 
   Fl_Color leftline = col, topline = col, rightline = col, bottomline = col;
 
-  if (typebox == _FL_OXY_ROUND_UP_BOX || typebox == _FL_OXY_ROUND_DOWN_BOX) {
+  if (typebox == FL_OXY_ROUND_UP_BOX || typebox == FL_OXY_ROUND_DOWN_BOX) {
     leftline = fl_color_average(col, FL_WHITE, 0.88f);
     leftline = topline = rightline = bottomline = fl_color_average(leftline, FL_BLACK, 0.97f);
   }
 
-  else if (typebox == _FL_OXY_UP_BOX || typebox == _FL_OXY_UP_FRAME) {
+  else if (typebox == FL_OXY_UP_BOX || typebox == FL_OXY_UP_FRAME) {
     topline = fl_color_average(col, FL_BLACK, 0.95f);
     leftline = fl_color_average(col, FL_BLACK, 0.85f);
     rightline = leftline;
     bottomline = fl_color_average(col, FL_BLACK, 0.88f);
   }
 
-  else if (typebox == _FL_OXY_DOWN_BOX || typebox == _FL_OXY_DOWN_FRAME) {
+  else if (typebox == FL_OXY_DOWN_BOX || typebox == FL_OXY_DOWN_FRAME) {
     topline = fl_color_average(col, FL_BLACK, 0.88f);
     leftline = fl_color_average(col, FL_BLACK, 0.85f);
     rightline = leftline;
     bottomline = fl_color_average(col, FL_BLACK, 0.95f);
   }
 
-  else if (typebox == _FL_OXY_BUTTON_UP_BOX || typebox == _FL_OXY_BUTTON_DOWN_BOX) {
+  else if (typebox == FL_OXY_BUTTON_UP_BOX || typebox == FL_OXY_BUTTON_DOWN_BOX) {
     topline = leftline = rightline = bottomline = fl_color_average(col, FL_BLACK, 0.85f);
   }
 
   // draw border
-  if (typebox != _FL_OXY_ROUND_UP_BOX && typebox != _FL_OXY_ROUND_DOWN_BOX) {
+  if (typebox != FL_OXY_ROUND_UP_BOX && typebox != FL_OXY_ROUND_DOWN_BOX) {
     // bottom side
     fl_color(oxy_color(bottomline));
     fl_line(x + 1, y + h - 1, x + w - 2, y + h - 1);
@@ -318,24 +318,24 @@ static void oxy_draw(int x, int y, int w, int h, Fl_Color col, int typebox, bool
   // draw shadow
   if (is_shadow) {
 
-    if (typebox == _FL_OXY_ROUND_UP_BOX) {
+    if (typebox == FL_OXY_ROUND_UP_BOX) {
       topline = fl_color_average(col, FL_WHITE, 0.35f);
       bottomline = fl_color_average(col, FL_BLACK, 0.94f);
     }
 
-    else if (typebox == _FL_OXY_ROUND_DOWN_BOX) {
+    else if (typebox == FL_OXY_ROUND_DOWN_BOX) {
       topline = fl_color_average(col, FL_BLACK, 0.94f);
       bottomline = fl_color_average(col, FL_WHITE, 0.35f);
     }
 
-    else if (typebox == _FL_OXY_UP_BOX || typebox == _FL_OXY_UP_FRAME) {
+    else if (typebox == FL_OXY_UP_BOX || typebox == FL_OXY_UP_FRAME) {
       topline = fl_color_average(col, FL_WHITE, 0.35f);
       leftline = fl_color_average(col, FL_WHITE, 0.4f);
       rightline = leftline;
       bottomline = fl_color_average(col, FL_BLACK, 0.8f);
     }
 
-    else if (typebox == _FL_OXY_DOWN_BOX || typebox == _FL_OXY_DOWN_FRAME) {
+    else if (typebox == FL_OXY_DOWN_BOX || typebox == FL_OXY_DOWN_FRAME) {
       topline = fl_color_average(col, FL_BLACK, 0.8f);
       leftline = fl_color_average(col, FL_BLACK, 0.94f);
       rightline = leftline;
@@ -348,7 +348,7 @@ static void oxy_draw(int x, int y, int w, int h, Fl_Color col, int typebox, bool
     int yh2 = y + h - 2;
     int yh1 = y + h - 1;
 
-    if (typebox == _FL_OXY_UP_BOX || typebox == _FL_OXY_UP_FRAME) {
+    if (typebox == FL_OXY_UP_BOX || typebox == FL_OXY_UP_FRAME) {
       fl_color(oxy_color(topline));
       X = x + 1;
       Y = y + 1;
@@ -378,7 +378,7 @@ static void oxy_draw(int x, int y, int w, int h, Fl_Color col, int typebox, bool
       fl_line(X, Y, X1, Y1); // bottom line
     }
 
-    else if (typebox == _FL_OXY_DOWN_BOX || typebox == _FL_OXY_DOWN_FRAME) {
+    else if (typebox == FL_OXY_DOWN_BOX || typebox == FL_OXY_DOWN_FRAME) {
       fl_color(oxy_color(topline));
       X = x + 1;
       Y = y + 1;
@@ -408,7 +408,7 @@ static void oxy_draw(int x, int y, int w, int h, Fl_Color col, int typebox, bool
       fl_line(X, Y, X1, Y1); // bottom line
     }
 
-    else if (typebox == _FL_OXY_ROUND_UP_BOX || typebox == _FL_OXY_ROUND_DOWN_BOX) {
+    else if (typebox == FL_OXY_ROUND_UP_BOX || typebox == FL_OXY_ROUND_DOWN_BOX) {
 
       int Radius, smooth;
       int r_offset2; // quarter of smooth and half of smooth
@@ -438,12 +438,12 @@ static void oxy_draw(int x, int y, int w, int h, Fl_Color col, int typebox, bool
       fl_color(oxy_color(topline));
       fl_line(x + 1, yh1 - smooth - r_offset2, x + 1, y + r_offset2 + smooth);  // left side
       fl_arc(x + 1, y + 1, Radius, Radius, 90.0, 180.0);                        // left-top corner
-      if (typebox == _FL_OXY_ROUND_DOWN_BOX) {
+      if (typebox == FL_OXY_ROUND_DOWN_BOX) {
         fl_arc(x + 1, y + 1, Radius + 1, Radius + 1, 90.0, 180.0);
       }                                                                         // left-top corner (DOWN_BOX)
       fl_line(x + smooth + r_offset2, y + 1, xw1 - smooth - r_offset2, y + 1);  // top side
       fl_arc(xw1 - Radius, y + 1, Radius, Radius, 00.0, 90.0);                  // right-top corner
-      if (typebox == _FL_OXY_ROUND_DOWN_BOX) {
+      if (typebox == FL_OXY_ROUND_DOWN_BOX) {
         fl_arc(xw1 - Radius, y + 1, Radius + 1, Radius + 1, 00.0, 90.0);
       }                                                                         // right-top corner (DOWN_BOX)
       fl_line(xw2, y + smooth + r_offset2, xw2, yh1 - smooth - r_offset2);      // right side
@@ -451,12 +451,12 @@ static void oxy_draw(int x, int y, int w, int h, Fl_Color col, int typebox, bool
       fl_arc(xw1 - Radius, yh1 - Radius, Radius, Radius, 340.0, 360.0);         // right-bottom
       fl_color(oxy_color(bottomline));
       fl_arc(x + 1, yh1 - Radius, Radius, Radius, 200.0, 270.0);                // left-bottom corner
-      if (typebox == _FL_OXY_ROUND_UP_BOX) {
+      if (typebox == FL_OXY_ROUND_UP_BOX) {
         fl_arc(x + 1, yh1 - Radius, Radius + 1, Radius + 1, 200.0, 270.0);
       }                                                                         // left-bottom corner (UP_BOX)
       fl_line(xw1 - smooth - r_offset2, yh2, x + smooth + r_offset2, yh2);      // bottom side
       fl_arc(xw1 - Radius, yh1 - Radius, Radius, Radius, 270.0, 340.0);         // right-bottom corner
-      if (typebox == _FL_OXY_ROUND_UP_BOX) {
+      if (typebox == FL_OXY_ROUND_UP_BOX) {
         fl_arc(xw1 - Radius, yh1 - Radius, Radius + 1, Radius + 1, 270.0, 340.0);
       } // right-bottom corner
     }
@@ -466,60 +466,39 @@ static void oxy_draw(int x, int y, int w, int h, Fl_Color col, int typebox, bool
 } // end `static void oxy_draw(...)'
 
 
-void button_up_box(int x, int y, int w, int h, Fl_Color col) {
-  oxy_draw(x, y, w, h, col, _FL_OXY_BUTTON_UP_BOX, true);
+void fl_oxy_button_up_box(int x, int y, int w, int h, Fl_Color col) {
+  oxy_draw(x, y, w, h, col, FL_OXY_BUTTON_UP_BOX, true);
 }
-void button_down_box(int x, int y, int w, int h, Fl_Color col) {
-  oxy_draw(x, y, w, h, col, _FL_OXY_BUTTON_DOWN_BOX, true);
+void fl_oxy_button_down_box(int x, int y, int w, int h, Fl_Color col) {
+  oxy_draw(x, y, w, h, col, FL_OXY_BUTTON_DOWN_BOX, true);
 }
-void up_box(int x, int y, int w, int h, Fl_Color col) {
-  oxy_draw(x, y, w, h, col, _FL_OXY_UP_BOX, true);
+void fl_oxy_up_box(int x, int y, int w, int h, Fl_Color col) {
+  oxy_draw(x, y, w, h, col, FL_OXY_UP_BOX, true);
 }
-void down_box(int x, int y, int w, int h, Fl_Color col) {
-  oxy_draw(x, y, w, h, col, _FL_OXY_DOWN_BOX, true);
+void fl_oxy_down_box(int x, int y, int w, int h, Fl_Color col) {
+  oxy_draw(x, y, w, h, col, FL_OXY_DOWN_BOX, true);
 }
-void thin_up_box(int x, int y, int w, int h, Fl_Color col) {
-  oxy_draw(x, y, w, h, col, _FL_OXY_UP_BOX, false);
+void fl_oxy_thin_up_box(int x, int y, int w, int h, Fl_Color col) {
+  oxy_draw(x, y, w, h, col, FL_OXY_UP_BOX, false);
 }
-void thin_down_box(int x, int y, int w, int h, Fl_Color col) {
-  oxy_draw(x, y, w, h, col, _FL_OXY_DOWN_BOX, false);
+void fl_oxy_thin_down_box(int x, int y, int w, int h, Fl_Color col) {
+  oxy_draw(x, y, w, h, col, FL_OXY_DOWN_BOX, false);
 }
-void up_frame(int x, int y, int w, int h, Fl_Color col) {
-  oxy_draw(x, y, w, h, col, _FL_OXY_UP_FRAME, true);
+void fl_oxy_up_frame(int x, int y, int w, int h, Fl_Color col) {
+  oxy_draw(x, y, w, h, col, FL_OXY_UP_FRAME, true);
 }
-void down_frame(int x, int y, int w, int h, Fl_Color col) {
-  oxy_draw(x, y, w, h, col, _FL_OXY_DOWN_FRAME, true);
+void fl_oxy_down_frame(int x, int y, int w, int h, Fl_Color col) {
+  oxy_draw(x, y, w, h, col, FL_OXY_DOWN_FRAME, true);
 }
-void thin_up_frame(int x, int y, int w, int h, Fl_Color col) {
-  oxy_draw(x, y, w, h, col, _FL_OXY_UP_FRAME, false);
+void fl_oxy_thin_up_frame(int x, int y, int w, int h, Fl_Color col) {
+  oxy_draw(x, y, w, h, col, FL_OXY_UP_FRAME, false);
 }
-void thin_down_frame(int x, int y, int w, int h, Fl_Color col) {
-  oxy_draw(x, y, w, h, col, _FL_OXY_DOWN_FRAME, false);
+void fl_oxy_thin_down_frame(int x, int y, int w, int h, Fl_Color col) {
+  oxy_draw(x, y, w, h, col, FL_OXY_DOWN_FRAME, false);
 }
-void round_up_box(int x, int y, int w, int h, Fl_Color col) {
-  oxy_draw(x, y, w, h, col, _FL_OXY_ROUND_UP_BOX, true);
+void fl_oxy_round_up_box(int x, int y, int w, int h, Fl_Color col) {
+  oxy_draw(x, y, w, h, col, FL_OXY_ROUND_UP_BOX, true);
 }
-void round_down_box(int x, int y, int w, int h, Fl_Color col) {
-  oxy_draw(x, y, w, h, col, _FL_OXY_ROUND_DOWN_BOX, true);
-}
-
-
-extern void fl_internal_boxtype(Fl_Boxtype, Fl_Box_Draw_F *);
-
-Fl_Boxtype fl_define_FL_OXY_UP_BOX() {
-
-  fl_internal_boxtype(_FL_OXY_UP_BOX, up_box);
-  fl_internal_boxtype(_FL_OXY_DOWN_BOX, down_box);
-  fl_internal_boxtype(_FL_OXY_UP_FRAME, up_frame);
-  fl_internal_boxtype(_FL_OXY_DOWN_FRAME, down_frame);
-  fl_internal_boxtype(_FL_OXY_THIN_UP_BOX, thin_up_box);
-  fl_internal_boxtype(_FL_OXY_THIN_DOWN_BOX, thin_down_box);
-  fl_internal_boxtype(_FL_OXY_THIN_UP_FRAME, thin_up_frame);
-  fl_internal_boxtype(_FL_OXY_THIN_DOWN_FRAME, thin_down_frame);
-  fl_internal_boxtype(_FL_OXY_ROUND_UP_BOX, round_up_box);
-  fl_internal_boxtype(_FL_OXY_ROUND_DOWN_BOX, round_down_box);
-  fl_internal_boxtype(_FL_OXY_BUTTON_UP_BOX, button_up_box);
-  fl_internal_boxtype(_FL_OXY_BUTTON_DOWN_BOX, button_down_box);
-
-  return _FL_OXY_UP_BOX;
+void fl_oxy_round_down_box(int x, int y, int w, int h, Fl_Color col) {
+  oxy_draw(x, y, w, h, col, FL_OXY_ROUND_DOWN_BOX, true);
 }

--- a/src/fl_plastic.cxx
+++ b/src/fl_plastic.cxx
@@ -268,7 +268,7 @@ static void shade_round(int x, int y, int w, int h, const char *c, Fl_Color bc) 
 }
 
 
-static void up_frame(int x, int y, int w, int h, Fl_Color c) {
+void fl_plastic_up_frame(int x, int y, int w, int h, Fl_Color c) {
   frame_rect(x, y, w, h - 1, "KLDIIJLM", c);
 }
 
@@ -290,7 +290,7 @@ static void narrow_thin_box(int x, int y, int w, int h, Fl_Color c) {
 }
 
 
-static void thin_up_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_plastic_thin_up_box(int x, int y, int w, int h, Fl_Color c) {
 #ifdef USE_OLD_PLASTIC_BOX
   shade_rect(x + 2, y + 2, w - 4, h - 5, "RVQNOPQRSTUVWVQ", c);
   up_frame(x, y, w, h, c);
@@ -305,7 +305,7 @@ static void thin_up_box(int x, int y, int w, int h, Fl_Color c) {
 }
 
 
-static void up_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_plastic_up_box(int x, int y, int w, int h, Fl_Color c) {
 #ifdef USE_OLD_PLASTIC_BOX
   shade_rect(x + 2, y + 2, w - 4, h - 5, "RVQNOPQRSTUVWVQ", c);
   up_frame(x, y, w, h, c);
@@ -314,27 +314,27 @@ static void up_box(int x, int y, int w, int h, Fl_Color c) {
     shade_rect(x + 1, y + 1, w - 2, h - 3, "RVQNOPQRSTUVWVQ", c);
     frame_rect(x, y, w, h - 1, "IJLM", c);
   } else {
-    thin_up_box(x, y, w, h, c);
+    fl_plastic_thin_up_box(x, y, w, h, c);
   }
 #endif // USE_OLD_PLASTIC_BOX
 }
 
 
-static void up_round(int x, int y, int w, int h, Fl_Color c) {
+void fl_plastic_up_round(int x, int y, int w, int h, Fl_Color c) {
   shade_round(x, y, w, h, "RVQNOPQRSTUVWVQ", c);
   frame_round(x, y, w, h, "IJLM", c);
 }
 
 
-static void down_frame(int x, int y, int w, int h, Fl_Color c) {
+void fl_plastic_down_frame(int x, int y, int w, int h, Fl_Color c) {
   frame_rect(x, y, w, h - 1, "LLLLTTRR", c);
 }
 
 
-static void down_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_plastic_down_box(int x, int y, int w, int h, Fl_Color c) {
   if (w > 6 && h > 6) {
     shade_rect(x + 2, y + 2, w - 4, h - 5, "STUVWWWVT", c);
-    down_frame(x, y, w, h, c);
+    fl_plastic_down_frame(x, y, w, h, c);
   }
   else {
     narrow_thin_box(x, y, w, h, c);
@@ -342,24 +342,8 @@ static void down_box(int x, int y, int w, int h, Fl_Color c) {
 }
 
 
-static void down_round(int x, int y, int w, int h, Fl_Color c) {
+void fl_plastic_down_round(int x, int y, int w, int h, Fl_Color c) {
   shade_round(x, y, w, h, "STUVWWWVT", c);
   frame_round(x, y, w, h, "IJLM", c);
 }
 
-
-extern void fl_internal_boxtype(Fl_Boxtype, Fl_Box_Draw_F*);
-
-
-Fl_Boxtype fl_define_FL_PLASTIC_UP_BOX() {
-  fl_internal_boxtype(_FL_PLASTIC_UP_BOX, up_box);
-  fl_internal_boxtype(_FL_PLASTIC_DOWN_BOX, down_box);
-  fl_internal_boxtype(_FL_PLASTIC_UP_FRAME, up_frame);
-  fl_internal_boxtype(_FL_PLASTIC_DOWN_FRAME, down_frame);
-  fl_internal_boxtype(_FL_PLASTIC_THIN_UP_BOX, thin_up_box);
-  fl_internal_boxtype(_FL_PLASTIC_THIN_DOWN_BOX, down_box);
-  fl_internal_boxtype(_FL_PLASTIC_ROUND_UP_BOX, up_round);
-  fl_internal_boxtype(_FL_PLASTIC_ROUND_DOWN_BOX, down_round);
-
-  return _FL_PLASTIC_UP_BOX;
-}

--- a/src/fl_round_box.cxx
+++ b/src/fl_round_box.cxx
@@ -1,7 +1,7 @@
 //
 // Round box drawing routines for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2010 by Bill Spitzak and others.
+// Copyright 1998-2014 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this
@@ -108,9 +108,14 @@ void fl_round_up_box(int x, int y, int w, int h, Fl_Color bgcolor) {
   draw(CLOSED,      x,   y, w,   h, 0, (Fl_Color)g[(int)'A']);
 }
 
-extern void fl_internal_boxtype(Fl_Boxtype, Fl_Box_Draw_F*);
-Fl_Boxtype fl_define_FL_ROUND_UP_BOX() {
-  fl_internal_boxtype(_FL_ROUND_DOWN_BOX, fl_round_down_box);
-  fl_internal_boxtype(_FL_ROUND_UP_BOX, fl_round_up_box);
-  return _FL_ROUND_UP_BOX;
+void fl_round_focus(Fl_Boxtype bt, int x, int y, int w, int h, Fl_Color fg, Fl_Color bg) {
+  x += Fl::box_dx(bt);
+  y += Fl::box_dy(bt);
+  w -= Fl::box_dw(bt);
+  h -= Fl::box_dh(bt);
+  Fl_Color savecolor = fl_color();
+  fl_line_style(FL_DOT);
+  draw(CLOSED, x, y, w, h, 0, fl_contrast(fg, bg));
+  fl_line_style(FL_SOLID);
 }
+

--- a/src/fl_rounded_box.cxx
+++ b/src/fl_rounded_box.cxx
@@ -37,23 +37,23 @@ static void rbox(int fill, int x, int y, int w, int h) {
     fl_rounded_rect(x, y, w, h, rs);
 }
 
-static void fl_rflat_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_rflat_box(int x, int y, int w, int h, Fl_Color c) {
   Fl::set_box_color(c);
   rbox(1, x, y, w, h); rbox(0, x, y, w, h);
 }
 
-static void fl_rounded_frame(int x, int y, int w, int h, Fl_Color c) {
+void fl_rounded_frame(int x, int y, int w, int h, Fl_Color c) {
   Fl::set_box_color(c);
   rbox(0, x, y, w, h);
 }
 
-static void fl_rounded_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_rounded_box(int x, int y, int w, int h, Fl_Color c) {
   Fl::set_box_color(c);
   rbox(1, x, y, w, h);
   fl_color(FL_BLACK); rbox(0, x, y, w, h);
 }
 
-static void fl_rshadow_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_rshadow_box(int x, int y, int w, int h, Fl_Color c) {
   // draw shadow:
   fl_color(FL_DARK3);
   rbox(1, x+BW, y+BW, w, h);
@@ -62,20 +62,15 @@ static void fl_rshadow_box(int x, int y, int w, int h, Fl_Color c) {
   fl_rounded_box(x, y, w, h, c);
 }
 
-extern void fl_internal_boxtype(Fl_Boxtype, Fl_Box_Draw_F*);
-
-Fl_Boxtype fl_define_FL_ROUNDED_BOX() {
-  fl_internal_boxtype(_FL_ROUNDED_FRAME, fl_rounded_frame);
-  fl_internal_boxtype(_FL_ROUNDED_BOX, fl_rounded_box);
-  return _FL_ROUNDED_BOX;
-}
-
-Fl_Boxtype fl_define_FL_RFLAT_BOX() {
-  fl_internal_boxtype(_FL_RFLAT_BOX, fl_rflat_box);
-  return _FL_RFLAT_BOX;
-}
-
-Fl_Boxtype fl_define_FL_RSHADOW_BOX() {
-  fl_internal_boxtype(_FL_RSHADOW_BOX, fl_rshadow_box);
-  return _FL_RSHADOW_BOX;
+void fl_rounded_focus(Fl_Boxtype bt, int x, int y, int w, int h, Fl_Color fg, Fl_Color bg) {
+  x += Fl::box_dx(bt);
+  y += Fl::box_dy(bt);
+  w -= Fl::box_dw(bt)+1;
+  h -= Fl::box_dh(bt)+1;
+  Fl_Color savecolor = fl_color();
+  fl_color(fl_contrast(fg, bg));
+  fl_line_style(FL_DOT);
+  rbox(0, x+1, y+1, w-1, h-1);
+  fl_line_style(FL_SOLID);
+  fl_color(savecolor);
 }

--- a/src/fl_shadow_box.cxx
+++ b/src/fl_shadow_box.cxx
@@ -22,7 +22,7 @@
 //  BW = box shadow width
 #define BW (Fl::box_shadow_width())
 
-static void fl_shadow_frame(int x, int y, int w, int h, Fl_Color c) {
+void fl_shadow_frame(int x, int y, int w, int h, Fl_Color c) {
   fl_color(FL_DARK3);
   fl_rectf(x+BW, y+h-BW,  w - BW, BW);
   fl_rectf(x+w-BW,  y+BW, BW,  h - BW);
@@ -30,15 +30,9 @@ static void fl_shadow_frame(int x, int y, int w, int h, Fl_Color c) {
   fl_rect(x,y,w-BW,h-BW);
 }
 
-static void fl_shadow_box(int x, int y, int w, int h, Fl_Color c) {
+void fl_shadow_box(int x, int y, int w, int h, Fl_Color c) {
   Fl::set_box_color(c);
   fl_rectf(x+1,y+1,w-2-BW,h-2-BW);
   fl_shadow_frame(x,y,w,h,FL_GRAY0);
 }
 
-extern void fl_internal_boxtype(Fl_Boxtype, Fl_Box_Draw_F*);
-Fl_Boxtype fl_define_FL_SHADOW_BOX() {
-  fl_internal_boxtype(_FL_SHADOW_FRAME, fl_shadow_frame);
-  fl_internal_boxtype(_FL_SHADOW_BOX, fl_shadow_box);
-  return _FL_SHADOW_BOX;
-}


### PR DESCRIPTION
[2145](https://www.fltk.org/str.php?L2145+P0+S-2+C0+I0+O0+E0+V1.+Q)

This is a big PR and it needs some explanation. The STR itself asks to fix the issue that the focus frame on some box types is just a rectangle and does not match the graphics of the frame or box. I fixed this by adding a focus-drawing callback to the box type array. That part was a few lines of code.

As a bigger refactoring, I removed all the box types starting with an underline, like `_FL_PLASTIC_UP_BOX` and replaced the no-underscore `FL_PLASTIC_UP_BOX` macros with direct enumeration values. The original code jumped through some really interesting hoops that helped linkers optimize unused code away. If an app never called `_FL_PLASTIC_UP_BOX`, the code to draw the plastic boxes would never be referenced, and a good linker could optimize and remove all plastic drawing routines.

Switch to 2024, and FLTK offers `-scheme` as a command line argument. This means that we always must link all possible drawing code, including the Plastic scheme and all others. So the whole macro setup and dynamic creation of the box type array is obsolete and wastes time and space, and adds complexity.

So I removed all the code that is no longer needed. Comments welcome.