### PR TITLE
Bugfix: Fix Multi Browser callback with FL_WHEN_NOT_CHANGED when Enter/space/up/down is pressed

### DIFF
--- a/src/Fl_Browser_.cxx
+++ b/src/Fl_Browser_.cxx
@@ -750,20 +750,26 @@ int Fl_Browser_::handle(int event) {
           }
           return 1;
         }
-      } else  {
+      } else {
         switch (Fl::event_key()) {
         case FL_Enter:
         case FL_KP_Enter:
-          select_only(l, when() & ~FL_WHEN_ENTER_KEY);
-          if (wp.deleted()) return 1;
-          if (when() & FL_WHEN_ENTER_KEY) {
-            set_changed();
-            do_callback(FL_REASON_CHANGED);
+          if (select_only(l, when() & ~FL_WHEN_ENTER_KEY_ALWAYS)) {
+            if (wp.deleted()) return 1;
+            if (when() & FL_WHEN_ENTER_KEY) {
+              set_changed();
+              do_callback(FL_REASON_CHANGED);
+            }
+          } else {
+            if (wp.deleted()) return 1;
+            if ((when() & FL_WHEN_ENTER_KEY) && (when() & FL_WHEN_NOT_CHANGED)) {
+              do_callback(FL_REASON_RESELECTED);
+            }
           }
           return 1;
         case ' ':
           selection_ = l;
-          select(l, !item_selected(l), when() & ~FL_WHEN_ENTER_KEY);
+          select(l, !item_selected(l), when());
           return 1;
         case FL_Down:
           while ((l = item_next(l))) {


### PR DESCRIPTION
**Bug:** When using a Fl_Multi_Browser with a `when_` of FL_WHEN_NOT_CHANGED, the callback was not being invoked correctly/consistently when Enter/space/up/down is pressed. (The callback would be invoked in several different scenarios when it shouldn't be, and sometimes called with the wrong `FL_REASON_*`.)

To summarize the changes:

* For space, up, and down: Pass `when() & ~(FL_WHEN_ENTER_KEY | FL_WHEN_NOT_CHANGED)` when `select()` is called.
   * The `when()` needs to include something other than FL_WHEN_ENTER_KEY or FL_WHEN_NOT_CHANGED for `select()` to consider doing the callback when a change occurs. (Remember for up/down, shift or ctrl must be held.)
   * This stops the callback from being invoked in cases where it shouldn't be.
* For Enter:
   * Also pass `when() & ~(FL_WHEN_ENTER_KEY | FL_WHEN_NOT_CHANGED)` when `select_only()` is called. This stops the callback from being invoked in cases where it shouldn't be.
   * Previously, the callback would be invoked with `FL_REASON_CHANGED` after `select_only()` is called, regardless of whether a change occurred (ie, even if `select_only()` returned 0). This must only be done if `select_only()` returned 1, so this is now wrapped in an `if` instead of coming immediately after the call to `select_only()`.
   * Additionally, there is now an `else` block for invoking the callback with `FL_REASON_RESELECTED` if `select_only()` returns 0, and only doing so if `when()` includes `FL_WHEN_ENTER_KEY_ALWAYS` (ie, FL_WHEN_ENTER_KEY and FL_WHEN_NOT_CHANGED).

A video of the before and after isn't very helpful here, since you wouldn't be able to see when I am pressing space or enter, or see when I am holding shift or ctrl.

To test:
* Run test/browser.exe
* Set the "when" dropdown to "FL_WHEN_NOT_CHANGED", "FL_WHEN_ENTER_KEY", or "FL_WHEN_ENTER_KEY_ALWAYS"
* Test all combinations of Enter, space, up, down
* See that the callback is invoked only exactly when expected