### PR TITLE
Paused: Add std::function callback support for Fl_Widget

### DIFF
--- a/FL/Fl_File_Chooser.H
+++ b/FL/Fl_File_Chooser.H
@@ -1,7 +1,7 @@
 //
 // Fl_File_Chooser dialog for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2024 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/FL/Fl_File_Chooser.H
+++ b/FL/Fl_File_Chooser.H
@@ -54,14 +54,22 @@ public:
                    ///< effect for directories.
     DIRECTORY = 4  ///< Select a single, existing directory. Can be combined with CREATE.
   };
+protected:
+  /**
+   Values for flags_ field.
+  */
+  enum Flags {
+  AUTO_DELETE_USER_DATA = 1<<0, ///< automatically call `delete` on the user_data pointer when destroying this widget; if set, user_data must point to a class derived from the class Fl_Callback_User_Data
+};
 private:
   static Fl_Preferences *prefs_;
-  void (*callback_)(Fl_File_Chooser*, void *);
-  void *data_;
+  void (*callback_)(Fl_File_Chooser*, void *) = nullptr;
+  void *user_data_ = nullptr;
   char directory_[FL_PATH_MAX];
   char pattern_[FL_PATH_MAX];
   char preview_text_[2048];
   int type_;
+  unsigned int flags_ = 0;
   void favoritesButtonCB();
   void favoritesCB(Fl_Widget *w);
   void fileListCB();
@@ -135,7 +143,6 @@ private:
   static void cb_favOkButton(Fl_Return_Button*, void*);
 public:
   ~Fl_File_Chooser();
-  void callback(void (*cb)(Fl_File_Chooser *, void *), void *d = 0);
   void color(Fl_Color c);
   Fl_Color color();
   int count();
@@ -170,8 +177,11 @@ public:
   Fl_Fontsize textsize();
   void type(int t);
   int type();
+  void callback(void (*cb)(Fl_File_Chooser *, void *), void *d = 0);
+  void callback(void (*cb)(Fl_File_Chooser *, void *), Fl_Callback_User_Data* d, bool auto_free);
   void * user_data() const;
   void user_data(void *d);
+  void user_data(Fl_Callback_User_Data* d, bool auto_free);
   const char *value(int f = 1);
   void value(const char *filename);
   int visible();
@@ -249,6 +259,9 @@ public:
   Fl_Widget* add_extra(Fl_Widget* gr);
 protected:
   void show_error_box(int val);
+  unsigned int flags() const;
+  void set_flag(unsigned int c);
+  void clear_flag(unsigned int c);
 };
 FL_EXPORT char *fl_dir_chooser(const char *message,const char *fname,int relative=0);
 FL_EXPORT char *fl_file_chooser(const char *message,const char *pat,const char *fname,int relative=0);

--- a/FL/Fl_Menu_Item.H
+++ b/FL/Fl_Menu_Item.H
@@ -139,6 +139,9 @@ struct FL_EXPORT Fl_Menu_Item {
   int shortcut_;            ///< menu item shortcut
   Fl_Callback *callback_;   ///< menu item callback
   void *user_data_;         ///< menu item user_data for the menu's callback
+  // This class does not support Fl_Callback_User_Data. Menu Item instances are
+  // usually statically initialised as part of an array and a destructor is
+  // never called, so there is no need to manage ownership.
   int flags;                ///< menu item flags like FL_MENU_TOGGLE, FL_MENU_RADIO
   uchar labeltype_;         ///< how the menu item text looks like
   Fl_Font labelfont_;       ///< which font for this menu item text

--- a/FL/Fl_Menu_Item.H
+++ b/FL/Fl_Menu_Item.H
@@ -1,7 +1,7 @@
 //
 // Menu item header file for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2024 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/FL/Fl_Tree_Item.H
+++ b/FL/Fl_Tree_Item.H
@@ -16,7 +16,7 @@
 //////////////////////
 //
 // Fl_Tree -- This file is part of the Fl_Tree widget for FLTK
-// Copyright (C) 2009-2010 by Greg Ercolano.
+// Copyright (C) 2009-2026 by Greg Ercolano.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/FL/Fl_Tree_Item.H
+++ b/FL/Fl_Tree_Item.H
@@ -71,10 +71,11 @@ class FL_EXPORT Fl_Tree_Item {
   Fl_Color                _labelbgcolor;        // label's bg color (0xffffffff is 'transparent')
   /// \enum Fl_Tree_Item_Flags
   enum Fl_Tree_Item_Flags {
-    OPEN                = 1<<0,         ///> item is open
-    VISIBLE             = 1<<1,         ///> item is visible
-    ACTIVE              = 1<<2,         ///> item is active
-    SELECTED            = 1<<3          ///> item is selected
+    OPEN                  = 1<<0,         ///> item is open
+    VISIBLE               = 1<<1,         ///> item is visible
+    ACTIVE                = 1<<2,         ///> item is active
+    SELECTED              = 1<<3,         ///> item is selected
+    AUTO_DELETE_USER_DATA = 1<<4          ///> see Fl_Widget::AUTO_DELETE_USER_DATA for details
   };
   unsigned short _flags;                // misc flags
   int                     _xywh[4];             // xywh of this widget (if visible)
@@ -134,9 +135,8 @@ public:
   void label(const char *val);
   const char *label() const;
 
-  /// Set a user-data value for the item.
-  inline void user_data( void* data ) { _userdata = data; }
-
+  void user_data( void* data );
+  void user_data(Fl_Callback_User_Data* data, bool auto_delete);
   /// Retrieve the user-data value that has been assigned to the item.
   inline void* user_data() const { return _userdata; }
 

--- a/FL/Fl_Widget.H
+++ b/FL/Fl_Widget.H
@@ -1,7 +1,7 @@
 //
 // Widget header file for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2025 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this
@@ -93,9 +93,9 @@ struct FL_EXPORT Fl_Label {
  */
 class FL_EXPORT Fl_Callback_User_Data {
 protected:
-  Fl_Callback_User_Data() {} ///< Protected constructor
+  Fl_Callback_User_Data() = default; ///< Protected constructor
 public:
-  virtual ~Fl_Callback_User_Data() { } ///< Destructor
+  virtual ~Fl_Callback_User_Data() = default; ///< Destructor
   /// Clone method to allow copying of user data when needed.
   /// *Must* be overridden by derived classes that are used in Fl_Tree_Item.
   virtual Fl_Callback_User_Data* clone() const { return new Fl_Callback_User_Data(*this); }
@@ -107,6 +107,7 @@ protected:
   std::function<void(Fl_Widget*)> func; ///< The lambda function to be called
 public:
   Fl_Std_Function_User_Data(std::function<void(Fl_Widget*)> f) : func(std::move(f)) {}
+  ~Fl_Std_Function_User_Data() override = default; ///< Default destructor
   Fl_Callback_User_Data* clone() const override { return new Fl_Std_Function_User_Data(*this); } ///< Clone method for Lambda captures
   void call(Fl_Widget* widget) { func(widget); } ///< Call the stored lambda function
 };

--- a/FL/Fl_Widget.H
+++ b/FL/Fl_Widget.H
@@ -97,7 +97,7 @@ protected:
 public:
   virtual ~Fl_Callback_User_Data() { } ///< Destructor
   /// Clone method to allow copying of user data when needed.
-  /// *Must* be overridden by derived classes that are used in Fl_Menu_Item.
+  /// *Must* be overridden by derived classes that are used in Fl_Tree_Item.
   virtual Fl_Callback_User_Data* clone() const { return new Fl_Callback_User_Data(*this); }
 };
 
@@ -806,9 +806,9 @@ public:
   /** Sets the widget callback to a \c std::function.
 
     Accepts any callable that matches the callback signature, including
-    capturing lambdas and \c std::bind expressions. Unlike the classic
-    C-style callback, there is no user data field — captures provide
-    type-safe access to context data without casting.
+    capturing lambdas and \c std::bind expressions. The user data field
+    is used internally and must not be overwritten; use captures instead
+    for type-safe access to context data without casting.
 
     \param[in] cb new callback
   */

--- a/FL/Fl_Widget.H
+++ b/FL/Fl_Widget.H
@@ -94,6 +94,9 @@ protected:
   Fl_Callback_User_Data() {} ///< Protected constructor
 public:
   virtual ~Fl_Callback_User_Data() { } ///< Destructor
+  /// Clone method to allow copying of user data when needed.
+  /// *Must* be overridden by derived classes that are used in Fl_Menu_Item.
+  virtual Fl_Callback_User_Data* clone() const { return new Fl_Callback_User_Data(*this); }
 };
 
 

--- a/FL/Fl_Widget.H
+++ b/FL/Fl_Widget.H
@@ -101,15 +101,15 @@ public:
   virtual Fl_Callback_User_Data* clone() const { return new Fl_Callback_User_Data(*this); }
 };
 
