### PR TITLE
find_shortcut(): fix testing of multi-label alt shortcuts

### DIFF
--- a/src/Fl_Menu.cxx
+++ b/src/Fl_Menu.cxx
@@ -1148,6 +1148,8 @@ const Fl_Menu_Item* Fl_Menu_Item::popup(
   return pulldown(X, Y, 0, 0, picked, menu_button, title ? &dummy : 0);
 }
 
+#define IS_SPECIAL_LABELTYPE(t) ((t) == _FL_MULTI_LABEL || (t) == _FL_ICON_LABEL || (t) == _FL_IMAGE_LABEL)
+
 /**
   Search only the top level menu for a shortcut.
   Either &x in the label or the shortcut fields are used.
@@ -1165,7 +1167,13 @@ const Fl_Menu_Item* Fl_Menu_Item::find_shortcut(int* ip, const bool require_alt)
   if (m) for (int ii = 0; m->text; m = next_visible_or_not(m), ii++) {
     if (m->active()) {
       if (Fl::test_shortcut(m->shortcut_)
-         || Fl_Widget::test_shortcut(m->text, require_alt)) {
+         || (!IS_SPECIAL_LABELTYPE(m->labeltype_) && Fl_Widget::test_shortcut(m->text, require_alt))
+         || (m->labeltype_ == _FL_MULTI_LABEL
+             && !IS_SPECIAL_LABELTYPE(((Fl_Multi_Label*)m->text)->typea)
+             && Fl_Widget::test_shortcut(((Fl_Multi_Label*)m->text)->labela, require_alt))
+         || (m->labeltype_ == _FL_MULTI_LABEL
+             && !IS_SPECIAL_LABELTYPE(((Fl_Multi_Label*)m->text)->typeb)
+             && Fl_Widget::test_shortcut(((Fl_Multi_Label*)m->text)->labelb, require_alt))) {
         if (ip) *ip=ii;
         return m;
       }
@@ -1173,6 +1181,8 @@ const Fl_Menu_Item* Fl_Menu_Item::find_shortcut(int* ip, const bool require_alt)
   }
   return 0;
 }
+
+#undef IS_SPECIAL_LABELTYPE
 
 // Recursive search of all submenus for anything with this key as a
 // shortcut.  Only uses the shortcut field, ignores &x in the labels:

--- a/src/Fl_Menu.cxx
+++ b/src/Fl_Menu.cxx
@@ -1148,7 +1148,9 @@ const Fl_Menu_Item* Fl_Menu_Item::popup(
   return pulldown(X, Y, 0, 0, picked, menu_button, title ? &dummy : 0);
 }
 
-#define IS_SPECIAL_LABELTYPE(t) ((t) == _FL_MULTI_LABEL || (t) == _FL_ICON_LABEL || (t) == _FL_IMAGE_LABEL)
+static bool is_special_labeltype(uchar t) {
+  return t == _FL_MULTI_LABEL || t == _FL_ICON_LABEL || t == _FL_IMAGE_LABEL;
+}
 
 /**
   Search only the top level menu for a shortcut.
@@ -1167,12 +1169,12 @@ const Fl_Menu_Item* Fl_Menu_Item::find_shortcut(int* ip, const bool require_alt)
   if (m) for (int ii = 0; m->text; m = next_visible_or_not(m), ii++) {
     if (m->active()) {
       if (Fl::test_shortcut(m->shortcut_)
-         || (!IS_SPECIAL_LABELTYPE(m->labeltype_) && Fl_Widget::test_shortcut(m->text, require_alt))
+         || (!is_special_labeltype(m->labeltype_) && Fl_Widget::test_shortcut(m->text, require_alt))
          || (m->labeltype_ == _FL_MULTI_LABEL
-             && !IS_SPECIAL_LABELTYPE(((Fl_Multi_Label*)m->text)->typea)
+             && !is_special_labeltype(((Fl_Multi_Label*)m->text)->typea)
              && Fl_Widget::test_shortcut(((Fl_Multi_Label*)m->text)->labela, require_alt))
          || (m->labeltype_ == _FL_MULTI_LABEL
-             && !IS_SPECIAL_LABELTYPE(((Fl_Multi_Label*)m->text)->typeb)
+             && !is_special_labeltype(((Fl_Multi_Label*)m->text)->typeb)
              && Fl_Widget::test_shortcut(((Fl_Multi_Label*)m->text)->labelb, require_alt))) {
         if (ip) *ip=ii;
         return m;
@@ -1181,8 +1183,6 @@ const Fl_Menu_Item* Fl_Menu_Item::find_shortcut(int* ip, const bool require_alt)
   }
   return 0;
 }
-
-#undef IS_SPECIAL_LABELTYPE
 
 // Recursive search of all submenus for anything with this key as a
 // shortcut.  Only uses the shortcut field, ignores &x in the labels:


### PR DESCRIPTION
This PR contains two bug fixes.

**First:** The original line of code (`Fl_Widget::test_shortcut(m->text, require_alt)`) unconditionally treated `m->text` as a `char *`.

This is invalid for "special" label types (_FL_MULTI_LABEL, _FL_ICON_LABEL, and _FL_IMAGE_LABEL) and would result in parsing a Fl_Multi_Label, Fl_File_Icon, or Fl_Image (etc) object as a char array, which has unpredictable results.

This was fixed by checking that the label type is not a special label type before calling `test_shortcut(m->text, require_alt)`.

**Second:** If the label type is _FL_MULTI_LABEL, the text in labela and labelb were not being processed for alt shortcuts _despite being drawn with the appropriate alt underlines_. (This was the bug that I noticed that led me here.)

This was fixed by also calling `test_shortcut()` with labela and/or labelb (if the label is not a special label type).

For now, this is not done recursively (ie, if labela or labelb is itself a Fl_Multi_Label, we don't process the nested labels any further). I wanted to get opinions on the general fix first. But if a recursive solution would be best, I can do that.

Also feel free to let me know of any docs or tests you would like to see updated.

P.S. This raises an interesting question IMO about `FL_FREE_LABELTYPE`. Should user-defined label types be assumed to be normal labels and not special labels?