### PR TITLE
options.cmake: Check Threads_FOUND, not CMAKE_HAVE_THREADS_LIBRARY.

### DIFF
--- a/CMake/options.cmake
+++ b/CMake/options.cmake
@@ -739,11 +739,11 @@ if(FLTK_USE_PTHREADS)
 
   include(FindThreads)
 
-  if(CMAKE_HAVE_THREADS_LIBRARY)
+  if(Threads_FOUND)
     add_definitions("-D_THREAD_SAFE -D_REENTRANT")
     set(USE_THREADS 1)
     set(FLTK_THREADS_FOUND TRUE)
-  endif(CMAKE_HAVE_THREADS_LIBRARY)
+  endif(Threads_FOUND)
 
   if(CMAKE_USE_PTHREADS_INIT AND NOT WIN32)
     set(HAVE_PTHREAD 1)


### PR DESCRIPTION
The former's been available since CMake v2.8 and documented since v3.17; the latter was never documented and quietly went away in CMake v3.24.

This will be helpful in 1.4 as well; please let me know if you'd like a formal PR on that front too.