### PR TITLE
Reinstating Fluid MergeBack feature.

### DIFF
--- a/fluid/Fl_Function_Type.cxx
+++ b/fluid/Fl_Function_Type.cxx
@@ -678,9 +678,13 @@ void Fl_Code_Type::write_code1(Fd_Code_Writer& f) {
   if ( handle_editor_changes() == 1 ) {
     main_window->redraw();    // tell fluid to redraw; edits may affect tree's contents
   }
-  // Matt: disabled f.tag(FD_TAG_GENERIC, 0);
+#ifdef FLUID_OPTION_MERGEBACK
+  f.tag(FD_TAG_GENERIC, 0);
+#endif // FLUID_OPTION_MERGEBACK
   f.write_c_indented(name(), 0, '\n');
-  // Matt: disabled f.tag(FD_TAG_CODE, get_uid());
+#ifdef FLUID_OPTION_MERGEBACK
+  f.tag(FD_TAG_CODE, get_uid());
+#endif // FLUID_OPTION_MERGEBACK
 }
 
 /**

--- a/fluid/Fl_Menu_Type.cxx
+++ b/fluid/Fl_Menu_Type.cxx
@@ -349,7 +349,9 @@ void Fl_Menu_Item_Type::write_static(Fd_Code_Writer& f) {
     f.write_c(", %s", ut);
     if (use_v) f.write_c(" v");
     f.write_c(") {\n");
-    // Matt: disabled f.tag(FD_TAG_GENERIC, 0);
+#ifdef FLUID_OPTION_MERGEBACK
+    f.tag(FD_TAG_GENERIC, 0);
+#endif // FLUID_OPTION_MERGEBACK
     f.write_c_indented(callback(), 1, 0);
     if (*(d-1) != ';' && *(d-1) != '}') {
       const char *p = strrchr(callback(), '\n');
@@ -360,7 +362,9 @@ void Fl_Menu_Item_Type::write_static(Fd_Code_Writer& f) {
       if (*p != '#' && *p) f.write_c(";");
     }
     f.write_c("\n");
-    // Matt: disabled f.tag(FD_TAG_MENU_CALLBACK, get_uid());
+#ifdef FLUID_OPTION_MERGEBACK
+    f.tag(FD_TAG_MENU_CALLBACK, get_uid());
+#endif // FLUID_OPTION_MERGEBACK
     f.write_c("}\n");
 
     // If the menu item is part of a Class or Widget Class, FLUID generates

--- a/fluid/Fl_Type.cxx
+++ b/fluid/Fl_Type.cxx
@@ -703,8 +703,9 @@ void Fl_Type::add(Fl_Type *anchor, Strategy strategy) {
   }
 
 #ifdef FLUID_OPTION_MERGEBACK
+  if (   g_project.write_mergeback_data
+      && strategy.source() == Strategy::FROM_USER)
   { // make sure that we have no duplicate uid's
-    // FIXME: if 'add' is called while loading a file, the UID will be set by the tag later
     Fl_Type *tp = this;
     do {
       tp->set_uid(tp->uid_);
@@ -759,7 +760,7 @@ void Fl_Type::insert(Fl_Type *g) {
   g->prev = end;
   update_visibility_flag(this);
 #ifdef FLUID_OPTION_MERGEBACK
-  { // make sure that we have no duplicate uid's
+  if (g_project.write_mergeback_data) { // make sure that we have no duplicate uid's
     Fl_Type *tp = this;
     do {
       tp->set_uid(tp->uid_);

--- a/fluid/Fl_Type.cxx
+++ b/fluid/Fl_Type.cxx
@@ -130,6 +130,8 @@ Fl_Type *in_this_only; // set if menu popped-up in window
 
 // ---- various functions
 
+// The following functions help debugging the type tree and are usually not
+// compiled into the app.
 #if 0
 #ifndef NDEBUG
 /**
@@ -699,15 +701,16 @@ void Fl_Type::add(Fl_Type *anchor, Strategy strategy) {
     Fl_Type::first = this;
   }
 
-#if 0
+#ifdef FLUID_OPTION_MERGEBACK
   { // make sure that we have no duplicate uid's
+    // FIXME: if 'add' is called while loading a file, the UID will be set by the tag later
     Fl_Type *tp = this;
     do {
       tp->set_uid(tp->uid_);
       tp = tp->next;
     } while (tp!=end && tp!=NULL);
   }
-#endif
+#endif // FLUID_OPTION_MERGEBACK
 
   // Give the widgets in our tree a chance to update themselves
   for (Fl_Type *t = this; t && t!=end->next; t = t->next) {
@@ -754,6 +757,7 @@ void Fl_Type::insert(Fl_Type *g) {
   end->next = g;
   g->prev = end;
   update_visibility_flag(this);
+#ifdef FLUID_OPTION_MERGEBACK
   { // make sure that we have no duplicate uid's
     Fl_Type *tp = this;
     do {
@@ -761,6 +765,7 @@ void Fl_Type::insert(Fl_Type *g) {
       tp = tp->next;
     } while (tp!=end && tp!=NULL);
   }
+#endif // FLUID_OPTION_MERGEBACK
   // tell parent that it has a new child, so it can update itself
   if (parent) parent->add_child(this, g);
   widget_browser->redraw();
@@ -956,7 +961,7 @@ void Fl_Type::read_property(Fd_Project_Reader &f, const char *c) {
     const char *hex = f.read_word();
     int x = 0;
     if (hex)
-      x = sscanf(hex, "%04x", &x);
+      sscanf(hex, "%04x", &x);
     set_uid(x);
   } else if (!strcmp(c,"label"))
     label(f.read_word());
@@ -1270,7 +1275,7 @@ void Fl_Type::write_code2(Fd_Code_Writer&) {
  until we find one that is unique.
 
  \param[in] suggested_uid the preferred uid for this node
- \return the actualt uid that was given to the node
+ \return the actual uid that was given to the node
  */
 unsigned short Fl_Type::set_uid(unsigned short suggested_uid) {
   if (suggested_uid==0)

--- a/fluid/Fl_Widget_Type.cxx
+++ b/fluid/Fl_Widget_Type.cxx
@@ -2965,7 +2965,9 @@ void Fl_Widget_Type::write_static(Fd_Code_Writer& f) {
     f.write_c(", %s", ut);
     if (use_v) f.write_c(" v");
     f.write_c(") {\n");
-    // Matt: disabled f.tag(FD_TAG_GENERIC, 0);
+#ifdef FLUID_OPTION_MERGEBACK
+    f.tag(FD_TAG_GENERIC, 0);
+#endif // FLUID_OPTION_MERGEBACK
     f.write_c_indented(callback(), 1, 0);
     if (*(d-1) != ';' && *(d-1) != '}') {
       const char *p = strrchr(callback(), '\n');
@@ -2976,7 +2978,9 @@ void Fl_Widget_Type::write_static(Fd_Code_Writer& f) {
       if (*p != '#' && *p) f.write_c(";");
     }
     f.write_c("\n");
-    // Matt: disabled f.tag(FD_TAG_WIDGET_CALLBACK, get_uid());
+#ifdef FLUID_OPTION_MERGEBACK
+    f.tag(FD_TAG_WIDGET_CALLBACK, get_uid());
+#endif // FLUID_OPTION_MERGEBACK
     f.write_c("}\n");
     if (k) {
       f.write_c("void %s::%s(%s* o, %s v) {\n", k, cn, t, ut);

--- a/fluid/file.cxx
+++ b/fluid/file.cxx
@@ -384,6 +384,8 @@ Fl_Type *Fd_Project_Reader::read_children(Fl_Type *p, int merge, Strategy strate
       if (!cc || !strcmp(cc,"}")) break;
       t->read_property(*this, cc);
     }
+    if (g_project.write_mergeback_data && t->get_uid()==0)
+      t->set_uid(0);
 
     if (t->can_have_children()) {
       c = read_word(1);

--- a/fluid/fluid.cxx
+++ b/fluid/fluid.cxx
@@ -1267,8 +1267,7 @@ void write_cb(Fl_Widget *, void *) {
     write_code_files();
 }
 
-#if 0
-// Matt: disabled
+#ifdef FLUID_OPTION_MERGEBACK
 /**
  Merge the possibly modified content of code files back into the project.
  */
@@ -1311,7 +1310,8 @@ int mergeback_code_files()
 void mergeback_cb(Fl_Widget *, void *) {
   mergeback_code_files();
 }
-#endif
+
+#endif // FLUID_OPTION_MERGEBACK
 
 /**
  Write the strings that are used in i18n.
@@ -1693,7 +1693,9 @@ Fl_Menu_Item Main_Menu[] = {
   {"Save As &Template...", 0, save_template_cb, 0, FL_MENU_DIVIDER},
   {"&Print...", FL_COMMAND+'p', print_menu_cb},
   {"Write &Code", FL_COMMAND+FL_SHIFT+'c', write_cb, 0},
-// Matt: disabled {"MergeBack Code", FL_COMMAND+FL_SHIFT+'m', mergeback_cb, 0},
+#ifdef FLUID_OPTION_MERGEBACK
+  {"MergeBack Code", FL_COMMAND+FL_SHIFT+'m', mergeback_cb, 0},
+#endif // FLUID_OPTION_MERGEBACK
   {"&Write Strings", FL_COMMAND+FL_SHIFT+'w', write_strings_cb, 0, FL_MENU_DIVIDER},
   {relative_history[0], FL_COMMAND+'1', menu_file_open_history_cb, absolute_history[0]},
   {relative_history[1], FL_COMMAND+'2', menu_file_open_history_cb, absolute_history[1]},

--- a/fluid/fluid.h
+++ b/fluid/fluid.h
@@ -17,6 +17,9 @@
 #ifndef _FLUID_FLUID_H
 #define _FLUID_FLUID_H
 
+// Set this to `define` to enable mergeback, or `undef` to disable if.
+#undef FLUID_OPTION_MERGEBACK
+
 #include "fluid_filename.h"
 #include <FL/Fl_Preferences.H>
 #include <FL/Fl_Menu_Item.H>

--- a/fluid/mergeback.cxx
+++ b/fluid/mergeback.cxx
@@ -14,12 +14,12 @@
 //     https://www.fltk.org/bugs.php
 //
 
-#if 0
-// Matt: disabled
+#include "fluid.h"
+
+#ifdef FLUID_OPTION_MERGEBACK
 
 #include "mergeback.h"
 
-#include "fluid.h"
 #include "code.h"
 #include "undo.h"
 #include "Fl_Function_Type.h"
@@ -489,5 +489,5 @@ int Fd_Mergeback::merge_back(const Fl_String &s, const Fl_String &p, int task) {
   return ret;
 }
 
-#endif
+#endif // FLUID_OPTION_MERGEBACK
 

--- a/fluid/mergeback.h
+++ b/fluid/mergeback.h
@@ -14,8 +14,9 @@
 //     https://www.fltk.org/bugs.php
 //
 
-// Matt: disabled
-#if 0
+#include "fluid.h"
+
+#ifdef FLUID_OPTION_MERGEBACK
 
 #ifndef _FLUID_MERGEBACK_H
 #define _FLUID_MERGEBACK_H
@@ -79,4 +80,5 @@ extern int merge_back(const Fl_String &s, const Fl_String &p, int task);
 
 #endif // _FLUID_MERGEBACK_H
 
-#endif
+#endif // FLUID_OPTION_MERGEBACK
+

--- a/fluid/settings_panel.cxx
+++ b/fluid/settings_panel.cxx
@@ -441,6 +441,10 @@ static void cb_avoid_early_includes_button(Fl_Check_Button* o, void* v) {
   }
 }
 
+static void cb_2(Fl_Group* o, void* v) {
+  propagate_load(o, v);
+}
+
 Fl_Check_Button *w_proj_mergeback=(Fl_Check_Button *)0;
 
 static void cb_w_proj_mergeback(Fl_Check_Button* o, void* v) {
@@ -507,7 +511,7 @@ Fl_Menu_Item menu_layout_choice[] = {
  {0,0,0,0,0,0,0,0,0}
 };
 
-static void cb_2(Fl_Button*, void* v) {
+static void cb_3(Fl_Button*, void* v) {
   // Clone the current layout suite
 
   if (v == LOAD) return;
@@ -765,7 +769,7 @@ static void cb_Gap(Fl_Value_Input* o, void* v) {
   }
 }
 
-static void cb_3(Fl_Value_Input* o, void* v) {
+static void cb_4(Fl_Value_Input* o, void* v) {
   if (v == LOAD) {
     o->value((double)layout->widget_min_h);
   } else {
@@ -773,7 +777,7 @@ static void cb_3(Fl_Value_Input* o, void* v) {
   }
 }
 
-static void cb_4(Fl_Value_Input* o, void* v) {
+static void cb_5(Fl_Value_Input* o, void* v) {
   if (v == LOAD) {
     o->value((double)layout->widget_inc_h);
   } else {
@@ -781,7 +785,7 @@ static void cb_4(Fl_Value_Input* o, void* v) {
   }
 }
 
-static void cb_5(Fl_Value_Input* o, void* v) {
+static void cb_6(Fl_Value_Input* o, void* v) {
   if (v == LOAD) {
     o->value((double)layout->widget_gap_y);
   } else {
@@ -789,7 +793,7 @@ static void cb_5(Fl_Value_Input* o, void* v) {
   }
 }
 
-static void cb_6(Fl_Choice* o, void* v) {
+static void cb_7(Fl_Choice* o, void* v) {
   if (v == LOAD) {
     o->value(layout->labelfont+1);
   } else {
@@ -797,7 +801,7 @@ static void cb_6(Fl_Choice* o, void* v) {
   }
 }
 
-static void cb_7(Fl_Value_Input* o, void* v) {
+static void cb_8(Fl_Value_Input* o, void* v) {
   if (v == LOAD) {
     o->value(layout->labelsize);
   } else {
@@ -805,7 +809,7 @@ static void cb_7(Fl_Value_Input* o, void* v) {
   }
 }
 
-static void cb_8(Fl_Choice* o, void* v) {
+static void cb_9(Fl_Choice* o, void* v) {
   if (v == LOAD) {
     o->value(layout->textfont+1);
   } else {
@@ -813,7 +817,7 @@ static void cb_8(Fl_Choice* o, void* v) {
   }
 }
 
-static void cb_9(Fl_Value_Input* o, void* v) {
+static void cb_a(Fl_Value_Input* o, void* v) {
   if (v == LOAD) {
     o->value(layout->textsize);
   } else {
@@ -905,7 +909,7 @@ static void cb_w_settings_shell_toolbox(Fl_Group* o, void* v) {
   }
 }
 
-static void cb_a(Fl_Button*, void* v) {
+static void cb_b(Fl_Button*, void* v) {
   if (v != LOAD) {
     int selected = w_settings_shell_list_selected;
     Fd_Shell_Command *cmd = new Fd_Shell_Command("new shell command");
@@ -1079,7 +1083,7 @@ static void cb_Menu(Fl_Input* o, void* v) {
   }
 }
 
-static void cb_b(Fl_Group* o, void* v) {
+static void cb_c(Fl_Group* o, void* v) {
   propagate_load(o, v);
 }
 
@@ -2217,7 +2221,7 @@ static void cb_i18n_pos_file_input(Fl_Input* o, void* v) {
   }
 }
 
-static void cb_c(Fl_Group* o, void* v) {
+static void cb_d(Fl_Group* o, void* v) {
   propagate_load(o, v);
 }
 
@@ -2657,6 +2661,7 @@ Fl_Double_Window* make_settings_window() {
           avoid_early_includes_button->callback((Fl_Callback*)cb_avoid_early_includes_button);
         } // Fl_Check_Button* avoid_early_includes_button
         { Fl_Group* o = new Fl_Group(100, 283, 220, 20);
+          o->callback((Fl_Callback*)cb_2);
           { Fl_Box* o = new Fl_Box(100, 283, 0, 20, "Experimental: ");
             o->labelfont(1);
             o->labelsize(11);
@@ -2699,7 +2704,7 @@ o->hide();
           layout_choice->menu(menu_layout_choice);
         } // Fl_Choice* layout_choice
         { Fl_Button* o = new Fl_Button(272, 78, 24, 24, "+");
-          o->callback((Fl_Callback*)cb_2);
+          o->callback((Fl_Callback*)cb_3);
         } // Fl_Button* o
         { w_layout_menu = new Fl_Menu_Button(296, 78, 24, 24);
           w_layout_menu->callback((Fl_Callback*)cb_w_layout_menu);
@@ -2930,14 +2935,14 @@ o->hide();
           o->maximum(32767);
           o->step(1);
           o->textsize(11);
-          o->callback((Fl_Callback*)cb_3);
+          o->callback((Fl_Callback*)cb_4);
         } // Fl_Value_Input* o
         { Fl_Value_Input* o = new Fl_Value_Input(145, 440, 55, 20);
           o->labelsize(11);
           o->maximum(32767);
           o->step(1);
           o->textsize(11);
-          o->callback((Fl_Callback*)cb_4);
+          o->callback((Fl_Callback*)cb_5);
           o->align(Fl_Align(FL_ALIGN_TOP_LEFT));
         } // Fl_Value_Input* o
         { Fl_Value_Input* o = new Fl_Value_Input(205, 440, 55, 20);
@@ -2945,7 +2950,7 @@ o->hide();
           o->maximum(32767);
           o->step(1);
           o->textsize(11);
-          o->callback((Fl_Callback*)cb_5);
+          o->callback((Fl_Callback*)cb_6);
           o->align(Fl_Align(FL_ALIGN_TOP_LEFT));
         } // Fl_Value_Input* o
         { Fl_Group* o = new Fl_Group(85, 465, 201, 20, "Label Font:");
@@ -2959,7 +2964,7 @@ o->hide();
             o->labelfont(1);
             o->labelsize(11);
             o->textsize(11);
-            o->callback((Fl_Callback*)cb_6);
+            o->callback((Fl_Callback*)cb_7);
             Fl_Group::current()->resizable(o);
             o->menu(fontmenu_w_default);
           } // Fl_Choice* o
@@ -2971,7 +2976,7 @@ o->hide();
             o->step(1);
             o->value(14);
             o->textsize(11);
-            o->callback((Fl_Callback*)cb_7);
+            o->callback((Fl_Callback*)cb_8);
           } // Fl_Value_Input* o
           o->end();
         } // Fl_Group* o
@@ -2986,7 +2991,7 @@ o->hide();
             o->labelfont(1);
             o->labelsize(11);
             o->textsize(11);
-            o->callback((Fl_Callback*)cb_8);
+            o->callback((Fl_Callback*)cb_9);
             o->menu(fontmenu_w_default);
           } // Fl_Choice* o
           { Fl_Value_Input* o = new Fl_Value_Input(235, 490, 50, 20);
@@ -2996,7 +3001,7 @@ o->hide();
             o->step(1);
             o->value(14);
             o->textsize(11);
-            o->callback((Fl_Callback*)cb_9);
+            o->callback((Fl_Callback*)cb_a);
           } // Fl_Value_Input* o
           o->end();
         } // Fl_Group* o
@@ -3029,7 +3034,7 @@ o->hide();
               o->tooltip("insert a new shell command into the list after the selected command");
               o->labelfont(1);
               o->labelsize(11);
-              o->callback((Fl_Callback*)cb_a);
+              o->callback((Fl_Callback*)cb_b);
             } // Fl_Button* o
             { w_settings_shell_dup = new Fl_Button(124, 200, 24, 22, "++");
               w_settings_shell_dup->tooltip("duplicate the selected shell command and insert it into the list");
@@ -3089,7 +3094,7 @@ o->hide();
             o->callback((Fl_Callback*)cb_Menu);
           } // Fl_Input* o
           { Fl_Group* o = new Fl_Group(100, 297, 140, 71);
-            o->callback((Fl_Callback*)cb_b);
+            o->callback((Fl_Callback*)cb_c);
             { Fl_Shortcut_Button* o = new Fl_Shortcut_Button(100, 297, 130, 20, "Shortcut");
               o->tooltip("an optional keyboard shortcut to run this shell command");
               o->box(FL_UP_BOX);
@@ -3316,7 +3321,7 @@ o->hide();
             i18n_pos_file_input->callback((Fl_Callback*)cb_i18n_pos_file_input);
           } // Fl_Input* i18n_pos_file_input
           { Fl_Group* o = new Fl_Group(100, 178, 90, 20);
-            o->callback((Fl_Callback*)cb_c);
+            o->callback((Fl_Callback*)cb_d);
             { i18n_pos_set_input = new Fl_Int_Input(100, 178, 80, 20, "Set:");
               i18n_pos_set_input->tooltip("The message set number.");
               i18n_pos_set_input->type(2);

--- a/fluid/settings_panel.cxx
+++ b/fluid/settings_panel.cxx
@@ -1,7 +1,7 @@
 //
 // Setting and shell dialogs for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2023 by Bill Spitzak and others.
+// Copyright 1998-2024 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this
@@ -67,7 +67,7 @@ Fl_Double_Window *script_panel=(Fl_Double_Window *)0;
 static void cb_script_panel(Fl_Double_Window*, void*) {
   if (Fl::event()==FL_SHORTCUT && Fl::event_key()==FL_Escape)
     return; // ignore Escape
-  script_panel->hide(); // otherwise hide..;
+  script_panel->hide(); // otherwise hide...;
 }
 
 Fl_Text_Editor *script_input=(Fl_Text_Editor *)0;
@@ -2656,22 +2656,26 @@ Fl_Double_Window* make_settings_window() {
           avoid_early_includes_button->labelsize(11);
           avoid_early_includes_button->callback((Fl_Callback*)cb_avoid_early_includes_button);
         } // Fl_Check_Button* avoid_early_includes_button
-        { Fl_Box* o = new Fl_Box(100, 283, 0, 20, "Experimental: ");
-          o->labelfont(1);
-          o->labelsize(11);
-          o->align(Fl_Align(FL_ALIGN_LEFT));
-          o->hide();
-        } // Fl_Box* o
-        { // // Matt: disabled
-          w_proj_mergeback = new Fl_Check_Button(100, 283, 220, 20, "generate MergeBack data");
-          w_proj_mergeback->tooltip("MergeBack is a feature under construction that allows changes in code files t"
+        { Fl_Group* o = new Fl_Group(100, 283, 220, 20);
+          { Fl_Box* o = new Fl_Box(100, 283, 0, 20, "Experimental: ");
+            o->labelfont(1);
+            o->labelsize(11);
+            o->align(Fl_Align(FL_ALIGN_LEFT));
+          } // Fl_Box* o
+          { w_proj_mergeback = new Fl_Check_Button(100, 283, 220, 20, "generate MergeBack data");
+            w_proj_mergeback->tooltip("MergeBack is a feature under construction that allows changes in code files t"
 "o be merged back into the project file. Checking this option will generate add"
 "itional data in code and project files.");
-          w_proj_mergeback->down_box(FL_DOWN_BOX);
-          w_proj_mergeback->labelsize(11);
-          w_proj_mergeback->callback((Fl_Callback*)cb_w_proj_mergeback);
-          w_proj_mergeback->hide();
-        } // Fl_Check_Button* w_proj_mergeback
+            w_proj_mergeback->down_box(FL_DOWN_BOX);
+            w_proj_mergeback->labelsize(11);
+            w_proj_mergeback->callback((Fl_Callback*)cb_w_proj_mergeback);
+          } // Fl_Check_Button* w_proj_mergeback
+          // hide this group if experimental features not wanted
+#ifndef FLUID_OPTION_MERGEBACK
+o->hide();
+#endif
+          o->end();
+        } // Fl_Group* o
         { Fl_Box* o = new Fl_Box(100, 530, 220, 10);
           o->hide();
           Fl_Group::current()->resizable(o);

--- a/fluid/settings_panel.fl
+++ b/fluid/settings_panel.fl
@@ -34,7 +34,7 @@ snap {
 comment {//
 // Setting and shell dialogs for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2023 by Bill Spitzak and others.
+// Copyright 1998-2024 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this
@@ -155,7 +155,7 @@ Function {make_script_panel()} {open
     label {Shell Script Editor}
     callback {if (Fl::event()==FL_SHORTCUT && Fl::event_key()==FL_Escape)
   return; // ignore Escape
-script_panel->hide(); // otherwise hide..} open
+script_panel->hide(); // otherwise hide...} open
     xywh {764 319 540 180} type Double labelsize 11 resizable
     code0 {o->size_range(200, 150);} modal visible
   } {
@@ -424,13 +424,20 @@ or just ".ext" to set extension.}
 }}
           tooltip {Do not emit \#include <FL//Fl.H> until it is needed by another include file.} xywh {100 255 220 20} down_box DOWN_BOX labelsize 11
         }
-        Fl_Box {} {
-          label {Experimental: }
-          xywh {100 283 0 20} labelfont 1 labelsize 11 align 4 hide
-        }
-        Fl_Check_Button w_proj_mergeback {
-          label {generate MergeBack data}
-          callback {if (v == LOAD) {
+        Fl_Group {} {open
+          xywh {100 283 220 20}
+          code3 {// hide this group if experimental features not wanted
+\#ifndef FLUID_OPTION_MERGEBACK
+o->hide();
+\#endif}
+        } {
+          Fl_Box {} {
+            label {Experimental: }
+            xywh {100 283 0 20} labelfont 1 labelsize 11 align 4
+          }
+          Fl_Check_Button w_proj_mergeback {
+            label {generate MergeBack data}
+            callback {if (v == LOAD) {
   o->value(g_project.write_mergeback_data);
 } else {
   if (g_project.write_mergeback_data != o->value()) {
@@ -438,8 +445,8 @@ or just ".ext" to set extension.}
     g_project.write_mergeback_data = o->value();
   }
 }}
-          comment {// Matt: disabled}
-          tooltip {MergeBack is a feature under construction that allows changes in code files to be merged back into the project file. Checking this option will generate additional data in code and project files.} xywh {100 283 220 20} down_box DOWN_BOX labelsize 11 hide
+            tooltip {MergeBack is a feature under construction that allows changes in code files to be merged back into the project file. Checking this option will generate additional data in code and project files.} xywh {100 283 220 20} down_box DOWN_BOX labelsize 11
+          }
         }
         Fl_Box {} {
           xywh {100 530 220 10} hide resizable

--- a/fluid/settings_panel.fl
+++ b/fluid/settings_panel.fl
@@ -424,7 +424,8 @@ or just ".ext" to set extension.}
 }}
           tooltip {Do not emit \#include <FL//Fl.H> until it is needed by another include file.} xywh {100 255 220 20} down_box DOWN_BOX labelsize 11
         }
-        Fl_Group {} {open
+        Fl_Group {} {
+          callback {propagate_load(o, v);} open
           xywh {100 283 220 20}
           code3 {// hide this group if experimental features not wanted
 \#ifndef FLUID_OPTION_MERGEBACK

--- a/fluid/settings_panel.h
+++ b/fluid/settings_panel.h
@@ -1,7 +1,7 @@
 //
 // Setting and shell dialogs for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2023 by Bill Spitzak and others.
+// Copyright 1998-2024 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/test/preferences.fl
+++ b/test/preferences.fl
@@ -1,5 +1,7 @@
 # data file for the Fltk User Interface Designer (fluid)
 version 1.0401
+use_FL_COMMAND
+utf8_in_src
 i18n_type 1
 i18n_include {<stdio.h>}
 i18n_conditional {}
@@ -119,7 +121,8 @@ for (i=0; i<n; i++) {
 if (found)
   return found;
 else
-  return text;} {}
+  return text;} {selected
+  }
 }
 
 Function {closeWindowCB( Fl_Widget*, void* )} {open private return_type void
@@ -138,8 +141,7 @@ Function {} {open return_type int
   code {readLanguagePrefs();
 Fl_Input::cut_menu_text = gettext("Cut");
 Fl_Input::copy_menu_text = gettext("Copy");
-Fl_Input::paste_menu_text = gettext("Paste");} {selected
-  }
+Fl_Input::paste_menu_text = gettext("Paste");} {}
   Fl_Window myWindow {
     label {My Preferences}
     callback closeWindowCB open


### PR DESCRIPTION
Improved conditional compilation for experimental MergeBack feature. Just define or undefined `FLUID_OPTION_MERGEBACK` in `fluid.h`.

Some testing needed before merging.

More testing needed before activation.