### PR TITLE
Windows: fix "heap-use-after-free" in resize_after_screen_change()

### DIFF
--- a/src/drivers/WinAPI/Fl_WinAPI_Window_Driver.cxx
+++ b/src/drivers/WinAPI/Fl_WinAPI_Window_Driver.cxx
@@ -50,6 +50,7 @@ Fl_WinAPI_Window_Driver::Fl_WinAPI_Window_Driver(Fl_Window *win)
 
 Fl_WinAPI_Window_Driver::~Fl_WinAPI_Window_Driver()
 {
+  Fl::remove_timeout(resize_after_screen_change, pWindow);
   if (shape_data_) {
     delete shape_data_->effective_bitmap_;
     delete shape_data_;


### PR DESCRIPTION
When a native window is destroyed, make sure the callback to Fl_WinAPI_Window_Driver::resize_after_screen_change() is removed.