### PR TITLE
Fix button down state when triggered by shortcut

### DIFF
--- a/src/Fl_Button.cxx
+++ b/src/Fl_Button.cxx
@@ -189,17 +189,14 @@ int Fl_Button::handle(int event) {
             do_callback(FL_REASON_RELEASED);
         } else {
           simulate_key_action();
-          value(1);
           if (when() & FL_WHEN_CHANGED) {
             set_changed();
             Fl_Widget_Tracker wp(this);
             do_callback(FL_REASON_CHANGED);
             if (wp.deleted()) return 1;
-            value(0);
             set_changed();
             do_callback(FL_REASON_RELEASED);
           } else if (when() & FL_WHEN_RELEASE) {
-            value(0);
             set_changed();
             do_callback(FL_REASON_RELEASED);
           }


### PR DESCRIPTION
Sorry, I should have noticed this when verifying #877 but I didn't catch it.

The `value(1)`/`value(0)` are not strictly necessary because it's already handled by `simulate_key_action()` and `key_release_timeout()`.
And resetting the value back to 0 so soon prevents the button from ever being drawn in its down state.

Before:

https://github.com/user-attachments/assets/4b6d903b-33fc-4024-b84e-4b8493a793df

After:

https://github.com/user-attachments/assets/feac7799-335d-4c3c-86cf-31a759b9b987

The only functional difference is that now the `do_callback(FL_REASON_RELEASED)` happens while the `value_` is still 1, since the early `value(0)` was removed.

I'm not sure what's best here..

The options I see are:

1. Let the `do_callback(FL_REASON_RELEASED)` happen while the `value_` is still 1. (This PR)
2. Do something like this instead:
    ```diff
                 value(0);
                 set_changed();
                 do_callback(FL_REASON_RELEASED);
    +            value(1);
               } else if (when() & FL_WHEN_RELEASE) {
                 value(0);
                 set_changed();
                 do_callback(FL_REASON_RELEASED);
    +            value(1);
               }
             }
             return 1;
    ```
    so that `do_callback(FL_REASON_RELEASED)` happens while `value_` is indeed 0 (if this is even important) but the button is still correctly drawn in the down state. (Simple change but maybe a little strange)
3. Let `do_callback(FL_REASON_RELEASED)` be the responsibility of `key_release_timeout()` instead of `handle()`. (Maybe the most complicated)

If the value of `value_` isn't particularly important during `do_callback(FL_REASON_RELEASED)` then this PR should be sufficient. But I'm happy to make more changes.