### PR TITLE
use MAC_OS_X_VERSION_MIN_REQUIRED to avoid building error when using …

### DIFF
--- a/src/Fl_Native_File_Chooser_MAC.mm
+++ b/src/Fl_Native_File_Chooser_MAC.mm
@@ -28,7 +28,7 @@
 #include <FL/fl_string_functions.h>
 #define MAXFILTERS      80
 #import <Cocoa/Cocoa.h>
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_11_0
 #  import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #endif
 
@@ -532,7 +532,7 @@ static char *prepareMacFilter(int count, const char *filter, char **patterns) {
 - (void)control_allowed_types:(const char *)p
 {
   NSString *ext = [NSString stringWithUTF8String:p];
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_11_0
   if (fl_mac_os_version >= 110000) {
     UTType *type = [UTType typeWithFilenameExtension:ext]; // 11.0 + framework UniformTypeIdentifiers
     [dialog setAllowedContentTypes:[NSArray arrayWithObject:type]]; // 11.0


### PR DESCRIPTION
…newer sdk and setting old target


> MAC_OS_X_VERSION_MIN_REQUIRED specifies the earliest OS version you support, and corresponds to MACOSX_DEPLOYMENT_TARGET in your project/ target configuration.

> MAC_OS_X_VERSION_MAX_ALLOWED specifies the maximum OS version your code knows about, and corresponds to SDKROOT in your project/target configuration.