### PR TITLE
Add support for forward and back mouse buttons on macOS and Windows

### DIFF
--- a/src/Fl_cocoa.mm
+++ b/src/Fl_cocoa.mm
@@ -1046,7 +1046,7 @@ static void cocoaMagnifyHandler(NSEvent *theEvent)
  */
 static void cocoaMouseHandler(NSEvent *theEvent)
 {
-  static int keysym[] = { 0, FL_Button+1, FL_Button+3, FL_Button+2 };
+  static int keysym[] = { 0, FL_Button+1, FL_Button+3, FL_Button+2, FL_Button+8, FL_Button+9 };
   static int px, py;
 
   fl_lock_function();

--- a/src/Fl_win32.cxx
+++ b/src/Fl_win32.cxx
@@ -1347,6 +1347,21 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
       case WM_RBUTTONUP:
         mouse_event(window, 2, 3, wParam, lParam);
         return 0;
+      case WM_XBUTTONDOWN: {
+        int xbutton = GET_XBUTTON_WPARAM(wParam) == XBUTTON1 ? 8 : 9;
+        mouse_event(window, 0, xbutton, wParam, lParam);
+        return 0;
+      }
+      case WM_XBUTTONDBLCLK: {
+        int xbutton = GET_XBUTTON_WPARAM(wParam) == XBUTTON1 ? 8 : 9;
+        mouse_event(window, 1, xbutton, wParam, lParam);
+        return 0;
+      }
+      case WM_XBUTTONUP: {
+        int xbutton = GET_XBUTTON_WPARAM(wParam) == XBUTTON1 ? 8 : 9;
+        mouse_event(window, 2, xbutton, wParam, lParam);
+        return 0;
+      }
 
       case WM_MOUSEMOVE:
 #ifdef USE_TRACK_MOUSE


### PR DESCRIPTION
I've been working on adding forward and back button support for TigerVNC.

This patch will add support for these mouse buttons on macOS and Windows. On X11, these buttons map to 8 and 9.

I also have backports to branch 1.3: https://github.com/CendioHalim/fltk/commit/971e25416479ac33966eea2561a42096313de149 https://github.com/CendioHalim/fltk/commit/0cff6ec1519a387991c2adedaaf57aace7db03d8

Tested this with TigerVNC on Windows 10, 11, and macOS 14.5