-/** Callback user data to manage Lambda expressions with captures. */
+/** Callback user data to manage std::function based callbacks. */
 class FL_EXPORT Fl_Std_Function_User_Data : public Fl_Callback_User_Data {
 protected:
-  std::function<void(Fl_Widget*)> func; ///< The lambda function to be called
+  std::function<void(Fl_Widget*)> func; ///< The std::function to be called
 public:
   Fl_Std_Function_User_Data(std::function<void(Fl_Widget*)> f) : func(std::move(f)) {}
   ~Fl_Std_Function_User_Data() override = default; ///< Default destructor
-  Fl_Callback_User_Data* clone() const override { return new Fl_Std_Function_User_Data(*this); } ///< Clone method for Lambda captures
-  void call(Fl_Widget* widget) { func(widget); } ///< Call the stored lambda function
+  Fl_Callback_User_Data* clone() const override { return new Fl_Std_Function_User_Data(*this); } ///< Clone this class
+  void call(Fl_Widget* widget) { func(widget); } ///< Call the stored std::function
 };
 
 /** Fl_Widget is the base class for all widgets in FLTK.

--- a/FL/Fl_Widget.H
+++ b/FL/Fl_Widget.H
@@ -803,8 +803,13 @@ public:
     user_data((void*)(fl_intptr_t)p);
   }
 
-  /** Sets the current callback to a Lambda expression with capture or std::function.
-    Each widget has a single callback.
+  /** Sets the widget callback to a \c std::function.
+
+    Accepts any callable that matches the callback signature, including
+    capturing lambdas and \c std::bind expressions. Unlike the classic
+    C-style callback, there is no user data field — captures provide
+    type-safe access to context data without casting.
+
     \param[in] cb new callback
   */
   void callback(std::function<void(Fl_Widget*)> f) {

--- a/FL/Fl_Widget.H
+++ b/FL/Fl_Widget.H
@@ -24,6 +24,8 @@
 
 #include "Fl.H"
 
+#include <functional>
+
 class Fl_Widget;
 class Fl_Window;
 class Fl_Group;
@@ -99,6 +101,15 @@ public:
   virtual Fl_Callback_User_Data* clone() const { return new Fl_Callback_User_Data(*this); }
 };
 
+/** Callback user data to manage Lambda expressions with captures. */
+class FL_EXPORT Fl_Std_Function_User_Data : public Fl_Callback_User_Data {
+protected:
+  std::function<void(Fl_Widget*)> func; ///< The lambda function to be called
+public:
+  Fl_Std_Function_User_Data(std::function<void(Fl_Widget*)> f) : func(std::move(f)) {}
+  Fl_Callback_User_Data* clone() const override { return new Fl_Std_Function_User_Data(*this); } ///< Clone method for Lambda captures
+  void call(Fl_Widget* widget) { func(widget); } ///< Call the stored lambda function
+};
 
 /** Fl_Widget is the base class for all widgets in FLTK.
 
@@ -129,6 +140,8 @@ class FL_EXPORT Fl_Widget {
   uchar when_;
 
   const char *tooltip_;
+
+  static void do_std_function_callback_(Fl_Widget* w, void* data);
 
   /** unimplemented copy ctor */
   Fl_Widget(const Fl_Widget &);
@@ -788,6 +801,15 @@ public:
   void callback(Fl_Callback1* cb, long p = 0) {
     callback_ = (Fl_Callback*)(fl_intptr_t)(cb);
     user_data((void*)(fl_intptr_t)p);
+  }
+
+  /** Sets the current callback to a Lambda expression with capture or std::function.
+    Each widget has a single callback.
+    \param[in] cb new callback
+  */
+  void callback(std::function<void(Fl_Widget*)> f) {
+    callback_ = do_std_function_callback_;
+    user_data(new Fl_Std_Function_User_Data(std::move(f)), true);
   }
 
   /** Gets the user data for this widget.

--- a/FL/fl_callback_macros.H
+++ b/FL/fl_callback_macros.H
@@ -23,6 +23,11 @@
  \file fl_callback_macros.H
  This file provides macros for easy function and method callbacks
  with multiple type safe arguments.
+
+ FLTK support C++11 style std::function callbacks, which can be used with
+ capturing lambdas and `std::bind` expressions with Fl_Widget callbacks.
+ These macros are no longer the preferred method for defining callbacks
+ and are now deprecated.
 */
 
 #ifdef FL_DOXYGEN

