### PR TITLE
fix table-sort dir output parsing with strtok()

### DIFF
--- a/examples/table-sort.cxx
+++ b/examples/table-sort.cxx
@@ -277,7 +277,8 @@ void MyTable::fill_from_dircmd() {
     // will get an extra empty, headerless column in our table due to the extra
     // "padding" we do when parsing the 3rd strtok() token for a line
     if ( rowdata_.size() > 2 ) {
-        rowdata_.pop_back(); rowdata_.pop_back();
+        rowdata_.pop_back();
+        rowdata_.pop_back();
         cols(rowdata_.back().cols.size());
     }
 #endif


### PR DESCRIPTION
## Summary

This PR updates the `table-sort` example program to handle the output of `dir` on Windows better.

It ensures that the "Filename" column correctly displays the file/directory names and the "Size" column will have the file sizes. The unnamed third column will hold the `"<DIR>"` marker for any directory listed.

## Details

Currently, after building + running `table-sort` on Windows, one will see the following window (if run in repo root):

<img width="612" height="528" alt="table-sort-win32-current" src="https://github.com/user-attachments/assets/795cf416-69e2-482d-8dd8-ba92835a82d8" />

The reason for the empty "Filename" column is that `MyTable::load_command()` reads tokens from a line of text using `strtok()`, which is fine when using `ls -l` on POSIX systems, but doesn't work as expected with `dir` output on Windows. `dir` output requires some special handling because the `dir` output on the FLTK repo root will look something like the following:

```
    ... CMD header (5 lines) ...
2025-11-30  23:42    <DIR>          .
2025-11-30  22:31    <DIR>          ..
2025-11-30  22:31             5,161 .clang-format
2025-11-30  23:45    <DIR>          .git
2025-11-30  22:31             1,291 .gitattributes
  ... other directory entries ...
              36 File(s)        597,038 bytes
              26 Dir(s)  489,786,810,368 bytes free
```

One can see that each directory entry, if parsed using `strtok()` with `" \t\n"` as delimiters (which is what is currently used), each directory entry line yields only 4 tokens from 5 text columns. Therefore, the 5th column, "Filename", ends up blank.

We fix this by ensuring that on Windows (i.e. enclosed in a `#ifdef _WIN32` block) after reading the first 2 tokens of the `dir` output, we check if the 3rd token is `"<DIR>"` or not, appropriately inserting an empty string after/before appropriately so that each table row gets 5 columns. Since the last row of the `dir` output has 5 tokens (results in 6 table columns), we also remember to resize the table back to 5 columns after dropping the last 2 rows of the `dir` output.

After these changes, `table-sort` now more appropriately mirrors the `dir` output:

<img width="592" height="530" alt="table-sort-win32-updated" src="https://github.com/user-attachments/assets/bcad9d94-5cac-4951-bd7e-a9c47568baeb" />


