### PR TITLE
Submenus with no callback enter their submenu instead of closing the whole menu

### DIFF
--- a/src/Fl_MacOS_Sys_Menu_Bar.mm
+++ b/src/Fl_MacOS_Sys_Menu_Bar.mm
@@ -378,7 +378,9 @@ static void createSubMenu( NSMenu *mh, pFl_Menu_Item &mm,  const Fl_Menu_Item *m
       mm = mm->next(0);
       continue;
     }
-    miCnt = [FLMenuItem addNewItem:mm menu:submenu action:selector];
+    miCnt = [FLMenuItem addNewItem:mm menu:submenu
+                            action:( (mm->flags & (FL_SUBMENU+FL_SUBMENU_POINTER) && !mm->callback()) ? nil : selector)
+            ];
     setMenuFlags( submenu, miCnt, mm );
     setMenuShortcut( submenu, miCnt, mm );
     if (mitem && (mm->flags & FL_MENU_INACTIVE || mitem->flags & FL_MENU_INACTIVE)) {

--- a/src/Fl_Menu.cxx
+++ b/src/Fl_Menu.cxx
@@ -821,6 +821,7 @@ int menuwindow::handle_part1(int e) {
       }
       return 1;
     case FL_Right:
+    RIGHT:
       if (pp.menubar && (pp.menu_number<=0 || (pp.menu_number == pp.nummenus-1)))
         forward(0);
       else if (pp.menu_number < pp.nummenus-1) forward(pp.menu_number+1);
@@ -833,6 +834,11 @@ int menuwindow::handle_part1(int e) {
     case FL_Enter:
     case FL_KP_Enter:
     case ' ':
+      // if the current item is a submenu with no callback,
+      // simulate FL_Right to enter the submenu
+      if (pp.current_item && (!pp.menubar || pp.menu_number > 0) &&
+          pp.current_item->activevisible() && pp.current_item->submenu() && !pp.current_item->callback_)
+        goto RIGHT;
       pp.state = DONE_STATE;
       return 1;
     case FL_Escape:
@@ -922,8 +928,9 @@ int menuwindow::handle_part1(int e) {
         pp.p[pp.menu_number]->redraw();
       } else
 #endif
-      // do nothing if they try to pick inactive items
-      if (!pp.current_item || pp.current_item->activevisible())
+      // do nothing if they try to pick an inactive item, or a submenu with no callback
+      if (!pp.current_item || (pp.current_item->activevisible() &&
+         (!pp.current_item->submenu() || pp.current_item->callback_ || (pp.menubar && pp.menu_number <= 0))))
         pp.state = DONE_STATE;
     }
     return 1;


### PR DESCRIPTION
Based on discussion in #1041

This PR includes the following changes:

1. Keep the menu open if a submenu with no callback is clicked.
   - This change was applied to both the FLTK menubar and the Mac sys menubar.
3. Enter the submenu if Enter or Space is hit on a submenu with no callback.
   - This change was only applied to the FLTK menubar. This is already the behavior of the Mac sys menubar.

These modifications are not applied to top-level menubar menu items, so Enter, Space, and mouse click still toggle the menu for top-level items.

I think this is more user-friendly, and is pretty common among menu systems, including the Mac sys menubar.

Apply this patch to test/menubar.cxx to test out a submenu _with_ a callback (can easily be tested with both the FLTK menubar and the Mac sys menubar):

```diff
diff --git a/test/menubar.cxx b/test/menubar.cxx
index a0424732d..fba4d6aa5 100644
--- a/test/menubar.cxx
+++ b/test/menubar.cxx
@@ -56,6 +56,10 @@ void test_cb(Fl_Widget* w, void*) {
     G_tty->printf("%s\n", m->label());
 }
 
+void test_cb2(Fl_Widget* w, void*) {
+  G_tty->printf("Submenu test\n");
+}
+
 void quit_cb(Fl_Widget*, void*) {exit(0);}
 
 Fl_Menu_Item hugemenu[100];
@@ -84,7 +88,7 @@ Fl_Menu_Item menutable[] = {
     {"shortcut",FL_ALT+FL_SHIFT+FL_F+1},
     {"shortcut",FL_ALT+FL_CTRL+FL_F+1},
     {"shortcut",FL_ALT+FL_SHIFT+FL_CTRL+FL_F+1, 0,0, FL_MENU_DIVIDER},
-    {"&Submenus", FL_ALT+'S',   0, (void*)"Submenu1", FL_SUBMENU},
+    {"&Submenus", FL_ALT+'S',   test_cb2, (void*)"Submenu1", FL_SUBMENU},
       {"A very long menu item"},
       {"&submenu",FL_CTRL+'S',  0, (void*)"submenu2", FL_SUBMENU},
         {"item 1"},
```

Feel free to defer this until after 1.4.0, if the implications of this change need to be ironed out first. But since this change isn't backwards compatible, strictly speaking, it would be useful to have this change in 1.4.0 rather than 1.4.x.
I think the "risk" for existing 1.3-based applications is very small, but not non-existent.