### PR TITLE
Fix MSVC Level4 compiler warnings in public header files

### DIFF
--- a/FL/Fl_Button.H
+++ b/FL/Fl_Button.H
@@ -158,7 +158,7 @@ public:
 
     \param[in] b down box type
    */
-  void down_box(Fl_Boxtype b) {down_box_ = b;}
+  void down_box(Fl_Boxtype b) {down_box_ = (uchar)b;}
 
   /// (for backwards compatibility)
   void shortcut(const char *s) {shortcut(fl_old_shortcut(s));}

--- a/FL/Fl_File_Input.H
+++ b/FL/Fl_File_Input.H
@@ -66,7 +66,7 @@ public:
   /** Gets the box type used for the navigation bar. */
   Fl_Boxtype    down_box() const { return (Fl_Boxtype)down_box_; }
   /** Sets the box type to use for the navigation bar.  */
-  void          down_box(Fl_Boxtype b) { down_box_ = b; }
+  void          down_box(Fl_Boxtype b) { down_box_ = (uchar)b; }
 
   /**
     Gets the current error color.

--- a/FL/Fl_Grid.H
+++ b/FL/Fl_Grid.H
@@ -177,15 +177,15 @@ public:
 
     Cell(int row, int col) {    // constructor
       Cell_();
-      row_ = row;
-      col_ = col;
+      row_ = (short)row;
+      col_ = (short)col;
     }
 
     Cell(Fl_Widget *w, int row, int col) {  // widget assignment
       Cell_();
       widget_ = w;
-      row_ = row;
-      col_ = col;
+      row_ = (short)row;
+      col_ = (short)col;
     }
 
     /**

--- a/FL/Fl_Menu_.H
+++ b/FL/Fl_Menu_.H
@@ -232,7 +232,7 @@ public:
   */
   Fl_Boxtype down_box() const {return (Fl_Boxtype)down_box_;}
   /** Sets the box type used to surround the currently-selected items in the menus.  */
-  void down_box(Fl_Boxtype b) {down_box_ = b;}
+  void down_box(Fl_Boxtype b) {down_box_ = (uchar)b;}
 
   /** Get the box type for the menu popup windows.
    \return the box type, or FL_NO_BOX if Fl_Menu_::box() is to be used instead

--- a/FL/Fl_Menu_Item.H
+++ b/FL/Fl_Menu_Item.H
@@ -206,7 +206,7 @@ struct FL_EXPORT Fl_Menu_Item {
     \see const char* Fl_Menu_Item::label() const
   */
   void label(Fl_Labeltype a, const char* b) {
-    labeltype_ = a;
+    labeltype_ = (uchar)a;
     text = b;
   }
 
@@ -262,7 +262,7 @@ struct FL_EXPORT Fl_Menu_Item {
     the label() pointer as another form of data such as a bitmap.
     The value FL_NORMAL_LABEL prints the label as text.
   */
-  void labeltype(Fl_Labeltype a) {labeltype_ = a;}
+  void labeltype(Fl_Labeltype a) {labeltype_ = (uchar)a;}
 
   /**
     Gets the menu item's label color.

--- a/FL/Fl_Slider.H
+++ b/FL/Fl_Slider.H
@@ -99,7 +99,7 @@ public:
   Fl_Boxtype slider() const {return (Fl_Boxtype)slider_;}
 
   /** Sets the slider box type. */
-  void slider(Fl_Boxtype c) {slider_ = c;}
+  void slider(Fl_Boxtype c) {slider_ = (uchar)c;}
 };
 
 #endif

--- a/FL/Fl_Table.H
+++ b/FL/Fl_Table.H
@@ -524,7 +524,7 @@ public:
     row_header() must also be enabled to allow resizing.
   */
   void row_resize(int flag) {                   // enable row resizing
-    _row_resize = flag;
+    _row_resize = (char)flag;
   }
 
   /**
@@ -541,7 +541,7 @@ public:
     \p col_header() must also be enabled to allow resizing.
   */
   void col_resize(int flag) {                   // enable col resizing
-    _col_resize = flag;
+    _col_resize = (char)flag;
   }
 
   /**
@@ -588,7 +588,7 @@ public:
     If changed, the table is redrawn.
   */
   void row_header(int flag) {
-    _row_header = flag;
+    _row_header = (char)flag;
     table_resized();
     redraw();
   }
