### PR TITLE
Declare some methods of Fl_Window 'const'

### DIFF
--- a/FL/Fl_Window.H
+++ b/FL/Fl_Window.H
@@ -361,7 +361,7 @@ public:
 
   void size_range(int minw, int minh, int maxw=0, int maxh=0, int dw=0, int dh=0, int aspect=0);
 
-  uchar get_size_range(int *minw, int *minh, int *maxw=NULL, int *maxh=NULL, int *dw=NULL, int *dh=NULL, int *aspect=NULL);
+  uchar get_size_range(int *minw, int *minh, int *maxw=NULL, int *maxh=NULL, int *dw=NULL, int *dh=NULL, int *aspect=NULL) const;
 
   /** See void Fl_Window::label(const char*)   */
   const char* label() const     {return Fl_Widget::label();}
@@ -431,7 +431,8 @@ public:
     ). You can tell if a window is iconified with (w->shown()
     && !w->visible()).
   */
-  int shown() {return flx_ != 0;}
+  int shown() const { return flx_ != 0; }
+
   /**
     Puts the window on the screen. This has the side
     effect of opening the display, if not done before.
@@ -611,12 +612,12 @@ public:
 
   void shape(const Fl_Image* img);
   void shape(const Fl_Image& b);
-  const Fl_Image *shape();
+  const Fl_Image *shape() const;
   void draw_backdrop();
-  int screen_num();
+  int screen_num() const;
   void screen_num(int screen_num);
   static bool is_a_rescale();
-  fl_uintptr_t os_id();
+  fl_uintptr_t os_id() const;
 
   /**
     Sets a static flag whether the next window should be opened iconified.

--- a/src/Fl_Window.cxx
+++ b/src/Fl_Window.cxx
@@ -694,7 +694,7 @@ void Fl_Window::size_range(int minWidth, int minHeight,
 */
 uchar Fl_Window::get_size_range(int *minWidth, int *minHeight,
                                 int *maxWidth, int *maxHeight,
-                                int *deltaX, int *deltaY, int *aspectRatio) {
+                                int *deltaX, int *deltaY, int *aspectRatio) const {
   if (minWidth) *minWidth = minw_;
   if (minHeight) *minHeight = minh_;
   if (maxWidth) *maxWidth = maxw_;
@@ -892,7 +892,7 @@ int Fl_Window::is_resizable() {
 
   \since 1.4.0
  */
-int Fl_Window::screen_num() {
+int Fl_Window::screen_num() const {
   return pWindowDriver->screen_num();
 }
 
@@ -977,7 +977,7 @@ void Fl_Window::shape(const Fl_Image& img) {pWindowDriver->shape(&img);}
 
   \since 1.4.0
 */
-const Fl_Image* Fl_Window::shape() {return pWindowDriver->shape();}
+const Fl_Image* Fl_Window::shape() const {return pWindowDriver->shape();}
 
 /** Returns true when a window is being rescaled.
 
@@ -997,7 +997,7 @@ bool Fl_Window::is_a_rescale() {return Fl_Window_Driver::is_a_rescale_;}
 
   \since 1.4.0
 */
-fl_uintptr_t Fl_Window::os_id() { return pWindowDriver->os_id();}
+fl_uintptr_t Fl_Window::os_id() const { return pWindowDriver->os_id(); }
 
 /**
   Maximizes a top-level window to its current screen.


### PR DESCRIPTION
These Fl_Window methods are 'const' but had not been declared 'const':

- uchar get_size_range(...) const
- int shown() const
- const Fl_Image *shape() const
- int screen_num() const
- fl_uintptr_t os_id() const