### PR TITLE
gl_draw: fix drawing of text outside of viewport

### DIFF
--- a/src/gl_draw.cxx
+++ b/src/gl_draw.cxx
@@ -510,6 +510,11 @@ void Fl_Gl_Window_Driver::draw_string_legacy(const char* str, int n)
 /** draws a utf8 string using an OpenGL texture */
 void Fl_Gl_Window_Driver::draw_string_with_texture(const char* str, int n)
 {
+  // Check if the raster pos is valid.
+  // If it's not, then drawing it results in undefined behaviour (#1006, #1007).
+  GLint valid;
+  glGetIntegerv(GL_CURRENT_RASTER_POSITION_VALID, &valid);
+  if (!valid) return;
   Fl_Gl_Window *gwin = Fl_Window::current()->as_gl_window();
   gl_scale = (gwin ? gwin->pixels_per_unit() : 1);
   if (!gl_fifo) gl_fifo = new gl_texture_fifo();


### PR DESCRIPTION
The function responsible for binding and displaying the prepared text texture is `gl_texture_fifo::display_texture`, but it doesn't check for the validity (inside the viewport in this case) of the raster position `GL_CURRENT_RASTER_POSITION_VALID`. When it is not valid, then drawing the raster results in undefined behaviour:

> The object coordinates presented by glRasterPos are treated just like those of a glVertex command: They are transformed by the current modelview and projection matrices and passed to the clipping stage. If the vertex is not culled, then it is projected and scaled to window coordinates, which become the new current raster position, and the GL_CURRENT_RASTER_POSITION_VALID flag is set. If the vertex is culled, then the valid bit is cleared and the current raster position and associated color and texture coordinates are undefined.

https://linux.die.net/man/3/glrasterpos

This PR adds a check for validity of the raster pos. If it's not valid, return before doing anything. This fixes #1006  for me. 