### PR TITLE
Correct draw translation by 0.5 pixels only

### DIFF
--- a/src/drivers/Cairo/Fl_Cairo_Graphics_Driver.cxx
+++ b/src/drivers/Cairo/Fl_Cairo_Graphics_Driver.cxx
@@ -1340,7 +1340,7 @@ void Fl_Cairo_Graphics_Driver::draw(const char* str, int n, float x, float y) {
   if (!n) return;
   cairo_save(cairo_);
   Fl_Cairo_Font_Descriptor *fd = (Fl_Cairo_Font_Descriptor*)font_descriptor();
-  cairo_translate(cairo_, x - 1.5, y - (fd->line_height - fd->descent) / float(PANGO_SCALE) - 1.5);
+  cairo_translate(cairo_, x - 0.5, y - (fd->line_height - fd->descent) / float(PANGO_SCALE) - 0.5);
   str = clean_utf8(str, n);
   pango_layout_set_text(pango_layout_, str, n);
   pango_cairo_show_layout(cairo_, pango_layout_); // 1.1O
@@ -1424,8 +1424,8 @@ void Fl_Cairo_Graphics_Driver::text_extents(const char* txt, int n, int& dx, int
   pango_layout_get_extents(pango_layout_, &ink_rect, NULL);
   double f = PANGO_SCALE;
   Fl_Cairo_Font_Descriptor *fd = (Fl_Cairo_Font_Descriptor*)font_descriptor();
-  dx = ink_rect.x / f - 1;
-  dy = (ink_rect.y - fd->line_height + fd->descent) / f - 1;
+  dx = ink_rect.x / f;
+  dy = (ink_rect.y - fd->line_height + fd->descent) / f;
   w = ceil(ink_rect.width / f);
   h = ceil(ink_rect.height / f);
 }


### PR DESCRIPTION
Using 1.5 pixels causes text to be rendered one pixel offset to the top left. This is visible when text is selected as the characters touch the top left border.

The fl_text_extents is also updated to make sure the bounding box is properly placed.

See also #1365

---

Here is the utf8fonts and unittests examples from before:

<img width="1155" height="448" alt="old-selection" src="https://github.com/user-attachments/assets/df6c9d1c-06cd-4d84-8a7e-d6765718aeed" />
<img width="700" height="600" alt="old-extents" src="https://github.com/user-attachments/assets/a656a9fc-4e10-4ebd-981c-5e774cf6b297" />

And from after:

<img width="1153" height="448" alt="new-selection" src="https://github.com/user-attachments/assets/7c3ba367-751b-42c8-94a2-e6273bcd5875" />
<img width="700" height="600" alt="new-extents" src="https://github.com/user-attachments/assets/12b5c29a-f67a-4697-b54d-bae96c71a0ee" />