### PR TITLE
[Idea] Fl_Scrollbar: Remove arrow buttons for very thin scrollbars

### DIFF
--- a/src/Fl_Scrollbar.cxx
+++ b/src/Fl_Scrollbar.cxx
@@ -68,9 +68,9 @@ int Fl_Scrollbar::handle(int event) {
 
   // adjust slider area to be inside the arrow buttons:
   if (horizontal()) {
-    if (W >= 3*H) {X += H; W -= 2*H;}
+    if (W >= 3*H && H >= 7) {X += H; W -= 2*H;}
   } else {
-    if (H >= 3*W) {Y += W; H -= 2*W;}
+    if (H >= 3*W && W >= 7) {Y += W; H -= 2*W;}
   }
 
   // which widget part is highlighted?
@@ -208,7 +208,7 @@ void Fl_Scrollbar::draw() {
     inset = 1;
 
   if (horizontal()) {
-    if (W < 3*H) {
+    if (W < 3*H || H < 7) {
       Fl_Slider::draw(X, Y, W, H);
       return;
     }
@@ -228,7 +228,7 @@ void Fl_Scrollbar::draw() {
       fl_draw_arrow(ab, FL_ARROW_SINGLE, FL_ORIENT_RIGHT, arrowcolor); // right arrow
     }
   } else { // vertical
-    if (H < 3*W) {
+    if (H < 3*W || W < 7) {
       Fl_Slider::draw(X, Y, W, H);
       return;
     }


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**

Currently the "arrow buttons" on both ends of a Fl_Scrollbar disappear if the scrollbar is not at least 3 times as long as it is wide. This is so that the "track" between the buttons is guaranteed to be at least 1/3 of the total length of the scrollbar; if the scrollbar is not long enough, the buttons disappear so that the "track" gets 100% of the length of the scrollbar. [<sup>1</sup>]

However, I think the buttons should also disappear if the scrollbar is too thin.

If the scrollbar is too thin, the buttons are not rendered well and are not very user-friendly.

For example, at 6 pixels wide:

<img width="117" height="108" alt="image" src="https://github.com/user-attachments/assets/7f746360-150c-439b-b664-d060638a192f" />

Personally, I think the arrow buttons are only suitable when the scrollbar is at least 7 pixels wide or wider.

When the scrollbar is less than 7 pixels wide (for example, 6 pixels wide), I think it works much better without the arrow buttons:

<img width="121" height="111" alt="image" src="https://github.com/user-attachments/assets/299bf9b0-9a25-4ca9-8d65-b4554fd073a7" />

**I am using FLTK**

 - Version 1.4.x

**Describe the solution you'd like**

I would really like to add a "thin" scrollbar like this to my FLTK 1.4.x app, but I think currently it is not possible. The proposed solution in this PR would not break the ABI and could be considered for 1.4.5 if there were no objections (although I understand that a "last minute" suggestion/addition like this is not ideal).

My chosen "minimum width" of "7" could be made to be customizable to the application programmer, which might be even better/more flexible, but I think that would break the ABI.

**Describe alternatives you've considered**

I don't think I can change this in my app without making this change directly to FLTK, unless I copy/paste the whole Fl_Scroll widget into a custom widget that is identical to Fl_Scroll except that it uses a custom subclass of Fl_Scrollbar instead of the "real" Fl_Scrollbar class. This seems like a lot of effort for such a small change (a change which I think would also be an appropriate improvement to FLTK itself).

Thanks for reading.

---

[<sup>1</sup>]: My point in explaining this is to point out that it is not unprecedented for Fl_Scrollbar to intelligently hide its arrow buttons at its own discretion.