### PR TITLE
Bugfix: Ensure tooltip window appears on the same screen as its widget

### DIFF
--- a/src/Fl_Tooltip.cxx
+++ b/src/Fl_Tooltip.cxx
@@ -105,17 +105,22 @@ void Fl_TooltipBox::layout() {
       oy += p->y();
     }
   }
+  screen_num(Fl_Tooltip::current()->top_window()->screen_num());
   if (Fl::screen_driver()->screen_boundaries_known()) {
-    int scr_x, scr_y, scr_w, scr_h;
-    Fl::screen_xywh(scr_x, scr_y, scr_w, scr_h);
-    if (ox+ww > scr_x+scr_w) ox = scr_x+scr_w - ww;
-    if (ox < scr_x) ox = scr_x;
-    if (currentTooltipH > 30) {
-      if (oy+hh > scr_y+scr_h) oy -= 23+hh;
-    } else {
-      if (oy+hh > scr_y+scr_h) oy -= (4+hh+currentTooltipH);
+    int mx, my;
+    int nscreen = Fl::screen_driver()->get_mouse(mx, my);
+    if (screen_num() == nscreen) {
+      int scr_x, scr_y, scr_w, scr_h;
+      Fl::screen_driver()->screen_xywh(scr_x, scr_y, scr_w, scr_h, nscreen);
+      if (ox+ww > scr_x+scr_w) ox = scr_x+scr_w - ww;
+      if (ox < scr_x) ox = scr_x;
+      if (currentTooltipH > 30) {
+        if (oy+hh > scr_y+scr_h) oy -= 23+hh;
+      } else {
+        if (oy+hh > scr_y+scr_h) oy -= (4+hh+currentTooltipH);
+      }
+      if (oy < scr_y) oy = scr_y;
     }
-    if (oy < scr_y) oy = scr_y;
   }
 
   resize(ox, oy, ww, hh);

--- a/src/Fl_win32.cxx
+++ b/src/Fl_win32.cxx
@@ -2367,7 +2367,7 @@ void Fl_WinAPI_Window_Driver::makeWindow() {
     if (!force_position()) {
       xp = yp = CW_USEDEFAULT;
     } else {
-      if (!Fl::grab()) {
+      if (!Fl::grab() && !w->tooltip_window()) {
         xp = xwm;
         yp = ywm;
         x(int(round(xp / s)));

--- a/src/Fl_x.cxx
+++ b/src/Fl_x.cxx
@@ -2220,7 +2220,7 @@ int fl_handle(const XEvent& thisevent)
     int num = d->screen_num_unscaled(X+ actual.width/2, Y +actual.height/2);
     if (num == -1) num = olds;
     float s = d->scale(num);
-    if (num != olds && !window->menu_window()) {
+    if (num != olds && !window->menu_window() && !window->tooltip_window()) {
       if (Fl::modal() && Fl::modal()->menu_window()) { // is a menu window active?
         Fl::e_x_root = 1000000;
         Fl::modal()->handle(FL_PUSH); // simulate a distant click to close menus
@@ -2248,7 +2248,7 @@ int fl_handle(const XEvent& thisevent)
 #if USE_XFT || FLTK_USE_CAIRO
     if (!Fl_X11_Window_Driver::data_for_resize_window_between_screens_.busy &&
       ( ceil(W/s) != window->w() || ceil(H/s) != window->h() ) &&
-      !window->menu_window()) {
+      !window->menu_window() && !window->tooltip_window()) {
         window->resize(rint(X/s), rint(Y/s), ceil(W/s), ceil(H/s));
     } else {
       window->position(rint(X/s), rint(Y/s));
@@ -2566,7 +2566,7 @@ void Fl_X::make_xid(Fl_Window* win, XVisualInfo *visual, Colormap colormap)
   if (W <= 0) W = 1; // X don't like zero...
   int H = win->h();
   if (H <= 0) H = 1; // X don't like zero...
-  if (!win->parent() && !Fl::grab()) {
+  if (!win->parent() && !Fl::grab() && !win->tooltip_window()) {
     // center windows in case window manager does not do anything:
 #ifdef FL_CENTER_WINDOWS
     if (!win->force_position()) {


### PR DESCRIPTION
Right now, tooltips suffer from "ambiguous coordinates" and therefore can appear on the wrong screen. Tooltip windows need to have their screen_num set using the widget's screen_num.

Before:

https://github.com/user-attachments/assets/b8964bfe-e5d7-4dec-88cb-e93176b4c8c2

After:

https://github.com/user-attachments/assets/c92afda7-0a3c-498f-b48c-d26319ee845f