@@ -605,7 +605,7 @@ public:
     If changed, the table is redrawn.
   */
   void col_header(int flag) {
-    _col_header = flag;
+    _col_header = (char)flag;
     table_resized();
     redraw();
   }

--- a/FL/Fl_Terminal.H
+++ b/FL/Fl_Terminal.H
@@ -483,14 +483,14 @@ protected:
       else                        bgcolor(defaultbgcolor_);
     }
     int  onoff(bool flag, Attrib a) { return (flag ? (attrib_ | a) : (attrib_ & ~a)); }
-    void sgr_bold(bool val)      { attrib_ = onoff(val, Fl_Terminal::BOLD);      } // e.g. ESC[1m
-    void sgr_dim(bool val)       { attrib_ = onoff(val, Fl_Terminal::DIM);       } // e.g. ESC[2m
-    void sgr_italic(bool val)    { attrib_ = onoff(val, Fl_Terminal::ITALIC);    } // e.g. ESC[3m
-    void sgr_underline(bool val) { attrib_ = onoff(val, Fl_Terminal::UNDERLINE); } // e.g. ESC[3m
-    void sgr_dbl_under(bool val) { attrib_ = onoff(val, Fl_Terminal::UNDERLINE); } // e.g. ESC[21m (TODO!)
-    void sgr_blink(bool val)     { (void)val; /* NOT IMPLEMENTED */              } // e.g. ESC[5m
-    void sgr_inverse(bool val)   { attrib_ = onoff(val, Fl_Terminal::INVERSE);   } // e.g. ESC[7m
-    void sgr_strike(bool val)    { attrib_ = onoff(val, Fl_Terminal::STRIKEOUT); } // e.g. ESC[9m
+    void sgr_bold(bool val)      { attrib_ = (uchar)onoff(val, Fl_Terminal::BOLD);      } // e.g. ESC[1m
+    void sgr_dim(bool val)       { attrib_ = (uchar)onoff(val, Fl_Terminal::DIM);       } // e.g. ESC[2m
+    void sgr_italic(bool val)    { attrib_ = (uchar)onoff(val, Fl_Terminal::ITALIC);    } // e.g. ESC[3m
+    void sgr_underline(bool val) { attrib_ = (uchar)onoff(val, Fl_Terminal::UNDERLINE); } // e.g. ESC[3m
+    void sgr_dbl_under(bool val) { attrib_ = (uchar)onoff(val, Fl_Terminal::UNDERLINE); } // e.g. ESC[21m (TODO!)
+    void sgr_blink(bool val)     { (void)val; /* NOT IMPLEMENTED */                     } // e.g. ESC[5m
+    void sgr_inverse(bool val)   { attrib_ = (uchar)onoff(val, Fl_Terminal::INVERSE);   } // e.g. ESC[7m
+    void sgr_strike(bool val)    { attrib_ = (uchar)onoff(val, Fl_Terminal::STRIKEOUT); } // e.g. ESC[9m
   };
 
 protected:

--- a/FL/Fl_Tree_Item.H
+++ b/FL/Fl_Tree_Item.H
@@ -349,7 +349,7 @@ public:
   }
   /// See if the item is selected.
   char is_selected() const {
-    return(is_flag(SELECTED));
+    return((char)is_flag(SELECTED));
   }
   /// Change the item's activation state to the optionally specified 'val'.
   ///
