### PR TITLE
Fix bug in Fl_Text_Display when tab is followed by multibyte char

### DIFF
--- a/src/Fl_Text_Display.cxx
+++ b/src/Fl_Text_Display.cxx
@@ -2139,7 +2139,7 @@ int Fl_Text_Display::handle_vline(
             // find x pos inside block
             free(lineStr);
             if (cursor_pos && (startX+w/2<rightClip))  // STR #2788
-              return lineStartPos + startIndex + len;  // STR #2788
+              return lineStartPos + startIndex + 1;  // STR #2788
             return lineStartPos + startIndex;
           }
         } else {


### PR DESCRIPTION
The issue seems to have been introduced in https://github.com/fltk/fltk/commit/bc42454074073803ad06ca4faa4af555ee5edf34 which changed the way the caret is placed for mouse clicks, using the center of the clicked character to determine whether the caret should be placed to the left or the right of the character. When a tab is followed by a multibyte character and the caret should be moved to the right of the tab, the byte len of the multibyte character is added to the index rather than the byte len of the tab character.

To reproduce the bug, open examples/texteditor-simple and insert a tab followed by a multibyte character (for example "	文"). Click on the right half of the tab and the text caret will be rendered inside the multibyte character. Then type another letter and the multibyte character will become invalid utf8 and it will render as ��.

![Screenshot 2024-09-27 18-37-06](https://github.com/user-attachments/assets/0e109e6e-5c2b-4d96-855a-b95b370fafb9)
![Screenshot 2024-09-27 18-37-19](https://github.com/user-attachments/assets/f692e9f7-29f6-4293-9386-bb1680992892)