### PR TITLE
Fix CHANGED flag for radio buttons when pressed with the mouse

### DIFF
--- a/src/Fl_Button.cxx
+++ b/src/Fl_Button.cxx
@@ -131,10 +131,13 @@ int Fl_Button::handle(int event) {
         if (when() & FL_WHEN_NOT_CHANGED) do_callback(FL_REASON_SELECTED);
         return 1;
       }
-      set_changed();
-      if (type() == FL_RADIO_BUTTON) setonly();
-      else if (type() == FL_TOGGLE_BUTTON) oldval = value_;
-      else {
+      if (type() == FL_RADIO_BUTTON) {
+        setonly();
+        set_changed();
+      } else if (type() == FL_TOGGLE_BUTTON) {
+        oldval = value_;
+        set_changed();
+      } else {
         value(oldval);
         set_changed();
         if (when() & FL_WHEN_CHANGED) {


### PR DESCRIPTION
Small bugfix for the state of the `CHANGED` flag for radio buttons when pressed with the mouse.

Use this small change to test/radio.fl to test radio buttons with `FL_WHEN_RELEASE_ALWAYS` in addition to the default `FL_WHEN_RELEASE`:

```diff
diff --git a/test/radio.fl b/test/radio.fl
index 3eff6a248..693839fea 100644
--- a/test/radio.fl
+++ b/test/radio.fl
@@ -54,7 +54,7 @@ Function {} {open
     } {
       Fl_Round_Button {} {
         label {radio &1}
-        tooltip {Radio button, only one button is set at a time, in the corresponding group.} xywh {190 10 70 30} type Radio down_box ROUND_DOWN_BOX
+        tooltip {Radio button, only one button is set at a time, in the corresponding group.} xywh {190 10 70 30} type Radio down_box ROUND_DOWN_BOX when 6
         code0 {o->callback((Fl_Callback*) button_cb);}
       }
       Fl_Round_Button {} {
```

Before:

https://github.com/user-attachments/assets/741ff2e0-c4ac-4539-9489-9ffc8feafad8

After:

https://github.com/user-attachments/assets/6d30270f-57a4-4dc3-88a7-708839a1488f

Essentially, `set_changed()` and `setonly()` had to be flipped, because `setonly()` clears the changed flag.

This already worked correctly for keyboard shortcuts, only the mouse button had the bug.
It also now works correctly when mixing a keyboard shortcut followed by a mouse click or vice versa.

This also saves a redundant `set_changed()` call for non check/radio buttons.