--- a/FL/fl_callback_macros.H
+++ b/FL/fl_callback_macros.H
@@ -1,7 +1,7 @@
 /*
  * Macros for easy callbacks for the Fast Light Tool Kit (FLTK).
  *
- * Copyright 2023-2025 by Bill Spitzak and others.
+ * Copyright 2023-2026 by Bill Spitzak and others.
  *
  * This library is free software. Distribution and use rights are outlined in
  * the file "COPYING" which should have been included with this file.  If this

--- a/documentation/src/common.dox
+++ b/documentation/src/common.dox
@@ -559,7 +559,10 @@ button->callback( [](Fl_Widget*, void*) { puts("Hello"); } , nullptr );
 
 Since version 1.5, Fl_Widget and all derived classes support
 `std::function`-based callbacks, including capturing lambdas and `std::bind`
-expressions. Unlike the classic C-style callback, there is no user data
+expressions. The user data field is used internally and must not be overwritten;
+use captures instead for type-safe access to context data without casting.
+
+Unlike the classic C-style callback, there is no user data
 field — instead, captures provide type-safe access to context data
 without casting.
 

--- a/documentation/src/common.dox
+++ b/documentation/src/common.dox
@@ -557,18 +557,65 @@ It's also possible to use a non-capturing lambda function directly, for example:
 button->callback( [](Fl_Widget*, void*) { puts("Hello"); } , nullptr );
 ```
 
-Many programmers new to FLTK or C++ try to use a
-non-static class method instead of a static class method
-or function for their callback. Since callbacks are done
-outside a C++ class, the `this` pointer is not
-initialized for class methods.
+Since version 1.5, Fl_Widget and all derived classes support
+`std::function`-based callbacks, including capturing lambdas and `std::bind`
+expressions. Unlike the classic C-style callback, there is no user data
+field — instead, captures provide type-safe access to context data
+without casting.
 
-To work around this problem, define a static method
-in your class that accepts a pointer to the class, and
-then have the static method call the class method(s) as
-needed. The data pointer you provide to the
-\p callback() method of the widget can be a
-pointer to the instance of your class.
+Lambda captures:
+
+The following example captures two strings at the point the callback is set,
+then uses them when the button is pressed:
+
+\code
+Fl_Button *btn = new Fl_Button(10, 10, 100, 100);
+std::string name = "Mr. Smith";
+std::string text = "Thank you for contacting us, %s!";
+btn->callback(
+  [name, text](Fl_Widget *w) {
+    fl_message(text.c_str(), name.c_str());
+  }
+);
+\endcode
+
+Capturing `this` is particularly useful for invoking member functions directly,
+removing the need for the static trampoline workaround required
+in older FLTK versions:
+
+\code
+class MyButton : public Fl_Button {
+  ...
+  void beep(int pitch, double duration) { ... }
+};
+...
+MyButton* btn = new MyButton(...);
+btn->callback([this](Fl_Widget* w) { beep(1000, 0.2); });
+\endcode
+
+Adapting signatures with std::bind
+
+When the target function has a different signature than the FLTK callback,
+`std::bind` maps it cleanly — bound arguments are captured implicitly
+with no extra boilerplate:
+
+\code
+void test_cb(int x, int y, int z) { printf("%d %d %d\n", x, y, z); }
+...
+Fl_Button *btn = new Fl_Button(10, 10, 100, 100);
+btn->callback(std::bind(test_cb, 1, 2, 42));
+\endcode
+
+Compatibility with older FLTK versions
+
+Prior to version 1.5, only static C-style callbacks were supported. Because
+these callbacks execute outside any class instance, member functions could
+not be called directly. The standard workaround was to define a static method
+accepting a pointer to the class instance, pass that pointer as the callback's
+user data, and dispatch to the desired member from there.
+
+This pattern remains valid for code that must support older FLTK versions.
+It is still required for `Fl_Menu_Item` based callbacks.
 
 \code
 class Foo {
@@ -580,40 +627,9 @@ class Foo {
 w->callback(my_static_callback, (void *)this);
 \endcode
 
-In an effort to make callbacks easier, more flexible, and type safe, FLTK
-provides three groups of macros that generate the code needed to call class
-methods directly with up to five custom parameters.
-
- - `FL_FUNCTION_CALLBACK_#(WIDGET, FUNCTION, ...)` creates code for callbacks to
-    functions and static class methods with up to five arguments. The `#` must
-    be replaced by the number of callback arguments.
- - `FL_METHOD_CALLBACK_#(WIDGET, CLASS, SELF, METH, ...)` creates code for
-    callbacks to arbitrary public class methods
- - `FL_INLINE_CALLBACK_#(WIDGET, ..., FUNCTION_BODY)` creates code for callback
-    functions that are very close to (almost in the same line) the widget
-    creation code, similar to lambda function in C++11. The last argument of
-    this macro is the callback code.
-
-The syntax is a bit unconventional, but the resulting code is flexible and
-needs no additional maintenance. It is also C++98 compatible. For example:
-
-\code
-#include <FL/fl_callback_macros.H>
-...
-std::string *str = new std::string("FLTK");
-Fl_Button *btn = new Fl_Button(10, 10, 100, 100);
-FL_METHOD_CALLBACK_2(btn,  std::string, str, insert,  int, 2,  const char*, "...");
-...
-Fl_Button *inline_cb_btn_2 = new Fl_Button(390, 60, 180, 25, "2 args");
-FL_INLINE_CALLBACK_2( inline_cb_btn_2,
-                      const char *, text, "FLTK",   int, number, 2,
-                      {
-                        fl_message("We received the message %s with %d!", text, number);
-                      }
-                    );
-\endcode
-
-\see Fl_Widget::callback(Fl_Callback*, void*), FL_FUNCTION_CALLBACK_3, FL_METHOD_CALLBACK_1, FL_INLINE_CALLBACK_2
+The `FL_FUNCTION_CALLBACK_...` and `FL_METHOD_CALLBACK_...` macros in
+`<FL/fl_callback_macros.H>` were provided to automate this pattern and are
+now deprecated.
 
 \section common_when When and Reason
 

--- a/fluid/app/Image_Asset.cxx
+++ b/fluid/app/Image_Asset.cxx
@@ -308,7 +308,7 @@ void Image_Asset::write_file_error(fld::io::Code_Writer& f, const char *fmt) {
 
  \code
   static Fl_Image *'initializer_function_'() {
-    static Fl_Image *image = 0L;
+    static Fl_Image *image = nullptr;
     if (!image)
       image = new 'type_name'('product of format and remaining args');
     return image;
@@ -325,7 +325,7 @@ void Image_Asset::write_initializer(fld::io::Code_Writer& f, const char *image_c
   f.write_c("static Fl_Image *%s() {\n", initializer_function_.c_str());
   if (is_animated_gif_)
     f.write_c("%sFl_GIF_Image::animate = true;\n", f.indent(1));
-  f.write_c("%sstatic Fl_Image *image = 0L;\n", f.indent(1));
+  f.write_c("%sstatic Fl_Image *image = nullptr;\n", f.indent(1));
   f.write_c("%sif (!image)\n", f.indent(1));
   f.write_c("%simage = new %s(", f.indent(2), image_class);
   f.vwrite_c(format, ap);

--- a/fluid/documentation/src/page_widget_panel.dox
+++ b/fluid/documentation/src/page_widget_panel.dox
@@ -376,8 +376,10 @@
 
  If the first letter of the callback text is a '[', FLUID expects a lambda
  function which will be inlined into the widget creation code. The lambda
- signature must be `[](Fl_Widget*, void*)->void { ... }`. The widget pointer
- can be casted to another type inside the lambda.
+ signature must be `[](Fl_Widget*, void*)->void { ... }` for "C" style
+ callbacks, or `[capture](Fl_Widget*)->void { ... }` for `std::function`
+ style callbacks. Fluid also recognizes and inlines callbacks starting
+ with `std::bind`.
 
  Otherwise, FLUID assumes that the text is the body of a C++ function,
  and a local static callback function is created. The name of the callback

--- a/fluid/nodes/Grid_Node.cxx
+++ b/fluid/nodes/Grid_Node.cxx
@@ -1,7 +1,7 @@
 //
 // Grid Node code for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 2023-2025 by Bill Spitzak and others.
+// Copyright 2023-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/fluid/nodes/Grid_Node.cxx
+++ b/fluid/nodes/Grid_Node.cxx
@@ -617,7 +617,7 @@ void Grid_Node::write_code2(fld::io::Code_Writer& f) {
     Fl_Grid::Cell *cell = grid->cell(c);
     if (cell) {
       if (first_cell) {
-        f.write_c("%sFl_Grid::Cell *cell = 0L;\n", f.indent());
+        f.write_c("%sFl_Grid::Cell *cell = nullptr;\n", f.indent());
         first_cell = false;
       }
       f.write_c("%scell = %s->widget(%s->child(%d), %d, %d, %d, %d, %d);\n",

--- a/fluid/nodes/Menu_Node.cxx
+++ b/fluid/nodes/Menu_Node.cxx
@@ -1,7 +1,7 @@
 //
 // Menu Node code for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2025 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/fluid/nodes/Menu_Node.cxx
+++ b/fluid/nodes/Menu_Node.cxx
@@ -867,7 +867,7 @@ void Menu_Bar_Node::write_static(fld::io::Code_Writer& f) {
       f.write_c_once( // must be less than 1024 bytes!
                      "\nclass %s: public %s {\n"
                      "public:\n"
-                     "  %s(int x, int y, int w, int h, const char *l=0L)\n"
+                     "  %s(int x, int y, int w, int h, const char *l=nullptr)\n"
                      "  : %s(x, y, w, h, l) { }\n"
                      "  void *_parent_class;\n"
                      "};\n",

--- a/fluid/nodes/Node.h
+++ b/fluid/nodes/Node.h
@@ -165,8 +165,10 @@ protected:
   /** Label text of a widget. */
   const char *label_;
   /** If it is just a word, it's the name of the callback function. If it starts
-   with a '[', it's a lambda function. Otherwise it is the full callback
-   C++ code. Can be nullptr. */
+   with a '[', it's a lambda function. `std::bind` expressions are recognized
+   and inlined. In all other cases, this text is recognized as C++ code, and
+   generates a callback function, including the static trampoline if required.
+   Can be nullptr. */
   const char *callback_;
   /** Widget user data field as C++ text. */
   std::string user_data_;

--- a/fluid/nodes/Node.h
+++ b/fluid/nodes/Node.h
@@ -1,7 +1,7 @@
 //
 // Node base class header file for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2025 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/fluid/nodes/Widget_Node.cxx
+++ b/fluid/nodes/Widget_Node.cxx
@@ -1542,7 +1542,12 @@ void Widget_Node::write_static(fld::io::Code_Writer& f) {
     if (strchr(c, '[') == nullptr) f.write_c("%s *%s=(%s *)0;\n", t.c_str(), c, t.c_str());
     else f.write_c("%s *%s={(%s *)0};\n", t.c_str(), c, t.c_str());
   }
