### PR TITLE
Bugfix: Fix Hold Browser callback with FL_WHEN_NOT_CHANGED when up/down is pressed

### DIFF
--- a/src/Fl_Browser_.cxx
+++ b/src/Fl_Browser_.cxx
@@ -714,13 +714,16 @@ int Fl_Browser_::handle(int event) {
         switch (Fl::event_key()) {
         case FL_Down:
           while ((l = item_next(l))) {
-            if (item_height(l)>0) {select_only(l, when()); break;}
+            if (item_height(l)>0) {
+              select_only(l, when() & ~FL_WHEN_NOT_CHANGED);
+              break;
+            }
           }
-            return 1;
+          return 1;
         case FL_Up:
           while ((l = item_prev(l))) {
             if (item_height(l)>0) {
-              select_only(l, when());
+              select_only(l, when() & ~FL_WHEN_NOT_CHANGED);
               break; // no need to test wp (return 1)
             }
           }


### PR DESCRIPTION
**Bug:** When using a Fl_Hold_Browser with a `when_` of FL_WHEN_NOT_CHANGED, the callback was still being invoked by the up/down arrow keys, even though the selection is being change.

...I don't know _why_ anyone would want to use FL_WHEN_NOT_CHANGED with Fl_Browser, but I think it should still be predictable and consistent, so I think this should still be fixed.

The fix is that when `select_only()` is called by the FL_Down or FL_Up case, pass `when() & ~FL_WHEN_NOT_CHANGED` instead of `when()`.

I also fixed up the formatting of the FL_Down case to match the formatting of the FL_Up case.

Before:

https://github.com/user-attachments/assets/d8eee953-d0d9-4b3e-b00c-aa3746223fff

After:

https://github.com/user-attachments/assets/f4acd0e2-1f76-4534-afc4-0824e9117d38