### PR TITLE
Fixes error: two consecutive '[' tokens on g++ with objcpp files

### DIFF
--- a/src/Fl_Native_File_Chooser_MAC.mm
+++ b/src/Fl_Native_File_Chooser_MAC.mm
@@ -498,7 +498,7 @@ static char *prepareMacFilter(int count, const char *filter, char **patterns) {
   BOOL isdir = NO;
   [[NSFileManager defaultManager] fileExistsAtPath:filename isDirectory:&isdir];
   if (isdir) return YES;
-  if ( fl_filename_match([filename fileSystemRepresentation], filter_pattern[ [nspopup indexOfSelectedItem] ]) ) return YES;
+  if ( fl_filename_match([filename fileSystemRepresentation], filter_pattern[([nspopup indexOfSelectedItem])]) ) return YES;
   return NO;
 }
 - (BOOL)panel:(id)sender shouldEnableURL:(NSURL *)url

--- a/src/Fl_cocoa.mm
+++ b/src/Fl_cocoa.mm
@@ -2758,7 +2758,7 @@ static FLTextInputContext* fltextinputcontext_instance = nil;
     NSData *data = [pboard dataForType:UTF8_pasteboard_type];
     DragData = (char *)malloc([data length] + 1);
     [data getBytes:DragData length:[data length]];
-    DragData[[data length]] = 0;
+    DragData[([data length])] = 0;
     Fl_Screen_Driver::convert_crlf(DragData, strlen(DragData));
   }
   else {


### PR DESCRIPTION
Fixes #1245

The issue seems specific to g++ on macos when building FLTK's Objective-C++ files with C++ > C++11. 
C++ grammar now requires that 2 consecutive '[' tokens introduce an attribute in certain positions.

The GCC entry on attribute syntax mentions that not all cases can be parsed correctly. 

Similarly lambda syntax for C++ can also cause parsing issues:
```cpp
int array[3];
array[[](){ return 1; }()];
```
The solution in these cases is to wrap the inner expression starting with `[` with parenthesis.