### PR TITLE
Bugfix: Fix Select/Hold Browser callback with FL_WHEN_CHANGED when mouse is dragged

### DIFF
--- a/src/Fl_Browser_.cxx
+++ b/src/Fl_Browser_.cxx
@@ -657,6 +657,10 @@ int Fl_Browser_::deselect(int docallbacks) {
     item_select(selection_, 0);
     redraw_line(selection_);
     selection_ = 0;
+    if (docallbacks) {
+      set_changed();
+      do_callback(FL_REASON_CHANGED);
+    }
     return 1;
   }
 }


### PR DESCRIPTION
**Bug:** When using a Fl_Select_Browser or Fl_Hold_Browser with a `when_` of `FL_WHEN_CHANGED`, the callback would fail to be invoked when the mouse is dragged below the last line in the list, ie when the `selection_` is changed to null.

This is because `Fl_Browser_::deselect()` only used `docallbacks` in the FL_MULTI_BROWSER case and fails to check it in the "else" case. The "else" case of `deselect()` is like a simplified version of `Fl_Browser_::select()` so the fix is to include the same last few lines from that function (the `if (docallbacks)` block).

Before:

https://github.com/user-attachments/assets/3401debd-f30d-4bc0-8837-0b646fbf0e6b

After:

https://github.com/user-attachments/assets/2cc48e9c-fdb0-473b-a406-02c12452a30d

Notice the "selection = 0" callbacks that only happen in the "after" video.