### PR TITLE
Correctly detect ucrt64 environment - CMake 

### DIFF
--- a/CMake/setup.cmake
+++ b/CMake/setup.cmake
@@ -172,7 +172,6 @@ if(WIN32)
 
  if(MINGW AND EXISTS /mingw)
     if(DEFINED ENV{MSYSTEM} AND $ENV{MSYSTEM} STREQUAL "UCRT64") # UCRT64
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_WIN32") # suppress compiler warnings
       list(APPEND CMAKE_PREFIX_PATH "$ENV{UCRT64}")
     else()
      list(APPEND CMAKE_PREFIX_PATH /mingw)


### PR DESCRIPTION
CMake ver.  3.31.1-1 and 3.31.2-3 (mingw-w64-ucrt-x86_64-cmake), MSYS2/ucrt64, OS win10. 

CMake does not properly detect the ucrt64 environment; it seems to happen apparently when MSYS might not be correctly installed.
CMake will then wrongly include the mingw headers, instead of ucrt64 ones, leading to compilation errors. 

Updated the CMAKE_PREFIX_PATH var to /ucrt64 (instead of /mingw, when ucrt64 detected), re-tested under win10/11 as standalone build as well as a lib included in a CMake project, compiles cleanly. 

Autotools detect the environment w/o issues. 