### PR TITLE
Win32: handle WM_SYSCOLORCHANGE

### DIFF
--- a/src/Fl_win32.cxx
+++ b/src/Fl_win32.cxx
@@ -1220,6 +1220,18 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
   if (window) {
     switch (uMsg) {
 
+      case WM_SYSCOLORCHANGE: {
+        Fl::get_system_colors(); // For selection color
+        DWORD bg = GetSysColor(COLOR_BTNFACE);
+        Fl::background(uchar(bg&255), uchar(bg>>8), uchar(bg>>16));
+        DWORD bg2 = GetSysColor(COLOR_WINDOW);
+        Fl::background2(uchar(bg2&255), uchar(bg2>>8), uchar(bg2>>16));
+        DWORD fg = GetSysColor(COLOR_WINDOWTEXT);
+        Fl::foreground(uchar(fg&255), uchar(fg>>8), uchar(fg>>16));
+        Fl::redraw();
+        return 0;
+      }
+
       case WM_DPICHANGED: { // 0x02E0, after display re-scaling and followed by WM_DISPLAYCHANGE
         if (is_dpi_aware && !Fl_WinAPI_Window_Driver::data_for_resize_window_between_screens_.busy) {
           RECT r, *lParam_rect = (RECT*)lParam;


### PR DESCRIPTION
This simple PR ensures that FLTK programs update their colors when the system color theme is changed on Windows.

Perhaps, a developer may use `show()` instead of `show(argc, argv)` for the top window with the intent of using the default FLTK colors. As per the documentation of `show(argc, argv)` in `Fl_Window.cxx` this isn't correct:

> This call should be used for top-level windows, at least for the first (main) window.

Nonetheless, in such a case the new `WM_SYSCOLORCHANGE` handler may be at odds with that decision.

Also, what if the color theme is changeable in the program itself, and the `WM_SYSCOLORCHANGE` handler does more harm than good? 