### PR TITLE
GDI: fix StretchBlt mode setting

### DIFF
--- a/src/drivers/GDI/Fl_GDI_Graphics_Driver_image.cxx
+++ b/src/drivers/GDI/Fl_GDI_Graphics_Driver_image.cxx
@@ -619,7 +619,7 @@ void Fl_GDI_Graphics_Driver::draw_rgb(Fl_RGB_Image *rgb, int XP, int YP, int WP,
   if ( (rgb->d() % 2) == 0 ) {
     alpha_blend_(this->floor(XP), this->floor(YP), WP, HP, new_gc, 0, 0, rgb->data_w(), rgb->data_h());
   } else {
-    SetStretchBltMode(gc_, HALFTONE);
+    SetStretchBltMode(gc_, (Fl_Image::scaling_algorithm() == FL_RGB_SCALING_BILINEAR ? HALFTONE : BLACKONWHITE));
     StretchBlt(gc_, this->floor(XP), this->floor(YP), WP, HP, new_gc, 0, 0, rgb->data_w(), rgb->data_h(), SRCCOPY);
   }
   RestoreDC(new_gc, save);


### PR DESCRIPTION
This PR adds a check for `Fl_Image::scaling_algorithm()` in the GDI graphics driver (src/drivers/GDI/Fl_GDI_Graphics_Driver_image.cxx in function `Fl_GDI_Graphics_Driver::draw_rgb`)

Currently, the mode for `StretchBlt` is set to `HALFTONE` at all times, which I guess can be described as _bilinear we have at home_. Now, if the scaling algorithm is set to nearest, the mode is set to `BLACKONWHITE` which is nearest in GDI parlance I guess.
This fixes #1023 for me.