@@ -378,7 +378,7 @@ public:
   }
   /// See if the item is activated.
   char is_activated() const {
-    return(is_flag(ACTIVE));
+    return((char)is_flag(ACTIVE));
   }
   /// See if the item is activated. Alias for is_activated().
   char is_active() const {

--- a/FL/Fl_Tree_Prefs.H
+++ b/FL/Fl_Tree_Prefs.H
@@ -361,7 +361,7 @@ public:
   ///                0: hides collapse icons.
   ///
   inline void showcollapse(int val) {
-    _showcollapse = val;
+    _showcollapse = (char)val;
   }
   /// Get the default sort order value
   inline Fl_Tree_Sort sortorder() const {

--- a/FL/Fl_Widget.H
+++ b/FL/Fl_Widget.H
@@ -446,7 +446,7 @@ public:
       \param[in] new_box the new box type
       \see box(), Fl_Boxtype
    */
-  void box(Fl_Boxtype new_box) {box_ = new_box;}
+  void box(Fl_Boxtype new_box) {box_ = (uchar)new_box;}
 
   /** Gets the background color of the widget.
       \return current background color
@@ -525,7 +525,7 @@ public:
   /** Shortcut to set the label text and type in one call.
       \see label(const char *), labeltype(Fl_Labeltype)
    */
-  void label(Fl_Labeltype a, const char* b) {label_.type = a; label_.value = b;}
+  void label(Fl_Labeltype a, const char* b) {label_.type = (uchar)a; label_.value = b;}
 
   /** Gets the label type.
       \return the current label type.
@@ -541,7 +541,7 @@ public:
       \param[in] a new label type
       \see Fl_Labeltype
    */
-  void labeltype(Fl_Labeltype a) {label_.type = a;}
+  void labeltype(Fl_Labeltype a) {label_.type = (uchar)a;}
 
   /** Gets the label color.
       The default color is FL_FOREGROUND_COLOR.

--- a/FL/forms.H
+++ b/FL/forms.H
@@ -223,7 +223,7 @@ inline void fl_set_object_callback(Fl_Widget*o,Forms_CB c,long a) {o->callback(c
 inline void fl_call_object_callback(Fl_Widget* o) {o->do_callback();}
 inline void fl_trigger_object(Fl_Widget* o) {o->do_callback();}
 inline void fl_set_object_return(Fl_Widget* o, int v) {
-  o->when((Fl_When)(v|FL_WHEN_RELEASE));}
+  o->when((uchar)(v|FL_WHEN_RELEASE));}
 
 inline void fl_redraw_object(Fl_Widget* o) {o->redraw();}
 inline void fl_show_object(Fl_Widget* o) {o->show();}
@@ -490,11 +490,11 @@ forms_constructor(Fl_Round_Button, fl_add_round3dbutton)
 #include "Fl_Check_Button.H"
 forms_constructor(Fl_Check_Button, fl_add_checkbutton)
 
-inline Fl_Widget* fl_add_bitmapbutton(int t,int x,int y,int w,int h,const char* l) {Fl_Widget* o = fl_add_button(t,x,y,w,h,l); return o;}
+inline Fl_Widget* fl_add_bitmapbutton(int t,int x,int y,int w,int h,const char* l) {Fl_Widget* o = fl_add_button((uchar)t,x,y,w,h,l); return o;}
 inline void fl_set_bitmapbutton_data(Fl_Widget* o,int a,int b,uchar* c) {
   (new Fl_Bitmap(c,a,b))->label(o);}  // does not delete old Fl_Bitmap!
 
-inline Fl_Widget* fl_add_pixmapbutton(int t,int x,int y,int w,int h,const char* l) {Fl_Widget* o = fl_add_button(t,x,y,w,h,l); return o;}
+inline Fl_Widget* fl_add_pixmapbutton(int t,int x,int y,int w,int h,const char* l) {Fl_Widget* o = fl_add_button((uchar)t,x,y,w,h,l); return o;}
 inline void fl_set_pixmapbutton_data(Fl_Widget* o, const char*const* c) {
   (new Fl_Pixmap(c))->label(o);}  // does not delete old Fl_Pixmap!
 
@@ -516,7 +516,7 @@ inline void fl_set_chart_bounds(Fl_Widget* o, double a, double b) {
 inline void fl_set_chart_maxnumb(Fl_Widget* o, int v) {
   ((Fl_Chart*)o)->maxsize(v);}
 inline void fl_set_chart_autosize(Fl_Widget* o, int v) {
-  ((Fl_Chart*)o)->autosize(v);}
+  ((Fl_Chart*)o)->autosize((uchar)v);}
 inline void fl_set_chart_lstyle(Fl_Widget* o, Fl_Font v) {
   ((Fl_Chart*)o)->textfont(v);}
 inline void fl_set_chart_lsize(Fl_Widget* o, int v) {
@@ -575,7 +575,7 @@ inline void fl_set_counter_step(Fl_Widget* o, double a, double b) {
 inline void fl_set_counter_precision(Fl_Widget* o, int v) {
     ((Fl_Counter*)o)->precision(v);}
 inline void fl_set_counter_return(Fl_Widget* o, int v) {
-    ((Fl_Counter*)o)->when((Fl_When)(v|FL_WHEN_RELEASE));}
+    ((Fl_Counter*)o)->when((uchar)(v|FL_WHEN_RELEASE));}
 inline double fl_get_counter_value(Fl_Widget* o) {
     return ((Fl_Counter*)o)->value();}
 inline void fl_get_counter_bounds(Fl_Widget* o, float* a, float* b) {
@@ -606,7 +606,7 @@ inline void fl_get_dial_bounds(Fl_Widget* o, float* a, float* b) {
   *b = float(((Fl_Dial*)o)->maximum());
 }
 inline void fl_set_dial_return(Fl_Widget* o, int i) {
-  ((Fl_Dial*)o)->when((Fl_When)(i|FL_WHEN_RELEASE));}
+  ((Fl_Dial*)o)->when((uchar)(i|FL_WHEN_RELEASE));}
 inline void fl_set_dial_angles(Fl_Widget* o, int a, int b) {
   ((Fl_Dial*)o)->angles((short)a, (short)b);}
 //inline void fl_set_dial_cross(Fl_Widget* o, int);
@@ -632,7 +632,7 @@ inline Fl_Free*
 fl_add_free(int t,double x,double y,double w,double h,const char* l,
             FL_HANDLEPTR hdl) {
  return (Fl_Free*)(fl_add_new(
-   new Fl_Free(t,int(x),int(y),int(w),int(h),l,hdl)));
+   new Fl_Free((uchar)t,int(x),int(y),int(w),int(h),l,hdl)));
 }
 
 #include "fl_ask.H"
@@ -676,7 +676,7 @@ forms_constructor(Fl_Input, fl_add_input)
 inline void fl_set_input(Fl_Widget* o, const char* v) {
     ((Fl_Input*)o)->value(v);}
 inline void fl_set_input_return(Fl_Widget* o, int x) {
-    ((Fl_Input*)o)->when((Fl_When)(x | FL_WHEN_RELEASE));}
+    ((Fl_Input*)o)->when((uchar)(x | FL_WHEN_RELEASE));}
 inline void fl_set_input_color(Fl_Widget* o, Fl_Color a, Fl_Color b) {
     ((Fl_Input*)o)->textcolor(a);
     ((Fl_Input*)o)->cursor_color(b);
@@ -765,7 +765,7 @@ inline void fl_set_positioner_xstep(Fl_Widget* o, double v) {
 inline void fl_set_positioner_ystep(Fl_Widget* o, double v) {
     ((Fl_Positioner*)o)->ystep(v);}
 inline void fl_set_positioner_return(Fl_Widget* o, int v) {
-    ((Fl_Positioner*)o)->when((Fl_When)(v|FL_WHEN_RELEASE));}
+    ((Fl_Positioner*)o)->when((uchar)(v|FL_WHEN_RELEASE));}
 
 #include "Fl_Slider.H"
 
@@ -785,7 +785,7 @@ inline void fl_get_slider_bounds(Fl_Widget* o, float* a, float* b) {
   *b = float(((Fl_Slider*)o)->maximum());
 }
 inline void fl_set_slider_return(Fl_Widget* o, int i) {
-    ((Fl_Slider*)o)->when((Fl_When)(i|FL_WHEN_RELEASE));}
+    ((Fl_Slider*)o)->when((uchar)(i|FL_WHEN_RELEASE));}
 inline void fl_set_slider_step(Fl_Widget* o, double v) {
     ((Fl_Slider*)o)->step(v);}
 // inline void fl_set_slider_increment(Fl_Widget* o, double v, double);


### PR DESCRIPTION
If a user application wishes to enable Level4 compiler warnings in Visual Studio (eg, `<WarningLevel>Level4</WarningLevel>`) then the public FL header files will produce many warnings, such as:

> ...\include\FL\Fl_Widget.H(528,60): warning C4244: '=': conversion from 'Fl_Labeltype' to 'uchar', possible loss of data
> ...\include\FL\Fl_Button.H(161,44): warning C4244: '=': conversion from 'Fl_Boxtype' to 'uchar', possible loss of data

To fix this, the application developer must wrap all FL includes like so:

```cpp
#pragma warning(push, 0)
#include <FL/Fl_Widget.H>
#include <FL/Fl_Button.H>
#pragma warning(pop)
```

It would be nice to be able to finally delete all the `#pragma warning(push, 0)`/`#pragma warning(pop)`.

This PR does the bare minimum to add the appropriate casts to fix the warnings in the public header files only.

This was original reported in fltk.general: https://groups.google.com/g/fltkgeneral/c/SQ3RSqNgXbE/m/lIl2lnjdBQAJ

This possibly raises the question of why there are some mismatches between data member types and argument types (in setters, for example), but now is obviously not the time to address all of it. This PR changes no functionality at all.