### PR TITLE
Fl_Text_Display: Fix text selection dragging off-by-one bug

### DIFF
--- a/src/Fl_Text_Display.cxx
+++ b/src/Fl_Text_Display.cxx
@@ -4335,7 +4335,6 @@ int Fl_Text_Display::handle(int event) {
           scroll_direction = 0;
         }
         pos = xy_to_position(X, Y, CURSOR_POS);
-        pos = buffer()->next_char(pos);
       }
       fl_text_drag_me(pos, this);
       return 1;


### PR DESCRIPTION
The bug can be reproduced in examples/texteditor-simple, and it's easier if you zoom in with Ctrl-+ or add edit->textsize(100). The endpoint of the text selection is always shifted right by one character which leads to strange selection behavior.