-  if (callback() && !is_name(callback()) && (callback()[0] != '[')) {
+  // Check if we need to write a standalone callback funtion
+  if (callback() &&                                 // callback defined
+      !is_name(callback()) &&                       // callback is not a simple name (externel function)
+      (callback()[0] != '[') &&                     // it's not a lambda expression
+      (strncmp(callback(), "std::bind(", 10) != 0)) // and not a `std::bind` call
+  {
     // see if 'o' or 'v' used, to prevent unused argument warnings:
     int use_o = 0;
     int use_v = 0;
@@ -1933,7 +1938,9 @@ void Widget_Node::write_widget_code(fld::io::Code_Writer& f) {
       f.write_c_indented(callback(), 1, 0);
       f.write_c("\n");
       f.tag(Mergeback::Tag::WIDGET_CALLBACK, Mergeback::Tag::GENERIC, get_uid());
-      f.write_c("%s", f.indent_plus(1));
+      f.write_c("%s", f.indent());
+    } else if (strncmp(callback(), "std::bind(", 10) == 0) { // std::bind callback function
+      f.write_c("%s%s->callback(%s", f.indent(), var, callback());
     } else {
       f.write_c("%s%s->callback((Fl_Callback*)%s", f.indent(), var, callback_name(f));
     }

--- a/fluid/panels/about_panel.cxx
+++ b/fluid/panels/about_panel.cxx
@@ -1,7 +1,7 @@
 //
 // About dialog for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2021 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/fluid/panels/about_panel.cxx
+++ b/fluid/panels/about_panel.cxx
@@ -139,7 +139,7 @@ static const unsigned char idata_fluid[] =
 99,199,176,225,186,61,16,35,74,220,19,2,0,59};
 static Fl_Image *image_fluid() {
   Fl_GIF_Image::animate = true;
-  static Fl_Image *image = 0L;
+  static Fl_Image *image = nullptr;
   if (!image)
     image = new Fl_Anim_GIF_Image("fluid.animated.gif", idata_fluid, 2545);
   return image;

--- a/fluid/panels/about_panel.fl
+++ b/fluid/panels/about_panel.fl
@@ -6,7 +6,7 @@ include_guard {}
 comment {//
 // About dialog for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2021 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/fluid/panels/about_panel.h
+++ b/fluid/panels/about_panel.h
@@ -1,7 +1,7 @@
 //
 // About dialog for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2021 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/fluid/panels/settings_panel.cxx
+++ b/fluid/panels/settings_panel.cxx
@@ -1,7 +1,7 @@
 //
 // Setting and shell dialogs for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2025 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/fluid/panels/settings_panel.cxx
+++ b/fluid/panels/settings_panel.cxx
@@ -228,7 +228,7 @@ static const unsigned char idata_general_64[] =
 150,102,123,63,248,127,27,97,180,206,27,14,172,151,0,0,0,0,73,69,78,68,174,66,
 96,130};
 static Fl_Image *image_general_64() {
-  static Fl_Image *image = 0L;
+  static Fl_Image *image = nullptr;
   if (!image)
     image = new Fl_PNG_Image("general_64.png", idata_general_64, 2162);
   return image;
@@ -361,7 +361,7 @@ static const unsigned char idata_document_64[] =
 147,239,104,255,202,153,244,20,250,15,100,60,232,29,230,9,101,148,0,0,0,0,73,69,
 78,68,174,66,96,130};
 static Fl_Image *image_document_64() {
-  static Fl_Image *image = 0L;
+  static Fl_Image *image = nullptr;
   if (!image)
     image = new Fl_PNG_Image("document_64.png", idata_document_64, 927);
   return image;
@@ -500,7 +500,7 @@ static const unsigned char idata_layout_64[] =
 219,234,153,20,127,159,185,12,250,99,90,14,203,239,127,120,165,154,78,208,47,
 215,15,118,242,56,45,94,1,0,0,0,0,73,69,78,68,174,66,96,130};
 static Fl_Image *image_layout_64() {
-  static Fl_Image *image = 0L;
+  static Fl_Image *image = nullptr;
   if (!image)
     image = new Fl_PNG_Image("layout_64.png", idata_layout_64, 481);
   return image;
@@ -878,7 +878,7 @@ static const unsigned char idata_shell_64[] =
 82,219,229,239,135,114,138,14,109,164,201,83,85,44,126,133,81,55,103,232,191,0,
 145,21,211,195,226,88,204,195,0,0,0,0,73,69,78,68,174,66,96,130};
 static Fl_Image *image_shell_64() {
-  static Fl_Image *image = 0L;
+  static Fl_Image *image = nullptr;
   if (!image)
     image = new Fl_PNG_Image("shell_64.png", idata_shell_64, 802);
   return image;
@@ -1679,7 +1679,7 @@ static const unsigned char idata_fd_project[] =
 213,122,16,176,223,94,207,73,175,70,249,59,81,177,117,128,158,31,49,127,246,30,
 207,181,170,20,0,0,0,0,73,69,78,68,174,66,96,130};
 static Fl_Image *image_fd_project() {
-  static Fl_Image *image = 0L;
+  static Fl_Image *image = nullptr;
   if (!image)
     image = new Fl_PNG_Image("fd_project.png", idata_fd_project, 6950);
   return image;
@@ -2044,7 +2044,7 @@ static const unsigned char idata_fd_user[] =
 116,89,108,93,41,107,255,5,119,155,194,247,64,241,254,70,0,0,0,0,73,69,78,68,
 174,66,96,130};
 static Fl_Image *image_fd_user() {
-  static Fl_Image *image = 0L;
+  static Fl_Image *image = nullptr;
   if (!image)
     image = new Fl_PNG_Image("fd_user.png", idata_fd_user, 8612);
   return image;
@@ -2123,7 +2123,7 @@ static const unsigned char idata_language_64[] =
 157,33,48,255,61,163,226,212,114,146,206,17,166,130,48,126,136,23,88,161,222,
 205,191,56,75,123,84,202,251,159,166,0,0,0,0,73,69,78,68,174,66,96,130};
 static Fl_Image *image_language_64() {
-  static Fl_Image *image = 0L;
+  static Fl_Image *image = nullptr;
   if (!image)
     image = new Fl_PNG_Image("language_64.png", idata_language_64, 1450);
   return image;
@@ -2436,7 +2436,7 @@ static const unsigned char idata_user_circle_64[] =
 252,106,89,247,128,255,3,60,207,245,248,165,38,113,147,0,0,0,0,73,69,78,68,174,
 66,96,130};
 static Fl_Image *image_user_circle_64() {
-  static Fl_Image *image = 0L;
+  static Fl_Image *image = nullptr;
   if (!image)
     image = new Fl_PNG_Image("user_circle_64.png", idata_user_circle_64, 3909);
   return image;

--- a/fluid/panels/settings_panel.fl
+++ b/fluid/panels/settings_panel.fl
@@ -35,7 +35,7 @@ snap {
 comment {//
 // Setting and shell dialogs for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2025 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/fluid/panels/settings_panel.h
+++ b/fluid/panels/settings_panel.h
@@ -1,7 +1,7 @@
 //
 // Setting and shell dialogs for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2025 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/src/Fl_File_Chooser.cxx
+++ b/src/Fl_File_Chooser.cxx
@@ -1,7 +1,7 @@
 //
 // Fl_File_Chooser dialog for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2024 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/src/Fl_File_Chooser.cxx
+++ b/src/Fl_File_Chooser.cxx
@@ -451,9 +451,7 @@ void * Fl_File_Chooser::user_data() const {
 void Fl_File_Chooser::user_data(void *d) {
   if (flags_ & AUTO_DELETE_USER_DATA) {
     clear_flag(AUTO_DELETE_USER_DATA);
-    if (user_data_) {
-      delete static_cast<Fl_Callback_User_Data*>(user_data_);
-    }
+    delete static_cast<Fl_Callback_User_Data*>(user_data_);
   }
   user_data_ = d;
 }

--- a/src/Fl_File_Chooser.cxx
+++ b/src/Fl_File_Chooser.cxx
@@ -449,9 +449,11 @@ void * Fl_File_Chooser::user_data() const {
 }
 
 void Fl_File_Chooser::user_data(void *d) {
-  if ((flags_ & AUTO_DELETE_USER_DATA) && user_data_) {
+  if (flags_ & AUTO_DELETE_USER_DATA) {
     clear_flag(AUTO_DELETE_USER_DATA);
-    delete static_cast<Fl_Callback_User_Data*>(user_data_);
+    if (user_data_) {
+      delete static_cast<Fl_Callback_User_Data*>(user_data_);
+    }
   }
   user_data_ = d;
 }

--- a/src/Fl_File_Chooser.cxx
+++ b/src/Fl_File_Chooser.cxx
@@ -62,7 +62,7 @@ static const unsigned char idata_new[] =
 {0,0,120,0,132,0,2,1,1,254,1,128,49,128,49,128,253,128,253,128,49,128,49,
 128,1,128,1,128,255,255,0,0};
 static Fl_Image *image_new() {
-  static Fl_Image *image = 0L;
+  static Fl_Image *image = nullptr;
   if (!image)
     image = new Fl_Bitmap(idata_new, 32, 16, 16);
   return image;
@@ -505,10 +505,10 @@ Fl_Widget* Fl_File_Chooser::add_extra(Fl_Widget* gr) {
   if (ext_group) {
     int sh=ext_group->h()+4;
     Fl_Widget* svres=window->resizable();
-    window->resizable(NULL);
+    window->resizable(nullptr);
     window->size(window->w(),window->h()-sh);
     window->remove(ext_group);
-    ext_group=NULL;
+    ext_group=nullptr;
     window->resizable(svres);
   }
   if (gr) {

--- a/src/Fl_File_Chooser.cxx
+++ b/src/Fl_File_Chooser.cxx
@@ -62,7 +62,7 @@ static const unsigned char idata_new[] =
 {0,0,120,0,132,0,2,1,1,254,1,128,49,128,49,128,253,128,253,128,49,128,49,
 128,1,128,1,128,255,255,0,0};
 static Fl_Image *image_new() {
-  static Fl_Image *image = NULL;
+  static Fl_Image *image = 0L;
   if (!image)
     image = new Fl_Bitmap(idata_new, 32, 16, 16);
   return image;
@@ -108,7 +108,7 @@ void Fl_File_Chooser::cb_okButton_i(Fl_Return_Button*, void*) {
 
   // Do any callback that is registered...
   if (callback_)
-    (*callback_)(this, data_);
+    (*callback_)(this, user_data_);
 }
 void Fl_File_Chooser::cb_okButton(Fl_Return_Button* o, void* v) {
   ((Fl_File_Chooser*)(o->parent()->parent()->parent()->user_data()))->cb_okButton_i(o,v);
@@ -309,8 +309,6 @@ Fl_File_Chooser::Fl_File_Chooser(const char *pathname, const char *pattern, int 
     favWindow->label(manage_favorites_label);
     favWindow->end();
   } // Fl_Double_Window* favWindow
-  callback_ = 0;
-  data_ = 0;
   directory_[0] = 0;
   window->size_range(window->w(), window->h());
   type(type_val);
@@ -327,14 +325,11 @@ Fl_File_Chooser::Fl_File_Chooser(const char *pathname, const char *pattern, int 
 
 Fl_File_Chooser::~Fl_File_Chooser() {
   Fl::remove_timeout((Fl_Timeout_Handler)previewCB, this);
-  if(ext_group)window->remove(ext_group);
+  if (ext_group)
+    window->remove(ext_group);
   delete window;
   delete favWindow;
-}
-
-void Fl_File_Chooser::callback(void (*cb)(Fl_File_Chooser *, void *), void *d ) {
-  callback_ = cb;
-  data_     = d;
+  user_data(nullptr);
 }
 
 void Fl_File_Chooser::color(Fl_Color c) {
@@ -439,12 +434,33 @@ int Fl_File_Chooser::type() {
   return (type_);
 }
 
+void Fl_File_Chooser::callback(void (*cb)(Fl_File_Chooser *, void *), void *d ) {
+  callback_ = cb;
+  user_data(d);
+}
+
+void Fl_File_Chooser::callback(void (*cb)(Fl_File_Chooser *, void *), Fl_Callback_User_Data* d, bool auto_free) {
+  callback_ = cb;
+  user_data(d, auto_free);
+}
+
 void * Fl_File_Chooser::user_data() const {
-  return (data_);
+  return user_data_;
 }
 
 void Fl_File_Chooser::user_data(void *d) {
-  data_ = d;
+  if ((flags_ & AUTO_DELETE_USER_DATA) && user_data_) {
+    clear_flag(AUTO_DELETE_USER_DATA);
+    delete static_cast<Fl_Callback_User_Data*>(user_data_);
+  }
+  user_data_ = d;
+}
+
+void Fl_File_Chooser::user_data(Fl_Callback_User_Data* d, bool auto_free) {
+  user_data(static_cast<void*>(d)); // clears AUTO_DELETE_USER_DATA
+  if (auto_free) {
+    set_flag(AUTO_DELETE_USER_DATA);
+  }
 }
 
 int Fl_File_Chooser::visible() {
@@ -518,4 +534,25 @@ void Fl_File_Chooser::show_error_box(int val) {
     errorBox->hide();
     fileList->show();
   }
+}
+
+/**
+ Gets all filechooser flags.
+*/
+unsigned int Fl_File_Chooser::flags() const {
+  return flags_;
+}
+
+/**
+ Set a filechooser flag.
+*/
+void Fl_File_Chooser::set_flag(unsigned int c) {
+  flags_ |= c;
+}
+
+/**
+ Clear a filechooser flag.
+*/
+void Fl_File_Chooser::clear_flag(unsigned int c) {
+  flags_ &= ~c;
 }

--- a/src/Fl_File_Chooser.fl
+++ b/src/Fl_File_Chooser.fl
@@ -409,9 +409,7 @@ user_data(d, auto_free);} {}
   } {
     code {if (flags_ & AUTO_DELETE_USER_DATA) {
   clear_flag(AUTO_DELETE_USER_DATA);
-  if (user_data_) {
-    delete static_cast<Fl_Callback_User_Data*>(user_data_);
-  }
+  delete static_cast<Fl_Callback_User_Data*>(user_data_);
 }
 user_data_ = d;} {}
   }

--- a/src/Fl_File_Chooser.fl
+++ b/src/Fl_File_Chooser.fl
@@ -84,7 +84,7 @@ Determines the type of file chooser presented to the user.
   }
   decl {void update_preview();} {private local
   }
-  Function {Fl_File_Chooser(const char *pathname, const char *pattern, int type_val, const char *title)} {open
+  Function {Fl_File_Chooser(const char *pathname, const char *pattern, int type_val, const char *title)} {open selected
   } {
     code {if (!prefs_) {
   prefs_ = new Fl_Preferences(Fl_Preferences::CORE_USER, "fltk.org", "filechooser");
@@ -94,7 +94,7 @@ Determines the type of file chooser presented to the user.
       label {Choose File}
       callback {fileName->value("");
 fileList->deselect();
-hide();} open selected
+hide();} open
       private xywh {467 277 490 380} type Double resizable
       code0 {if (title) window->label(title);} modal visible
     } {
@@ -407,9 +407,11 @@ user_data(d, auto_free);} {}
   }
   Function {user_data(void *d)} {return_type void
   } {
-    code {if ((flags_ & AUTO_DELETE_USER_DATA) && user_data_) {
+    code {if (flags_ & AUTO_DELETE_USER_DATA) {
   clear_flag(AUTO_DELETE_USER_DATA);
-  delete static_cast<Fl_Callback_User_Data*>(user_data_);
+  if (user_data_) {
+    delete static_cast<Fl_Callback_User_Data*>(user_data_);
+  }
 }
 user_data_ = d;} {}
   }

--- a/src/Fl_File_Chooser.fl
+++ b/src/Fl_File_Chooser.fl
@@ -6,7 +6,7 @@ include_guard {}
 comment {//
 // Fl_File_Chooser dialog for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2024 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/src/Fl_File_Chooser.fl
+++ b/src/Fl_File_Chooser.fl
@@ -2,6 +2,7 @@
 version 1.0500
 header_name {../FL/Fl_File_Chooser.H}
 code_name {.cxx}
+include_guard {}
 comment {//
 // Fl_File_Chooser dialog for the Fast Light Tool Kit (FLTK).
 //
@@ -44,11 +45,16 @@ class FL_EXPORT Fl_File_Chooser {open
 Determines the type of file chooser presented to the user.
 } public local
   }
+  decl {enum Flags {
+  AUTO_DELETE_USER_DATA = 1<<0, ///< automatically call `delete` on the user_data pointer when destroying this widget; if set, user_data must point to a class derived from the class Fl_Callback_User_Data
+};} {
+    comment {Values for flags_ field.} protected local
+  }
   decl {static Fl_Preferences *prefs_;} {private local
   }
-  decl {void (*callback_)(Fl_File_Chooser*, void *);} {private local
+  decl {void (*callback_)(Fl_File_Chooser*, void *) = nullptr;} {private local
   }
-  decl {void *data_;} {private local
+  decl {void *user_data_ = nullptr;} {private local
   }
   decl {char directory_[FL_PATH_MAX];} {private local
   }
@@ -57,6 +63,8 @@ Determines the type of file chooser presented to the user.
   decl {char preview_text_[2048];} {private local
   }
   decl {int type_;} {private local
+  }
+  decl {unsigned int flags_ = 0;} {private local
   }
   decl {void favoritesButtonCB();} {private local
   }
@@ -87,7 +95,7 @@ Determines the type of file chooser presented to the user.
       callback {fileName->value("");
 fileList->deselect();
 hide();} open selected
-      private xywh {467 276 490 380} type Double resizable
+      private xywh {467 277 490 380} type Double resizable
       code0 {if (title) window->label(title);} modal visible
     } {
       Fl_Group {} {open
@@ -171,7 +179,7 @@ hide();} open selected
 
 // Do any callback that is registered...
 if (callback_)
-  (*callback_)(this, data_);}
+  (*callback_)(this, user_data_);}
             private xywh {313 345 85 25}
             code0 {\#include <FL/fl_ask.H>}
             code1 {okButton->label(fl_ok);}
@@ -239,9 +247,7 @@ hide();}
         }
       }
     }
-    code {callback_ = 0;
-data_ = 0;
-directory_[0] = 0;
+    code {directory_[0] = 0;
 window->size_range(window->w(), window->h());
 type(type_val);
 filter(pattern);
@@ -254,17 +260,13 @@ preview(e);
 Fl_Group::current(prev_current);} {}
     code {ext_group=(Fl_Widget*)0;} {}
   }
-  Function {~Fl_File_Chooser()} {open
-  } {
+  Function {~Fl_File_Chooser()} {} {
     code {Fl::remove_timeout((Fl_Timeout_Handler)previewCB, this);
-if(ext_group)window->remove(ext_group);
+if (ext_group)
+  window->remove(ext_group);
 delete window;
-delete favWindow;} {}
-  }
-  Function {callback(void (*cb)(Fl_File_Chooser *, void *), void *d = 0)} {return_type void
-  } {
-    code {callback_ = cb;
-data_     = d;} {}
+delete favWindow;
+user_data(nullptr);} {}
   }
   Function {color(Fl_Color c)} {} {
     code {fileList->color(c);} {}
@@ -389,13 +391,34 @@ else
   } {
     code {return (type_);} {}
   }
+  Function {callback(void (*cb)(Fl_File_Chooser *, void *), void *d = 0)} {return_type void
+  } {
+    code {callback_ = cb;
+user_data(d);} {}
+  }
+  Function {callback(void (*cb)(Fl_File_Chooser *, void *), Fl_Callback_User_Data* d, bool auto_free)} {return_type void
+  } {
+    code {callback_ = cb;
+user_data(d, auto_free);} {}
+  }
   Function {user_data() const} {return_type {void *}
   } {
-    code {return (data_);} {}
+    code {return user_data_;} {}
   }
   Function {user_data(void *d)} {return_type void
   } {
-    code {data_ = d;} {}
+    code {if ((flags_ & AUTO_DELETE_USER_DATA) && user_data_) {
+  clear_flag(AUTO_DELETE_USER_DATA);
+  delete static_cast<Fl_Callback_User_Data*>(user_data_);
+}
+user_data_ = d;} {}
+  }
+  Function {user_data(Fl_Callback_User_Data* d, bool auto_free)} {return_type void
+  } {
+    code {user_data(static_cast<void*>(d)); // clears AUTO_DELETE_USER_DATA
+if (auto_free) {
+  set_flag(AUTO_DELETE_USER_DATA);
+}} {}
   }
   decl {const char *value(int f = 1);} {public local
   }
@@ -429,7 +452,7 @@ else
   } {
     code {window->size(w, h);} {}
   }
-  Function {resize(int x, int y, int w, int h)} {open return_type void
+  Function {resize(int x, int y, int w, int h)} {return_type void
   } {
     code {window->resize(x, y, w, h);} {}
   }
@@ -481,7 +504,7 @@ the contents of a directory.} public local
   }
   decl {Fl_Widget* ext_group;} {private local
   }
-  Function {add_extra(Fl_Widget* gr)} {open return_type {Fl_Widget*}
+  Function {add_extra(Fl_Widget* gr)} {return_type {Fl_Widget*}
   } {
     code {Fl_Widget* ret=ext_group;} {}
     codeblock {if (gr==ext_group)} {open
@@ -512,7 +535,7 @@ window->resizable(svres);} {}
     code {return ret;} {}
   }
   Function {show_error_box(int val)} {
-    comment {Show error box if val=1, hide if val=0} open protected return_type void
+    comment {Show error box if val=1, hide if val=0} protected return_type void
   } {
     code {if ( val ) {
   errorBox->color(fileList->color()); // inherit fileList's bg color
@@ -522,6 +545,21 @@ window->resizable(svres);} {}
   errorBox->hide();
   fileList->show();
 }} {}
+  }
+  Function {flags() const} {
+    comment {Gets all filechooser flags.} protected return_type {unsigned int}
+  } {
+    code {return flags_;} {}
+  }
+  Function {set_flag(unsigned int c)} {
+    comment {Set a filechooser flag.} protected return_type void
+  } {
+    code {flags_ |= c;} {}
+  }
+  Function {clear_flag(unsigned int c)} {
+    comment {Clear a filechooser flag.} protected return_type void
+  } {
+    code {flags_ &= ~c;} {}
   }
 }
 

--- a/src/Fl_File_Chooser.fl
+++ b/src/Fl_File_Chooser.fl
@@ -84,7 +84,7 @@ Determines the type of file chooser presented to the user.
   }
   decl {void update_preview();} {private local
   }
-  Function {Fl_File_Chooser(const char *pathname, const char *pattern, int type_val, const char *title)} {open selected
+  Function {Fl_File_Chooser(const char *pathname, const char *pattern, int type_val, const char *title)} {open
   } {
     code {if (!prefs_) {
   prefs_ = new Fl_Preferences(Fl_Preferences::CORE_USER, "fltk.org", "filechooser");
@@ -506,7 +506,7 @@ the contents of a directory.} public local
   }
   decl {Fl_Widget* ext_group;} {private local
   }
-  Function {add_extra(Fl_Widget* gr)} {return_type {Fl_Widget*}
+  Function {add_extra(Fl_Widget* gr)} {open return_type {Fl_Widget*}
   } {
     code {Fl_Widget* ret=ext_group;} {}
     codeblock {if (gr==ext_group)} {open
@@ -517,10 +517,10 @@ the contents of a directory.} public local
     } {
       code {int sh=ext_group->h()+4;
 Fl_Widget* svres=window->resizable();
-window->resizable(NULL);
+window->resizable(nullptr);
 window->size(window->w(),window->h()-sh);
 window->remove(ext_group);
-ext_group=NULL;
+ext_group=nullptr;
 window->resizable(svres);} {}
     }
     codeblock {if (gr)} {open
@@ -532,7 +532,8 @@ window->size(window->w(),nh);
 gr->position(2,okButton->y()+okButton->h()+2);
 window->add(gr);
 ext_group=gr;
-window->resizable(svres);} {}
+window->resizable(svres);} {selected
+      }
     }
     code {return ret;} {}
   }

--- a/src/Fl_File_Chooser2.cxx
+++ b/src/Fl_File_Chooser2.cxx
@@ -2,7 +2,7 @@
 // More Fl_File_Chooser routines.
 //
 // Copyright 1999-2007 by Michael Sweet.
-// Copyright 2008-2024 by Bill Spitzak and others.
+// Copyright 2008-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/src/Fl_File_Chooser2.cxx
+++ b/src/Fl_File_Chooser2.cxx
@@ -696,7 +696,7 @@ Fl_File_Chooser::fileListCB()
     {
       // Hide the window - picked the file...
       window->hide();
-      if (callback_) (*callback_)(this, data_);
+      if (callback_) (*callback_)(this, user_data_);
     }
   }
   else
@@ -741,7 +741,7 @@ Fl_File_Chooser::fileListCB()
     Fl::add_timeout(1.0, (Fl_Timeout_Handler)previewCB, this);
 
     // Do any callback that is registered...
-    if (callback_) (*callback_)(this, data_);
+    if (callback_) (*callback_)(this, user_data_);
 
     // Activate the OK button as needed...
     if (!Fl::system_driver()->filename_isdir_quick(pathname) || (type_ & DIRECTORY))
@@ -817,7 +817,7 @@ Fl_File_Chooser::fileNameCB()
         update_preview();
 
         // Do any callback that is registered...
-        if (callback_) (*callback_)(this, data_);
+        if (callback_) (*callback_)(this, user_data_);
 
         // Hide the window to signal things are done...
         window->hide();

--- a/src/Fl_Tree_Item.cxx
+++ b/src/Fl_Tree_Item.cxx
@@ -14,7 +14,7 @@
 //////////////////////
 //
 // Fl_Tree -- This file is part of the Fl_Tree widget for FLTK
-// Copyright (C) 2009-2010 by Greg Ercolano.
+// Copyright (C) 2009-2026 by Greg Ercolano.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/src/Fl_Tree_Item.cxx
+++ b/src/Fl_Tree_Item.cxx
@@ -178,15 +178,13 @@ const char *Fl_Tree_Item::label() const {
 void Fl_Tree_Item::user_data( void* data ) {
   if (_flags & AUTO_DELETE_USER_DATA) {
     _flags &= ~AUTO_DELETE_USER_DATA;
-    if (_userdata) {
-      delete static_cast<Fl_Callback_User_Data*>(_userdata);
-    }
+    delete static_cast<Fl_Callback_User_Data*>(_userdata);
   }
   _userdata = data;
 }
 
 /**
- Set user data for this item with the option togive ownership to this class.
+ Set user data for this item with the option to give ownership to this class.
 
  \note Fl_Tree_Item has a copy constructor. To handle ownership correctly
  when `auto_delete` is set, `data` must implement a working `clone()` method

--- a/src/Fl_Tree_Item.cxx
+++ b/src/Fl_Tree_Item.cxx
@@ -102,6 +102,7 @@ Fl_Tree_Item::~Fl_Tree_Item() {
   if ( _tree && this == _tree->_item_focus )
     { _tree->_item_focus = 0; }
   //_children.clear();          // array's destructor handles itself
+  user_data(nullptr);           // free user data if AUTO_DELETE_USER_DATA is set
 }
 
 /// Copy constructor.
@@ -113,7 +114,7 @@ Fl_Tree_Item::Fl_Tree_Item(const Fl_Tree_Item *o) {
   _labelfgcolor = o->labelfgcolor();
   _labelbgcolor = o->labelbgcolor();
   _widget       = o->widget();
-  _flags        = o->_flags;
+  _flags        = o->_flags & ~AUTO_DELETE_USER_DATA;
   _xywh[0]      = o->_xywh[0];
   _xywh[1]      = o->_xywh[1];
   _xywh[2]      = o->_xywh[2];
@@ -127,7 +128,12 @@ Fl_Tree_Item::Fl_Tree_Item(const Fl_Tree_Item *o) {
   _label_xywh[2]    = o->_label_xywh[2];
   _label_xywh[3]    = o->_label_xywh[3];
   _usericon         = o->usericon();
-  _userdata         = o->user_data();
+  if ((o->_flags & AUTO_DELETE_USER_DATA) && o->user_data()) {
+    auto data = static_cast<Fl_Callback_User_Data*>(o->user_data());
+    user_data(data->clone(), true);
+  } else {
+    _userdata = o->user_data();
+  }
   _parent           = o->_parent;
   _prev_sibling     = 0;                // do not copy ptrs! use update_prev_next()
   _next_sibling     = 0;                // do not copy ptrs! use update_prev_next()
@@ -165,6 +171,32 @@ void Fl_Tree_Item::label(const char *name) {
 /// Return the label.
 const char *Fl_Tree_Item::label() const {
   return(_label);
+}
+
+
+/// Set a user-data value for the item.
+void Fl_Tree_Item::user_data( void* data ) {
+  if (_flags & AUTO_DELETE_USER_DATA) {
+    _flags &= ~AUTO_DELETE_USER_DATA;
+    if (_userdata) {
+      delete static_cast<Fl_Callback_User_Data*>(_userdata);
+    }
+  }
+  _userdata = data;
+}
+
+/**
+ Set user data for this item with the option togive ownership to this class.
+
+ \note Fl_Tree_Item has a copy constructor. To handle ownership correctly
+ when `auto_delete` is set, `data` must implement a working `clone()` method
+ that returns a deep copy of the user data.
+ */
+void Fl_Tree_Item::user_data( Fl_Callback_User_Data* data, bool auto_delete) {
+  user_data(static_cast<void*>(data));
+  if (auto_delete) {
+    _flags |= AUTO_DELETE_USER_DATA;
+  }
 }
 
 /// Return const child item for the specified 'index'.

--- a/src/Fl_Widget.cxx
+++ b/src/Fl_Widget.cxx
@@ -1,7 +1,7 @@
 //
 // Base widget class for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2025 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this

--- a/src/Fl_Widget.cxx
+++ b/src/Fl_Widget.cxx
@@ -271,8 +271,7 @@ Fl_Widget::~Fl_Widget() {
   fl_throw_focus(this);
   // remove stale entries from default callback queue (Fl::readqueue())
   if (callback_ == default_callback) cleanup_readqueue(this);
-  if ( (flags_ & AUTO_DELETE_USER_DATA) && user_data_)
-    delete (Fl_Callback_User_Data*)user_data_;
+  user_data(nullptr); // remove user data pointer and delete if owned
 }
 
 /**
@@ -483,9 +482,12 @@ void Fl_Widget::do_callback(Fl_Widget *widget, void *arg, Fl_Callback_Reason rea
  \param[in] v new user data
  */
 void Fl_Widget::user_data(void* v) {
-  if ((flags_ & AUTO_DELETE_USER_DATA) && user_data_)
-    delete (Fl_Callback_User_Data*)user_data_;
-  clear_flag(AUTO_DELETE_USER_DATA);
+  if (flags_ & AUTO_DELETE_USER_DATA) {
+    clear_flag(AUTO_DELETE_USER_DATA);
+    if (user_data_) {
+      delete (Fl_Callback_User_Data*)user_data_;
+    }
+  }
   user_data_ = v;
 }
 

--- a/src/Fl_Widget.cxx
+++ b/src/Fl_Widget.cxx
@@ -491,9 +491,7 @@ void Fl_Widget::do_callback(Fl_Widget *widget, void *arg, Fl_Callback_Reason rea
 void Fl_Widget::user_data(void* v) {
   if (flags_ & AUTO_DELETE_USER_DATA) {
     clear_flag(AUTO_DELETE_USER_DATA);
-    if (user_data_) {
-      delete (Fl_Callback_User_Data*)user_data_;
-    }
+    delete (Fl_Callback_User_Data*)user_data_;
   }
   user_data_ = v;
 }

--- a/src/Fl_Widget.cxx
+++ b/src/Fl_Widget.cxx
@@ -439,6 +439,13 @@ void Fl_Widget::bind_deimage(Fl_Image* img) {
   bind_deimage( (img != NULL) );
 }
 
+void Fl_Widget::do_std_function_callback_(Fl_Widget* w, void* data) {
+  auto std_function_callback = static_cast<Fl_Std_Function_User_Data*>(w->user_data());
+  if (std_function_callback) {
+    std_function_callback->call(w);
+  }
+}
+
 /** Calls the widget callback function with arbitrary arguments.
 
  All overloads of do_callback() call this method.

--- a/test/unittest_core.cxx
+++ b/test/unittest_core.cxx
@@ -200,22 +200,6 @@ TEST(std_function_callbacks, lambda) {
   return true;
 }
 
-#include <FL/fl_ask.H>
-
-TEST(std_function_callbacks, lambda2) {
-  Fl_Group::current(NULL);
-
-Fl_Button *btn = new Fl_Button(10, 10, 100, 100);
-std::string name = "Mr. Smith";
-std::string text = "Thank you for contacting us, %s!";
-btn->callback([name, text](Fl_Widget *w) {
-  fl_message(text.c_str(), name.c_str());
-}
-);
-btn->do_callback();
-delete btn;
-return true;
-}
 
 //
 //------- test aspects of the FLTK core library ----------

--- a/test/unittest_core.cxx
+++ b/test/unittest_core.cxx
@@ -1,7 +1,7 @@
 //
 // Unit tests for the Fast Light Tool Kit (FLTK).
 //
-// Copyright 1998-2023 by Bill Spitzak and others.
+// Copyright 1998-2026 by Bill Spitzak and others.
 //
 // This library is free software. Distribution and use rights are outlined in
 // the file "COPYING" which should have been included with this file.  If this
@@ -244,7 +244,7 @@ public:
   static void timer_cb(void*) {
     // Run a test every few milliseconds to visualize the progress
     if (Ut_Suite::run_next_test())
-      Fl::repeat_timeout(0.15, timer_cb);
+      Fl::repeat_timeout(0.1, timer_cb);
   }
 
   // Showing this tab for the first time will trigger the tests

--- a/test/unittest_core.cxx
+++ b/test/unittest_core.cxx
@@ -166,6 +166,7 @@ TEST(Fl_Callback_Macros, FL_INLINE_CALLBACK) {
 int ok = 0;
 void test_cb(Fl_Widget*w) { (void)w; ok = 1; }
 TEST(std_function_callbacks, function) {
+  ok = 0;
   Fl_Group::current(NULL);
   Fl_Button *btn = new Fl_Button(10, 10, 100, 100);
   std::function<void(Fl_Widget*)> f = test_cb;
@@ -178,6 +179,7 @@ TEST(std_function_callbacks, function) {
 
 void test_2_cb(int x, int y, int z) { (void)x; (void)y, ok = z; }
 TEST(std_function_callbacks, std::bind) {
+  ok = 0;
   Fl_Group::current(NULL);
   Fl_Button *btn = new Fl_Button(10, 10, 100, 100);
   btn->callback(std::bind(test_2_cb, 1, 2, 42));
@@ -188,6 +190,7 @@ TEST(std_function_callbacks, std::bind) {
 }
 
 TEST(std_function_callbacks, lambda) {
+  ok = 0;
   Fl_Group::current(NULL);
   Fl_Button *btn = new Fl_Button(10, 10, 100, 100);
   int capture_me = 36;

--- a/test/unittest_core.cxx
+++ b/test/unittest_core.cxx
@@ -50,8 +50,6 @@ TEST(Fl_Preferences, Strings) {
   return true;
 }
 
-#if 0
-
 TEST(fl_filename, ext) {
   std::string r = fl_filename_ext("test.txt");
   EXPECT_STREQ(r.c_str(), ".txt");
@@ -63,45 +61,44 @@ TEST(fl_filename, ext) {
 }
 
 TEST(fl_filename, setext) {
-  std::string r = fl_filename_setext(std::string("test.txt"), ".rtf");
+  std::string r = fl_filename_setext_str("test.txt", ".rtf");
   EXPECT_STREQ(r.c_str(), "test.rtf");
-  r = fl_filename_setext(std::string("test"), ".rtf");
+  r = fl_filename_setext_str("test", ".rtf");
   EXPECT_STREQ(r.c_str(), "test.rtf");
-  r = fl_filename_setext(std::string("test.txt"), "");
+  r = fl_filename_setext_str("test.txt", "");
   EXPECT_STREQ(r.c_str(), "test");
-  r = fl_filename_setext(std::string(""), ".rtf");
+  r = fl_filename_setext_str("", ".rtf");
   EXPECT_STREQ(r.c_str(), ".rtf");
-  r = fl_filename_setext(std::string("path/test"), ".rtf");
+  r = fl_filename_setext_str("path/test", ".rtf");
   EXPECT_STREQ(r.c_str(), "path/test.rtf");
   return true;
 }
 
 TEST(fl_filename, relative) {
   std::string base = "/var/tmp/somedir";
-  std::string r = fl_filename_relative("/var/tmp/somedir/foo.txt", base);
+  std::string r = fl_filename_relative_str("/var/tmp/somedir/foo.txt", base);
   EXPECT_STREQ(r.c_str(), "foo.txt");
-  r = fl_filename_relative("/var/tmp/foo.txt", base);
+  r = fl_filename_relative_str("/var/tmp/foo.txt", base);
   EXPECT_STREQ(r.c_str(), "../foo.txt");
-  r = fl_filename_relative("./foo.txt", base);
+  r = fl_filename_relative_str("./foo.txt", base);
   EXPECT_STREQ(r.c_str(), "./foo.txt");
-  r = fl_filename_relative("../foo.txt", base);
+  r = fl_filename_relative_str("../foo.txt", base);
   EXPECT_STREQ(r.c_str(), "../foo.txt");
   return true;
 }
 
 TEST(fl_filename, absolute) {
   std::string base = "/var/tmp/somedir";
-  std::string r = fl_filename_absolute("foo.txt", base);
+  std::string r = fl_filename_absolute_str("foo.txt", base);
   EXPECT_STREQ(r.c_str(), "/var/tmp/somedir/foo.txt");
-  r = fl_filename_absolute("/var/tmp/foo.txt", base);
+  r = fl_filename_absolute_str("/var/tmp/foo.txt", base);
   EXPECT_STREQ(r.c_str(), "/var/tmp/foo.txt");
-  r = fl_filename_absolute("./foo.txt", base);
+  r = fl_filename_absolute_str("./foo.txt", base);
   EXPECT_STREQ(r.c_str(), "/var/tmp/somedir/foo.txt");
-  r = fl_filename_absolute("../foo.txt", base);
+  r = fl_filename_absolute_str("../foo.txt", base);
   EXPECT_STREQ(r.c_str(), "/var/tmp/foo.txt");
   return true;
 }
-
 
 bool cb1a_ok = false, cb1b_ok = false, cb1c_ok = false;
 int cb1_alloc = 0;
@@ -165,7 +162,60 @@ TEST(Fl_Callback_Macros, FL_INLINE_CALLBACK) {
   return true;
 }
 
-#endif // FIXME - Fl_String
+/* Test std::function callbacks. */
+int ok = 0;
+void test_cb(Fl_Widget*w) { (void)w; ok = 1; }
+TEST(std_function_callbacks, function) {
+  Fl_Group::current(NULL);
+  Fl_Button *btn = new Fl_Button(10, 10, 100, 100);
+  std::function<void(Fl_Widget*)> f = test_cb;
+  btn->callback(f);
+  btn->do_callback();
+  EXPECT_EQ(ok, 1);
+  delete btn;
+  return true;
+}
+
+void test_2_cb(int x, int y, int z) { (void)x; (void)y, ok = z; }
+TEST(std_function_callbacks, std::bind) {
+  Fl_Group::current(NULL);
+  Fl_Button *btn = new Fl_Button(10, 10, 100, 100);
+  btn->callback(std::bind(test_2_cb, 1, 2, 42));
+  btn->do_callback();
+  EXPECT_EQ(ok, 42);
+  delete btn;
+  return true;
+}
+
+TEST(std_function_callbacks, lambda) {
+  Fl_Group::current(NULL);
+  Fl_Button *btn = new Fl_Button(10, 10, 100, 100);
+  int capture_me = 36;
+  btn->callback([capture_me](Fl_Widget*) {
+    ok = capture_me;
+  });
+  btn->do_callback();
+  EXPECT_EQ(ok, 36);
+  delete btn;
+  return true;
+}
+
+#include <FL/fl_ask.H>
+
+TEST(std_function_callbacks, lambda2) {
+  Fl_Group::current(NULL);
+
+Fl_Button *btn = new Fl_Button(10, 10, 100, 100);
+std::string name = "Mr. Smith";
+std::string text = "Thank you for contacting us, %s!";
+btn->callback([name, text](Fl_Widget *w) {
+  fl_message(text.c_str(), name.c_str());
+}
+);
+btn->do_callback();
+delete btn;
+return true;
+}
 
 //
 //------- test aspects of the FLTK core library ----------


### PR DESCRIPTION
By automatically managing callback user data, I was now able to implement `std::function` based callbacks. This is great if the user wants to call a member function directly without writing a static callback trampoline. I also updated the documentation and added unit tests to `test/unittest`. 

As a side effect, I also added managed callback data to `Fl_Tree_Item` and `Fl_File_Chooser`. I might add `std::function` support to those two as well.

I invite anyone interested in doing a code review. I am sure this PR will be open for a few more days for testing before I merge it with master.

Example:

```
class MyButton : public Fl_Button {
  ...
  void beep(int pitch, double duration) { ... }
};
...
MyButton* btn = new MyButton(...);
btn->callback([this](Fl_Widget*) { beep(1000, 0.2); });
```

