### PR TITLE
Bugfix: Fix Select/Hold Browser callback with FL_WHEN_RELEASE when mouse is dragged

### DIFF
--- a/src/Fl_Browser_.cxx
+++ b/src/Fl_Browser_.cxx
@@ -789,6 +789,7 @@ J1:
 // This second call of Fl_Browser_::handle() may result in a -
 // somewhat unexpected - second concurrent invocation of the callback.
 
+  static void* initsel;
   static char change;
   static char whichway;
   static int py;
@@ -800,6 +801,7 @@ J1:
       redraw();
     }
     my = py = Fl::event_y();
+    initsel = selection_;
     change = 0;
     if (type() == FL_NORMAL_BROWSER || !top_)
       ;
@@ -904,11 +906,10 @@ J1:
       }
       if (l) selection_ = l;
     } else {
-      void* l1 = selection_;
       void* l =
         (Fl::event_x()<x() || Fl::event_x()>x()+w()) ? selection_ :
         find_item(my);
-      change = (l != l1);
+      change = (l != initsel);
       select_only(l, when() & FL_WHEN_CHANGED);
       if (wp.deleted()) return 1;
     }


### PR DESCRIPTION
**Bug:** When using a Fl_Select_Browser or Fl_Hold_Browser with a `when_` of `FL_WHEN_RELEASE` (ie, "when released and changed"), the callback would fail to be invoked when the mouse is released and the selection is changed if the mouse had been dragged any amount.
(The callback would only be invoked correctly if the mouse is pushed and then released without a single drag event in between the push and the release.)

This happens because a drag _within_ a line tricks the handle function into thinking the selection is not changing. But for the purposes of `FL_WHEN_RELEASE`, we care if the selection at the time of the release is different than the selection at the time of the push.
(Rather than caring about if the selection at the time of the release is different than the selection at the previous pixel movement of the mouse -- this is very unhelpful for Select/Hold.)

**Video:**

https://github.com/user-attachments/assets/7dc1f62f-3408-48c5-80bf-b1f79aa062a6

Steps:
* Run test/browser.exe
* Change the "type" dropdown to "Hold" (or "Select")
* Change the "when" dropdown to "FL_WHEN_RELEASE"
* Click a line
* See that the callback is invoked (in the output at the bottom of the window)
* Press and hold the mouse on any line
* Move the mouse any amount (within the same line, or to another line, or to another line and back again to the original line)
* Release the mouse
* See that the callback is never invoked

**Fix:** The fix for this is to grab the initial selection when the mouse is pushed, and on drag compare the current selection to that initial value.

Note that this fix does not cause any negative effects for other `when_` values like `FL_WHEN_CHANGED` and does not cause any negative issues for `FL_MULTI_BROWSER`.

After:

https://github.com/user-attachments/assets/581eb171-f50a-4678-8200-6ec1564a3c3c

**Additional context:** While adding the first Fl_Browser to my 1.4 app, I found about 5 bugs with event/callback handling in Fl_Browser_. I decided to fix only 1 issue per PR because:
* The `Fl_Browser_::handle()` code is complicated
* I'll submit my bugfixes from most important to least important
* You can veto the less important fixes if you want, while still hopefully accepting the more important bugfixes (like this PR)

Please consider backporting this PR (and the others, once I submit them) to branch-1.4.

Thanks for reading.