### PR TITLE
Bugfix: Fl_Hold_Browser: Don't skip first line on down press if nothing is selected

### DIFF
--- a/src/Fl_Browser_.cxx
+++ b/src/Fl_Browser_.cxx
@@ -717,11 +717,13 @@ int Fl_Browser_::handle(int event) {
       if (type()==FL_HOLD_BROWSER) {
         switch (Fl::event_key()) {
         case FL_Down:
-          while ((l = item_next(l))) {
+          if (l1) l = item_next(l);
+          while (l) {
             if (item_height(l)>0) {
               select_only(l, when() & ~FL_WHEN_NOT_CHANGED);
               break;
             }
+            l = item_next(l);
           }
           return 1;
         case FL_Up:


### PR DESCRIPTION
Pressing the down arrow key in a Fl_Hold_Browser while nothing is selected would skip straight from "line 0" to line 2, but in this scenario it makes much more sense for line 1 to become selected.

Before:

https://github.com/user-attachments/assets/0abfaa89-87c6-49b7-be76-54be46fcbe41

After:

https://github.com/user-attachments/assets/be7220a3-fdcf-4b1b-845e-7d195a1b6a81

This is my last bugfix for Fl_Browser_. Thanks for considering.

If #1396 is merged first, this PR will have merge conflicts, but I'll be happy to fix it.