### PR TITLE
Fix Fl_Table_Row crashes (1.3.x branch, possibly 1.4.x)

### DIFF
--- a/src/Fl_Table_Row.cxx
+++ b/src/Fl_Table_Row.cxx
@@ -150,9 +150,9 @@ void Fl_Table_Row::select_all_rows(int flag) {
 
 // Set number of rows
 void Fl_Table_Row::rows(int val) {
-  Fl_Table::rows(val);
   while ( val > (int)_rowselect.size() ) { _rowselect.push_back(0); }	// enlarge
   while ( val < (int)_rowselect.size() ) { _rowselect.pop_back(); }	// shrink
+  Fl_Table::rows(val);
 }
 
 //#define DEBUG 1


### PR DESCRIPTION
Hello,

I faced with the following issue: sometimes when a new `Fl_Table_Row` is created, then new rows to it are assigned (i.e. via method `rows(int)` ).  In the current implementation,  it forward the rows assignment to the parent class, and only after that it allocates internal structures for the selected rows. 

The problem is that parent class (`Fl_Table`) in its `rows(int)` implementation might trigger some events processing, right after assigning new rows number... and the events processing in the `Fl_Table_Row` assume the internal structures are already prepared (allocated), while they are not.  Which leads to segfault.

My patch fixes that. Also, I think the bug  exits on 1.4.x branch too.

I attach the screenshots with backtraces of segfault. 

I tested my patch, and it works fine.

Thank you!

![2025-01-11_10-59](https://github.com/user-attachments/assets/c9097216-9cd8-48e0-904b-c7f1763e14bc)
![2025-01-11_xx](https://github.com/user-attachments/assets/0c8e1769-c2a4-4eb7-b0ed-d528d79b9494)


