### PR TITLE
X11: Fix resize of menutitle windows when across 2 screens with diverse scaling

### DIFF
--- a/src/Fl_x.cxx
+++ b/src/Fl_x.cxx
@@ -2247,7 +2247,8 @@ int fl_handle(const XEvent& thisevent)
     resize_bug_fix = window;
 #if USE_XFT || FLTK_USE_CAIRO
     if (!Fl_X11_Window_Driver::data_for_resize_window_between_screens_.busy &&
-      ( ceil(W/s) != window->w() || ceil(H/s) != window->h() ) ) {
+      ( ceil(W/s) != window->w() || ceil(H/s) != window->h() ) &&
+      !window->menu_window()) {
         window->resize(rint(X/s), rint(Y/s), ceil(W/s), ceil(H/s));
     } else {
       window->position(rint(X/s), rint(Y/s));


### PR DESCRIPTION
Fixes the outstanding issue from #1380.

Please backport into branch-1.4 after merging. Thanks.

Before:

<img width="408" height="386" alt="image" src="https://github.com/user-attachments/assets/564d1844-4bda-42ac-b978-c5d512915bd3" />
<img width="311" height="428" alt="image" src="https://github.com/user-attachments/assets/279869a6-ee09-49b2-9e68-46e40867172c" />
<img width="281" height="131" alt="image" src="https://github.com/user-attachments/assets/53d60f82-3f81-4c7e-a1ec-5829ce6c666b" />
<img width="157" height="123" alt="image" src="https://github.com/user-attachments/assets/78c69bd2-c3a9-489a-95b1-0772524d15dd" />

---

After:

<img width="408" height="386" alt="image" src="https://github.com/user-attachments/assets/94ccd8db-39ad-49a0-b42a-a9a33490d0f3" />
<img width="310" height="422" alt="image" src="https://github.com/user-attachments/assets/987b243a-e7a5-44fc-90b6-9d3481c99b8b" />
<img width="302" height="144" alt="image" src="https://github.com/user-attachments/assets/2c2ac398-2183-4067-9376-dee3a05a61b7" />
<img width="156" height="108" alt="image" src="https://github.com/user-attachments/assets/5c9509d9-77be-46a8-8697-a26be55426a6" />
