### PR TITLE
Fl_Gl_Window::make_current() does not crash if the window hasn't been shown yet

### DIFF
--- a/src/Fl_Gl_Window.cxx
+++ b/src/Fl_Gl_Window.cxx
@@ -118,6 +118,9 @@ int Fl_Gl_Window::mode(int m, const int *a) {
 void Fl_Gl_Window::make_current() {
 //  puts("Fl_Gl_Window::make_current()");
 //  printf("make_current: context_=%p\n", context_);
+
+  if (!shown()) return;
+
   pGlWindowDriver->make_current_before();
   if (!context_) {
     mode_ &= ~NON_LOCAL_CONTEXT;


### PR DESCRIPTION
Hi. Currently if you call any Fl_Gl_Window functions before the window has been shown, a crash results: make_current() calls create_gl_context(g=NULL), and creaate_gl_context() then dereferences this NULL pointer.

There's no reason to actually touch Fl_Gl_Window that early usually, but I've done it many times by mistake, and crashing isn't what should happen in that case. This patch fixes this by making make_current() do nothing in this case. It's a weird way to do it (it should look at g and not at shown(), and it should probably report an error somehow instead of doing nothing), but that's how this code does it in the other place where create_gl_context() is called.

I tested it in my cases, and it makes things work