### PR TITLE
Fix test/browser.cxx focus on first line

### DIFF
--- a/test/browser.cxx
+++ b/test/browser.cxx
@@ -145,11 +145,11 @@ void sort_cb(Fl_Widget *, void *) {
 
 void btype_cb(Fl_Widget *, void *) {
   for ( int t=1; t<=browser->size(); t++ ) browser->select(t,0);
-  browser->select(1,0);         // leave focus box on first line
        if ( strcmp(btype->text(),"Normal")==0) browser->type(FL_NORMAL_BROWSER);
   else if ( strcmp(btype->text(),"Select")==0) browser->type(FL_SELECT_BROWSER);
   else if ( strcmp(btype->text(),"Hold"  )==0) browser->type(FL_HOLD_BROWSER);
   else if ( strcmp(btype->text(),"Multi" )==0) browser->type(FL_MULTI_BROWSER);
+  browser->select(1,0);         // leave focus box on first line
   browser->redraw();
 }
 


### PR DESCRIPTION
For a long while I thought this was a bug with Fl_Browser_, but ultimately I decided this was just a bug with the test program.

Previously, when changing the browser type, it "deselected" all the lines one by one, then deselected again the first line (to give it focus), according to the _current type's_ "select" logic, and _then_ it changed the type to the new type.

The issue with this is that when changing from Multi to Hold, it leaves the first line _focused_ but not _selected_, which is not normally a valid scenario for Hold-type. When this happens, _clicking_ on the first (focused-but-not-selected) line, the line fails to become highlighted because it is already the internal `selection_` item, and `Fl_Browser_::select()` returns early before highlighting it.

So instead, deselect all the lines one by one, then change the type to the new type, then deselect again the first line to give it focus.
This leaves the first line properly un-selected when changing to "Hold", and so clicking on it correctly selects it.

Before:

https://github.com/user-attachments/assets/05b71999-3d0b-4f20-aeb7-2cfb5b02cb06

After:

https://github.com/user-attachments/assets/7e65d294-9e72-4f6b-84b7-46f1e507d6fd

If this \*were\* to be considered a bug with Fl_Browser_ (if we were to try to fix `Fl_Browser_::select()` to correctly highlight the line when the focused-but-not-selected line is clicked while type=Hold), then it would be fixed with a change like this:

```diff
diff --git a/src/Fl_Browser_.cxx b/src/Fl_Browser_.cxx
index 56b751415..ea8e193b6 100644
--- a/src/Fl_Browser_.cxx
+++ b/src/Fl_Browser_.cxx
@@ -615,7 +615,7 @@ int Fl_Browser_::select(void* item, int val, int docallbacks) {
     item_select(item, val);
     redraw_line(item);
   } else {
-    if (val && selection_ == item) return 0;
+    if (val && selection_ == item && item_selected(item)) return 0;
     if (!val && selection_ != item) return 0;
     if (selection_) {
       item_select(selection_, 0);
```

(ie, don't return early unless the "selected" item is \*really\* selected)

But I don't think this change is necessary IMO.