### PR TITLE
New `Fl::set_font_by_family` font loading system

### DIFF
--- a/FL/Enumerations.H
+++ b/FL/Enumerations.H
@@ -989,6 +989,27 @@ const Fl_Font FL_BOLD                   = 1;    ///< add this to Helvetica, Cour
 const Fl_Font FL_ITALIC                 = 2;    ///< add this to Helvetica, Courier, or Times
 const Fl_Font FL_BOLD_ITALIC            = 3;    ///< add this to Helvetica, Courier, or Times
 
+enum Fl_Font_Weight {
+    FL_WEIGHT_THIN = 100,
+    FL_WEIGHT_EXTRALIGHT = 200,
+    FL_WEIGHT_LIGHT = 300,
+    FL_WEIGHT_SEMILIGHT = 350,
+    FL_WEIGHT_BOOK = 380,
+    FL_WEIGHT_NORMAL = 400,
+    FL_WEIGHT_MEDIUM = 500,
+    FL_WEIGHT_SEMIBOLD = 600,
+    FL_WEIGHT_BOLD = 700,
+    FL_WEIGHT_EXTRABOLD = 800,
+    FL_WEIGHT_HEAVY = 900,
+    FL_WEIGHT_ULTRAHEAVY = 1000,
+};
+
+enum Fl_Font_Style {
+    FL_STYLE_NORMAL = 0,
+    FL_STYLE_ITALIC = 1,
+    FL_STYLE_OBLIQUE = 2,
+};
+
 /**@}*/
 
 /** Size of a font in pixels.

--- a/FL/Fl.H
+++ b/FL/Fl.H
@@ -619,6 +619,17 @@ FL_EXPORT extern const char* get_font(Fl_Font);
 FL_EXPORT extern const char* get_font_name(Fl_Font, int* attributes = 0);
 
 /**
+  Get a human-readable string describing the family of this face.  This
+  is useful if you are presenting a choice to the user.  There is no
+  guarantee that each face has a different name.  The return value points
+  to a static buffer that is overwritten each call.
+
+  The integer pointed to by \p weight (if not null) is set to a OpenType font weight from 100 to 900.
+  The integer pointed to by \p style (if not null) is set to 0, if no style, 1 if italic, and 2 if oblique.
+*/
+FL_EXPORT extern const char* get_font_name2(Fl_Font, int* weight = 0, int* style = 0);
+
+/**
   Return an array of sizes in \p sizep.  The return value is the
   length of this array.  The sizes are sorted from smallest to largest
   and indicate what sizes can be given to fl_font() that will
@@ -632,6 +643,7 @@ FL_EXPORT extern const char* get_font_name(Fl_Font, int* attributes = 0);
 FL_EXPORT extern int get_font_sizes(Fl_Font, int*& sizep);
 FL_EXPORT extern void set_font(Fl_Font, const char*);
 FL_EXPORT extern void set_font(Fl_Font, Fl_Font);
+FL_EXPORT extern void set_font_by_family(Fl_Font, const char*, int weight, int style);
 
 /**
   FLTK will open the display, and add every fonts on the server to the

--- a/FL/Fl.H
+++ b/FL/Fl.H
@@ -605,6 +605,8 @@ FL_EXPORT extern void   free_color(Fl_Color i, int overlay = 0); // platform dep
 FL_EXPORT extern const char* get_font(Fl_Font);
 
 /**
+  This function should be used if \ref set_font was used to set the font.
+
   Get a human-readable string describing the family of this face.  This
   is useful if you are presenting a choice to the user.  There is no
   guarantee that each face has a different name.  The return value points
@@ -619,15 +621,17 @@ FL_EXPORT extern const char* get_font(Fl_Font);
 FL_EXPORT extern const char* get_font_name(Fl_Font, int* attributes = 0);
 
 /**
+  This function should be used if \ref set_font_by_family was used to set the font.
+
   Get a human-readable string describing the family of this face.  This
   is useful if you are presenting a choice to the user.  There is no
   guarantee that each face has a different name.  The return value points
-  to a static buffer that is overwritten each call.
+  to a buffer that the user passed in set_font_by_family().
 
   The integer pointed to by \p weight (if not null) is set to a OpenType font weight from 100 to 900.
   The integer pointed to by \p style (if not null) is set to 0, if no style, 1 if italic, and 2 if oblique.
 */
-FL_EXPORT extern const char* get_font_name2(Fl_Font, int* weight = 0, int* style = 0);
+FL_EXPORT extern const char* get_font_family(Fl_Font, int* weight = 0, int* style = 0);
 
 /**
   Return an array of sizes in \p sizep.  The return value is the

--- a/FL/Fl_Graphics_Driver.H
+++ b/FL/Fl_Graphics_Driver.H
@@ -358,12 +358,13 @@ public:
   virtual Fl_Region XRectangleRegion(int x, int y, int w, int h);
   virtual void XDestroyRegion(Fl_Region r);
   virtual const char* get_font_name(Fl_Font fnum, int* ap);
+  virtual const char* get_font_name2(Fl_Font fnum, int* weight, int* style);
   virtual int get_font_sizes(Fl_Font fnum, int*& sizep);
   virtual Fl_Font set_fonts(const char *name);
   virtual Fl_Fontdesc* calc_fl_fonts(void);
   virtual unsigned font_desc_size();
   virtual const char *font_name(int num);
-  virtual void font_name(int num, const char *name);
+  virtual void font_name(int num, const char *name, int weight, int style, bool legacy);
   // Defaut implementation may be enough
   virtual void overlay_rect(int x, int y, int w , int h);
   virtual float override_scale();

--- a/FL/Fl_Graphics_Driver.H
+++ b/FL/Fl_Graphics_Driver.H
@@ -358,7 +358,7 @@ public:
   virtual Fl_Region XRectangleRegion(int x, int y, int w, int h);
   virtual void XDestroyRegion(Fl_Region r);
   virtual const char* get_font_name(Fl_Font fnum, int* ap);
-  virtual const char* get_font_name2(Fl_Font fnum, int* weight, int* style);
+  virtual const char* get_font_family(Fl_Font fnum, int* weight, int* style);
   virtual int get_font_sizes(Fl_Font fnum, int*& sizep);
   virtual Fl_Font set_fonts(const char *name);
   virtual Fl_Fontdesc* calc_fl_fonts(void);

--- a/src/Fl.cxx
+++ b/src/Fl.cxx
@@ -2472,6 +2472,10 @@ const char* Fl::get_font_name(Fl_Font fnum, int* ap) {
   return Fl_Graphics_Driver::default_driver().get_font_name(fnum, ap);
 }
 
+const char* Fl::get_font_name2(Fl_Font fnum, int* weight, int* style) {
+  return Fl_Graphics_Driver::default_driver().get_font_name2(fnum, weight, style);
+}
+
 int Fl::get_font_sizes(Fl_Font fnum, int*& sizep) {
   return Fl_Graphics_Driver::default_driver().get_font_sizes(fnum, sizep);
 }

--- a/src/Fl.cxx
+++ b/src/Fl.cxx
@@ -2472,8 +2472,8 @@ const char* Fl::get_font_name(Fl_Font fnum, int* ap) {
   return Fl_Graphics_Driver::default_driver().get_font_name(fnum, ap);
 }
 
-const char* Fl::get_font_name2(Fl_Font fnum, int* weight, int* style) {
-  return Fl_Graphics_Driver::default_driver().get_font_name2(fnum, weight, style);
+const char* Fl::get_font_family(Fl_Font fnum, int* weight, int* style) {
+  return Fl_Graphics_Driver::default_driver().get_font_family(fnum, weight, style);
 }
 
 int Fl::get_font_sizes(Fl_Font fnum, int*& sizep) {

--- a/src/Fl_Graphics_Driver.cxx
+++ b/src/Fl_Graphics_Driver.cxx
@@ -740,6 +740,9 @@ float Fl_Graphics_Driver::scale_bitmap_for_PostScript() { return 2; }
 /** Support for Fl::get_font_name() */
 const char* Fl_Graphics_Driver::get_font_name(Fl_Font fnum, int* ap) {return NULL;}
 
+/** Support for Fl::get_font_name2() */
+const char* Fl_Graphics_Driver::get_font_name2(Fl_Font fnum, int* weight, int* style) {return NULL;}
+
 /** Support for Fl::get_font_sizes() */
 int Fl_Graphics_Driver::get_font_sizes(Fl_Font fnum, int*& sizep) {return 0;}
 
@@ -753,7 +756,7 @@ Fl_Fontdesc* Fl_Graphics_Driver::calc_fl_fonts(void) {return NULL;}
 const char *Fl_Graphics_Driver::font_name(int num) {return NULL;}
 
 /** Support for Fl::set_font() */
-void Fl_Graphics_Driver::font_name(int num, const char *name) {}
+void Fl_Graphics_Driver::font_name(int num, const char *name, int weight, int style, bool legacy) {}
 
 /** Support function for fl_overlay_rect() and scaled GUI.*/
 void Fl_Graphics_Driver::overlay_rect(int x, int y, int w , int h) {
@@ -789,7 +792,7 @@ int Fl_Graphics_Driver::antialias() {
 
 #ifndef FL_DOXYGEN
 
-Fl_Font_Descriptor::Fl_Font_Descriptor(const char* name, Fl_Fontsize Size) {
+Fl_Font_Descriptor::Fl_Font_Descriptor(const char* name, Fl_Fontsize Size, int weight, int style) {
   next = 0;
 #  if HAVE_GL
   listbase = 0;

--- a/src/Fl_Graphics_Driver.cxx
+++ b/src/Fl_Graphics_Driver.cxx
@@ -740,8 +740,8 @@ float Fl_Graphics_Driver::scale_bitmap_for_PostScript() { return 2; }
 /** Support for Fl::get_font_name() */
 const char* Fl_Graphics_Driver::get_font_name(Fl_Font fnum, int* ap) {return NULL;}
 
-/** Support for Fl::get_font_name2() */
-const char* Fl_Graphics_Driver::get_font_name2(Fl_Font fnum, int* weight, int* style) {return NULL;}
+/** Support for Fl::get_font_family() */
+const char* Fl_Graphics_Driver::get_font_family(Fl_Font fnum, int* weight, int* style) {return NULL;}
 
 /** Support for Fl::get_font_sizes() */
 int Fl_Graphics_Driver::get_font_sizes(Fl_Font fnum, int*& sizep) {return 0;}

--- a/src/Fl_Scalable_Graphics_Driver.H
+++ b/src/Fl_Scalable_Graphics_Driver.H
@@ -139,7 +139,7 @@ public:
   /** linked list for this Fl_Fontdesc */
   Fl_Font_Descriptor *next;
   Fl_Fontsize size; /**< font size */
-  Fl_Font_Descriptor(const char* fontname, Fl_Fontsize size);
+  Fl_Font_Descriptor(const char* fontname, Fl_Fontsize size, int weight, int style);
   virtual FL_EXPORT ~Fl_Font_Descriptor() {}
   int ascent, descent;
   unsigned int listbase;// base of display list, 0 = none
@@ -149,7 +149,10 @@ public:
 struct Fl_Fontdesc {
   const char *name;
   char fontname[128];  // "Pretty" font name
+  int weight;
+  int style;
   Fl_Font_Descriptor *first;  // linked list of sizes of this style
+  bool legacy;
 };
 
 #endif // FL_DOXYGEN

--- a/src/drivers/Cairo/Fl_Cairo_Graphics_Driver.H
+++ b/src/drivers/Cairo/Fl_Cairo_Graphics_Driver.H
@@ -32,7 +32,7 @@ typedef struct _PangoFontDescription PangoFontDescription;
 
 class Fl_Cairo_Font_Descriptor : public Fl_Font_Descriptor {
 public:
-  Fl_Cairo_Font_Descriptor(const char* fontname, Fl_Fontsize size, PangoContext *context);
+  Fl_Cairo_Font_Descriptor(const char* fontname, Fl_Fontsize size, PangoContext *context, int weight, int style);
   FL_EXPORT ~Fl_Cairo_Font_Descriptor() FL_OVERRIDE;
   PangoFontDescription *fontref;
   int **width; // array of arrays of character widths
@@ -181,8 +181,9 @@ public:
   static void init_built_in_fonts();
   Fl_Font set_fonts(const char* pattern_name) FL_OVERRIDE;
   const char *font_name(int num) FL_OVERRIDE;
-  void font_name(int num, const char *name) FL_OVERRIDE;
+  void font_name(int num, const char *name, int weight, int style, bool legacy) FL_OVERRIDE;
   const char* get_font_name(Fl_Font fnum, int* ap) FL_OVERRIDE;
+  const char* get_font_name2(Fl_Font fnum, int* weight, int* style) FL_OVERRIDE;
   int get_font_sizes(Fl_Font fnum, int*& sizep) FL_OVERRIDE;
   Fl_Region XRectangleRegion(int x, int y, int w, int h) FL_OVERRIDE;
   void XDestroyRegion(Fl_Region r) FL_OVERRIDE;

--- a/src/drivers/Cairo/Fl_Cairo_Graphics_Driver.H
+++ b/src/drivers/Cairo/Fl_Cairo_Graphics_Driver.H
@@ -183,7 +183,7 @@ public:
   const char *font_name(int num) FL_OVERRIDE;
   void font_name(int num, const char *name, int weight, int style, bool legacy) FL_OVERRIDE;
   const char* get_font_name(Fl_Font fnum, int* ap) FL_OVERRIDE;
-  const char* get_font_name2(Fl_Font fnum, int* weight, int* style) FL_OVERRIDE;
+  const char* get_font_family(Fl_Font fnum, int* weight, int* style) FL_OVERRIDE;
   int get_font_sizes(Fl_Font fnum, int*& sizep) FL_OVERRIDE;
   Fl_Region XRectangleRegion(int x, int y, int w, int h) FL_OVERRIDE;
   void XDestroyRegion(Fl_Region r) FL_OVERRIDE;

--- a/src/drivers/Cairo/Fl_Cairo_Graphics_Driver.cxx
+++ b/src/drivers/Cairo/Fl_Cairo_Graphics_Driver.cxx
@@ -1044,30 +1044,17 @@ void Fl_Cairo_Graphics_Driver::init_built_in_fonts() {
   }
 }
 
-
-// FIXME: this (static) function should likely be in Fl_Graphics_Driver.
-// The code is the same as in src/drivers/Xlib/Fl_Xlib_Graphics_Driver_font_xft.cxx
-
-static int font_name_process(const char *name, char &face) {
-  int l = strlen(name);
-  face = ' ';
-  if      (l >  8 && !memcmp(name + l -  8, " Regular", 8)) l -= 8;
-  else if (l >  6 && !memcmp(name + l -  6, " Plain", 6)) l -= 6;
-  else if (l > 12 && !memcmp(name + l - 12, " Bold Italic", 12)) {l -= 12; face = 'P';}
-  else if (l >  7 && !memcmp(name + l -  7, " Italic", 7)) {l -= 7; face = 'I';}
-  else if (l >  5 && !memcmp(name + l -  5, " Bold", 5)) {l -= 5; face = 'B';}
-  return l;
-}
-
 typedef int (*sort_f_type)(const void *aa, const void *bb);
 
 
-static int font_sort(Fl_Fontdesc *fa, Fl_Fontdesc *fb) {
-  char face_a, face_b;
-  int la = font_name_process(fa->name, face_a);
-  int lb = font_name_process(fb->name, face_b);
-  int c = strncasecmp(fa->name, fb->name, la >= lb ? lb : la);
-  return (c == 0 ? face_a - face_b : c);
+static int font_sort(const Fl_Fontdesc* fa, const Fl_Fontdesc* fb) {
+  int c = strcasecmp(fa->name, fb->name);
+  if (c != 0) return c;
+
+  if (fa->style != fb->style)
+    return fa->style - fb->style;
+
+  return fa->weight - fb->weight;
 }
 
 
@@ -1130,9 +1117,11 @@ const char *Fl_Cairo_Graphics_Driver::font_name(int num) {
 }
 
 
-void Fl_Cairo_Graphics_Driver::font_name(int num, const char *name) {
+void Fl_Cairo_Graphics_Driver::font_name(int num, const char *name, int weight, int style, bool) {
   Fl_Fontdesc *s = fl_fonts + num;
   if (s->name) {
+    s->weight = weight;
+    s->style = style;
     if (!strcmp(s->name, name)) {s->name = name; return;}
     for (Fl_Font_Descriptor* f = s->first; f;) {
       Fl_Font_Descriptor* n = f->next; delete f; f = n;
@@ -1141,28 +1130,44 @@ void Fl_Cairo_Graphics_Driver::font_name(int num, const char *name) {
   }
   s->name = name;
   s->fontname[0] = 0;
+  s->weight = weight;
+  s->style = style;
   s->first = 0;
 }
-
-
-// turn a stored font name into a pretty name:
-#define ENDOFBUFFER  sizeof(fl_fonts->fontname)-1
 
 const char* Fl_Cairo_Graphics_Driver::get_font_name(Fl_Font fnum, int* ap) {
   Fl_Fontdesc *f = fl_fonts + fnum;
   if (!f->fontname[0]) {
-    strcpy(f->fontname, f->name); // to check
-    const char* thisFont = f->name;
-    if (!thisFont || !*thisFont) {if (ap) *ap = 0; return "";}
-    int type = 0;
-    if (strstr(f->name, "Bold")) type |= FL_BOLD;
-    if (strstr(f->name, "Italic") || strstr(f->name, "Oblique")) type |= FL_ITALIC;
-    f->fontname[ENDOFBUFFER] = (char)type;
+    const char* p = f->name;
+    if (!p || !*p) {if (ap) *ap = 0; return "";}
+    strlcpy(f->fontname, p, sizeof(f->fontname));
   }
-  if (ap) *ap = f->fontname[ENDOFBUFFER];
+
+  if (ap) {
+    *ap = 0;
+
+    if (f->weight == FL_WEIGHT_BOLD)
+      *ap |= FL_BOLD;
+    if (f->style == FL_STYLE_ITALIC)
+      *ap |= FL_ITALIC;
+  }
+
   return f->fontname;
 }
 
+const char* Fl_Cairo_Graphics_Driver::get_font_name2(Fl_Font fnum, int* weight, int* style) {
+  Fl_Fontdesc *f = fl_fonts + fnum;
+  const char* p = f->name;
+  if (!p || !*p) {
+    if (weight) *weight = 0;
+    if (style) *style = 0;
+    return "";
+  }
+
+  if (weight) *weight = f->weight;
+  if (style) *style = f->style;
+  return p;
+}
 
 int Fl_Cairo_Graphics_Driver::get_font_sizes(Fl_Font fnum, int*& sizep) {
   static int array[128];
@@ -1180,13 +1185,15 @@ int Fl_Cairo_Graphics_Driver::get_font_sizes(Fl_Font fnum, int*& sizep) {
 
 
 Fl_Cairo_Font_Descriptor::Fl_Cairo_Font_Descriptor(const char* name, Fl_Fontsize size,
-                                                   PangoContext *context) :
-                                                      Fl_Font_Descriptor(name, size) {
+                                                   PangoContext *context, int weight, int style) :
+                                                      Fl_Font_Descriptor(name, size, weight, style) {
   char *string = new char[strlen(name) + 10];
   strcpy(string, name);
   snprintf(string + strlen(string), 10, " %dpx", size);
   //A PangoFontDescription describes a font in an implementation-independent manner.
   fontref = pango_font_description_from_string(string);
+  pango_font_description_set_weight(fontref, (PangoWeight)weight);
+  pango_font_description_set_style(fontref, (PangoStyle)style);
   delete[] string;
   width = NULL;
   //A PangoFontset represents a set of PangoFont to use when rendering text.
@@ -1232,7 +1239,7 @@ static Fl_Font_Descriptor* find(Fl_Font fnum, Fl_Fontsize size, PangoContext *co
   Fl_Font_Descriptor* f;
   for (f = s->first; f; f = f->next)
     if (f->size == size) return f;
-  f = new Fl_Cairo_Font_Descriptor(s->name, size, context);
+  f = new Fl_Cairo_Font_Descriptor(s->name, size, context, s->weight, s->style);
   f->next = s->first;
   s->first = f;
   return f;

--- a/src/drivers/Cairo/Fl_Cairo_Graphics_Driver.cxx
+++ b/src/drivers/Cairo/Fl_Cairo_Graphics_Driver.cxx
@@ -1155,7 +1155,7 @@ const char* Fl_Cairo_Graphics_Driver::get_font_name(Fl_Font fnum, int* ap) {
   return f->fontname;
 }
 
-const char* Fl_Cairo_Graphics_Driver::get_font_name2(Fl_Font fnum, int* weight, int* style) {
+const char* Fl_Cairo_Graphics_Driver::get_font_family(Fl_Font fnum, int* weight, int* style) {
   Fl_Fontdesc *f = fl_fonts + fnum;
   const char* p = f->name;
   if (!p || !*p) {

--- a/src/drivers/GDI/Fl_Font.H
+++ b/src/drivers/GDI/Fl_Font.H
@@ -31,7 +31,7 @@ public:
   int *width[64];
   TEXTMETRIC metr;
   int angle;
-  FL_EXPORT Fl_GDI_Font_Descriptor(const char* fontname, Fl_Fontsize size);
+  FL_EXPORT Fl_GDI_Font_Descriptor(const char* fontname, Fl_Fontsize size, int weight, int style, bool legacy);
 #  if HAVE_GL
   char glok[64];
 #  endif // HAVE_GL

--- a/src/drivers/GDI/Fl_GDI_Graphics_Driver.H
+++ b/src/drivers/GDI/Fl_GDI_Graphics_Driver.H
@@ -149,8 +149,9 @@ protected:
   Fl_Font set_fonts(const char *name) FL_OVERRIDE;
   int get_font_sizes(Fl_Font fnum, int*& sizep) FL_OVERRIDE;
   const char* get_font_name(Fl_Font fnum, int* ap) FL_OVERRIDE;
+  const char* get_font_name2(Fl_Font fnum, int* weight, int* style) FL_OVERRIDE;
   const char *font_name(int num) FL_OVERRIDE;
-  void font_name(int num, const char *name) FL_OVERRIDE;
+  void font_name(int num, const char *name, int weight, int style, bool legacy) FL_OVERRIDE;
   void global_gc() FL_OVERRIDE;
   void overlay_rect(int x, int y, int w , int h) FL_OVERRIDE;
   void cache_size(Fl_Image *img, int &width, int &height) FL_OVERRIDE;

--- a/src/drivers/GDI/Fl_GDI_Graphics_Driver.H
+++ b/src/drivers/GDI/Fl_GDI_Graphics_Driver.H
@@ -149,7 +149,7 @@ protected:
   Fl_Font set_fonts(const char *name) FL_OVERRIDE;
   int get_font_sizes(Fl_Font fnum, int*& sizep) FL_OVERRIDE;
   const char* get_font_name(Fl_Font fnum, int* ap) FL_OVERRIDE;
-  const char* get_font_name2(Fl_Font fnum, int* weight, int* style) FL_OVERRIDE;
+  const char* get_font_family(Fl_Font fnum, int* weight, int* style) FL_OVERRIDE;
   const char *font_name(int num) FL_OVERRIDE;
   void font_name(int num, const char *name, int weight, int style, bool legacy) FL_OVERRIDE;
   void global_gc() FL_OVERRIDE;

--- a/src/drivers/GDI/Fl_GDI_Graphics_Driver_font.cxx
+++ b/src/drivers/GDI/Fl_GDI_Graphics_Driver_font.cxx
@@ -54,32 +54,49 @@
 # include <wchar.h>
 #endif
 
-// Bug: older versions calculated the value for *ap as a side effect of
-// making the name, and then forgot about it. To avoid having to change
-// the header files I decided to store this value in the last character
-// of the font name array.
-#define ENDOFBUFFER 127 // sizeof(Fl_Font.fontname)-1
-
 // turn a stored font name into a pretty name:
 const char* Fl_GDI_Graphics_Driver::get_font_name(Fl_Font fnum, int* ap) {
   Fl_Fontdesc *f = fl_fonts + fnum;
   if (!f->fontname[0]) {
     const char* p = f->name;
     if (!p || !*p) {if (ap) *ap = 0; return "";}
-    int type;
-    switch (*p) {
-    case 'B': type = FL_BOLD; break;
-    case 'I': type = FL_ITALIC; break;
-    case 'P': type = FL_BOLD | FL_ITALIC; break;
-    default:  type = 0; break;
+    if (f->legacy) {
+      switch (*p) {
+        case 'B':
+        case 'I':
+        case 'P':
+        case ' ':
+          p++;
+          break;
+      }
     }
-    strlcpy(f->fontname, p+1, ENDOFBUFFER);
-    if (type & FL_BOLD) strlcat(f->fontname, " bold", ENDOFBUFFER);
-    if (type & FL_ITALIC) strlcat(f->fontname, " italic", ENDOFBUFFER);
-    f->fontname[ENDOFBUFFER] = (char)type;
+    strlcpy(f->fontname, p, sizeof(f->fontname));
   }
-  if (ap) *ap = f->fontname[ENDOFBUFFER];
+
+  if (ap) {
+    *ap = 0;
+
+    if (f->weight == FL_WEIGHT_BOLD)
+      *ap |= FL_BOLD;
+    if (f->style == FL_STYLE_ITALIC)
+      *ap |= FL_ITALIC;
+  }
+
   return f->fontname;
+}
+
+const char* Fl_GDI_Graphics_Driver::get_font_name2(Fl_Font fnum, int* weight, int* style) {
+  Fl_Fontdesc *f = fl_fonts + fnum;
+  const char* p = f->name;
+  if (!p || !*p) {
+    if (weight) *weight = 0;
+    if (style) *style = 0;
+    return "";
+  }
+
+  if (weight) *weight = f->weight;
+  if (style) *style = f->style;
+  return p;
 }
 
 static int fl_free_font = FL_FREE_FONT;
@@ -192,8 +209,21 @@ int Fl_GDI_Graphics_Driver::get_font_sizes(Fl_Font fnum, int*& sizep) {
 //  int l = fl_utf_nb_char((unsigned char*)s->name+1, strlen(s->name+1));
 //  unsigned short *b = (unsigned short*) malloc((l + 1) * sizeof(short));
 //  fl_utf2unicode((unsigned char*)s->name+1, l, (wchar_t*)b);
-  const char *nm = (const char*)s->name+1;
-  size_t len = strlen(s->name+1);
+  const char* p = s->name;
+
+  if (s->legacy) {
+    switch (*p) {
+      case 'B':
+      case 'I':
+      case 'P':
+      case ' ':
+        p++;
+        break;
+    }
+  }
+
+  const char *nm = p;
+  size_t len = strlen(p);
   unsigned l = fl_utf8toUtf16(nm, (unsigned) len, NULL, 0); // Pass NULL to query length required
   unsigned short *b = (unsigned short*) malloc((l + 1) * sizeof(short));
   l = fl_utf8toUtf16(nm, (unsigned) len, b, (l+1)); // Now do the conversion
@@ -209,9 +239,11 @@ const char *Fl_GDI_Graphics_Driver::font_name(int num) {
   return fl_fonts[num].name;
 }
 
-void Fl_GDI_Graphics_Driver::font_name(int num, const char *name) {
+void Fl_GDI_Graphics_Driver::font_name(int num, const char *name, int weight, int style, bool legacy) {
   Fl_Fontdesc *s = fl_fonts + num;
   if (s->name) {
+    s->weight = weight;
+    s->style = style;
     if (!strcmp(s->name, name)) {s->name = name; return;}
     for (Fl_Font_Descriptor* f = s->first; f;) {
       Fl_Font_Descriptor* n = f->next; delete f; f = n;
@@ -220,6 +252,9 @@ void Fl_GDI_Graphics_Driver::font_name(int num, const char *name) {
   }
   s->name = name;
   s->fontname[0] = 0;
+  s->weight = weight;
+  s->style = style;
+  s->legacy = legacy;
   s->first = 0;
 }
 
@@ -230,15 +265,15 @@ static unsigned short *wstr = NULL;
 static int wstr_len    = 0;
 
 #ifndef FL_DOXYGEN
-Fl_GDI_Font_Descriptor::Fl_GDI_Font_Descriptor(const char* name, Fl_Fontsize fsize) : Fl_Font_Descriptor(name,fsize) {
-  int weight = FW_NORMAL;
-  int italic = 0;
-  switch (*name++) {
-  case 'I': italic = 1; break;
-  case 'P': italic = 1;
-  case 'B': weight = FW_BOLD; break;
-  case ' ': break;
-  default: name--;
+Fl_GDI_Font_Descriptor::Fl_GDI_Font_Descriptor(const char* name, Fl_Fontsize fsize, int weight, int style, bool legacy) : Fl_Font_Descriptor(name,fsize, weight, style) {
+  if (legacy) {
+    switch (*name) {
+      case 'I':
+      case 'P':
+      case 'B':
+      case ' ':
+        name++;
+    }
   }
   int wn = fl_utf8toUtf16(name, (unsigned int)strlen(name), wstr, wstr_len);
   if (wn >= wstr_len) {
@@ -253,7 +288,7 @@ Fl_GDI_Font_Descriptor::Fl_GDI_Font_Descriptor(const char* name, Fl_Fontsize fsi
     fl_angle_*10,                   // angle of escapement
     fl_angle_*10,                   // base-line orientation angle
     weight,
-    italic,
+    style != FL_STYLE_NORMAL ? TRUE : FALSE,
     FALSE,              // underline attribute flag
     FALSE,              // strikeout attribute flag
     DEFAULT_CHARSET,    // character set identifier
@@ -323,7 +358,7 @@ static Fl_GDI_Font_Descriptor* find(Fl_Font fnum, Fl_Fontsize size, int angle) {
   Fl_GDI_Font_Descriptor* f;
   for (f = (Fl_GDI_Font_Descriptor*)s->first; f; f = (Fl_GDI_Font_Descriptor*)f->next)
     if (f->size == size && f->angle == angle) return f;
-  f = new Fl_GDI_Font_Descriptor(s->name, size);
+  f = new Fl_GDI_Font_Descriptor(s->name, size, s->weight, s->style, s->legacy);
   f->next = s->first;
   s->first = f;
   return f;

--- a/src/drivers/GDI/Fl_GDI_Graphics_Driver_font.cxx
+++ b/src/drivers/GDI/Fl_GDI_Graphics_Driver_font.cxx
@@ -85,7 +85,7 @@ const char* Fl_GDI_Graphics_Driver::get_font_name(Fl_Font fnum, int* ap) {
   return f->fontname;
 }
 
-const char* Fl_GDI_Graphics_Driver::get_font_name2(Fl_Font fnum, int* weight, int* style) {
+const char* Fl_GDI_Graphics_Driver::get_font_family(Fl_Font fnum, int* weight, int* style) {
   Fl_Fontdesc *f = fl_fonts + fnum;
   const char* p = f->name;
   if (!p || !*p) {

--- a/src/drivers/Quartz/Fl_Font.H
+++ b/src/drivers/Quartz/Fl_Font.H
@@ -29,7 +29,7 @@
 
 class Fl_Quartz_Font_Descriptor : public Fl_Font_Descriptor {
 public:
-  Fl_Quartz_Font_Descriptor(const char* fontname, Fl_Fontsize size);
+  Fl_Quartz_Font_Descriptor(const char* fontname, Fl_Fontsize size, int weight, int style);
   virtual FL_EXPORT ~Fl_Quartz_Font_Descriptor();
   CTFontRef fontref;
   // the unicode span is divided in 512 blocks of 128 characters

--- a/src/drivers/Quartz/Fl_Quartz_Graphics_Driver.H
+++ b/src/drivers/Quartz/Fl_Quartz_Graphics_Driver.H
@@ -125,9 +125,10 @@ protected:
   void quartz_restore_line_style();
   inline Fl_Quartz_Font_Descriptor *valid_font_descriptor();
   const char* get_font_name(Fl_Font fnum, int* ap) FL_OVERRIDE;
+  const char* get_font_name2(Fl_Font fnum, int* weight, int* style) FL_OVERRIDE;
   int get_font_sizes(Fl_Font fnum, int*& sizep) FL_OVERRIDE;
   const char *font_name(int num) FL_OVERRIDE;
-  void font_name(int num, const char *name) FL_OVERRIDE;
+  void font_name(int num, const char *name, int weight, int style, bool legacy) FL_OVERRIDE;
   Fl_Fontdesc* calc_fl_fonts(void) FL_OVERRIDE;
 
   void text_extents(const char*, int n, int& dx, int& dy, int& w, int& h) FL_OVERRIDE;

--- a/src/drivers/Quartz/Fl_Quartz_Graphics_Driver.H
+++ b/src/drivers/Quartz/Fl_Quartz_Graphics_Driver.H
@@ -125,7 +125,7 @@ protected:
   void quartz_restore_line_style();
   inline Fl_Quartz_Font_Descriptor *valid_font_descriptor();
   const char* get_font_name(Fl_Font fnum, int* ap) FL_OVERRIDE;
-  const char* get_font_name2(Fl_Font fnum, int* weight, int* style) FL_OVERRIDE;
+  const char* get_font_family(Fl_Font fnum, int* weight, int* style) FL_OVERRIDE;
   int get_font_sizes(Fl_Font fnum, int*& sizep) FL_OVERRIDE;
   const char *font_name(int num) FL_OVERRIDE;
   void font_name(int num, const char *name, int weight, int style, bool legacy) FL_OVERRIDE;

--- a/src/drivers/Quartz/Fl_Quartz_Graphics_Driver_font.cxx
+++ b/src/drivers/Quartz/Fl_Quartz_Graphics_Driver_font.cxx
@@ -54,14 +54,6 @@ static Fl_Fontdesc built_in_table_PS[] = { // PostScript font names preferred wh
   {"ZapfDingbatsITC"}
 };
 
-
-// Bug: older versions calculated the value for *ap as a side effect of
-// making the name, and then forgot about it. To avoid having to change
-// the header files I decided to store this value in the last character
-// of the font name array.
-#define ENDOFBUFFER  sizeof(fl_fonts->fontname)-1
-
-// turn a stored font name into a pretty name:
 const char* Fl_Quartz_Graphics_Driver::get_font_name(Fl_Font fnum, int* ap) {
   if (!fl_fonts) fl_fonts = calc_fl_fonts();
   Fl_Fontdesc *f = fl_fonts + fnum;
@@ -69,15 +61,33 @@ const char* Fl_Quartz_Graphics_Driver::get_font_name(Fl_Font fnum, int* ap) {
     this->set_fontname_in_fontdesc(f);
     const char* thisFont = f->name;
     if (!thisFont || !*thisFont) {if (ap) *ap = 0; return "";}
-    int type = 0;
-    if (strstr(f->name, "Bold")) type |= FL_BOLD;
-    if (strstr(f->name, "Italic") || strstr(f->name, "Oblique")) type |= FL_ITALIC;
-    f->fontname[ENDOFBUFFER] = (char)type;
   }
-  if (ap) *ap = f->fontname[ENDOFBUFFER];
+
+  if (ap) {
+    *ap = 0;
+
+    if (f->weight == FL_WEIGHT_BOLD)
+      *ap |= FL_BOLD;
+    if (f->style == FL_STYLE_ITALIC)
+      *ap |= FL_ITALIC;
+  }
+
   return f->fontname;
 }
 
+const char* Fl_Quartz_Graphics_Driver::get_font_name2(Fl_Font fnum, int* weight, int* style) {
+  Fl_Fontdesc *f = fl_fonts + fnum;
+  const char* p = f->name;
+  if (!p || !*p) {
+    if (weight) *weight = 0;
+    if (style) *style = 0;
+    return "";
+  }
+
+  if (weight) *weight = f->weight;
+  if (style) *style = f->style;
+  return p;
+}
 
 int Fl_Quartz_Graphics_Driver::get_font_sizes(Fl_Font fnum, int*& sizep) {
   static int array[128];
@@ -94,7 +104,7 @@ int Fl_Quartz_Graphics_Driver::get_font_sizes(Fl_Font fnum, int*& sizep) {
   return cnt;
 }
 
-Fl_Quartz_Font_Descriptor::Fl_Quartz_Font_Descriptor(const char* name, Fl_Fontsize Size) : Fl_Font_Descriptor(name, Size) {
+Fl_Quartz_Font_Descriptor::Fl_Quartz_Font_Descriptor(const char* name, Fl_Fontsize Size, int weight, int style) : Fl_Font_Descriptor(name, Size, weight, style) {
   fontref = NULL;
   Fl_Quartz_Graphics_Driver *driver = (Fl_Quartz_Graphics_Driver*)&Fl_Graphics_Driver::default_driver();
   driver->descriptor_init(name, size, this);
@@ -145,7 +155,7 @@ static Fl_Font_Descriptor* find(Fl_Font fnum, Fl_Fontsize size) {
   Fl_Font_Descriptor* f;
   for (f = s->first; f; f = f->next)
     if (f->size == size) return f;
-  f = new Fl_Quartz_Font_Descriptor(s->name, size);
+  f = new Fl_Quartz_Font_Descriptor(s->name, size, s->weight, s->style);
   f->next = s->first;
   s->first = f;
   return f;
@@ -228,19 +238,114 @@ double Fl_Quartz_Graphics_Driver::width(unsigned int wc) {
   return width(utf16, l);
 }
 
+static CGFloat ct_weight_from_opentype(int weight)
+{
+    // OpenType weight -> CoreText weight trait
+
+    if (weight <= 100) return -0.8;
+    if (weight <= 200) return -0.6;
+    if (weight <= 300) return -0.4;
+    if (weight <= 400) return  0.0;
+    if (weight <= 500) return  0.23;
+    if (weight <= 600) return  0.30;
+    if (weight <= 700) return  0.40;
+    if (weight <= 800) return  0.56;
+    return 0.62;
+}
+
+CTFontRef create_font(
+    const char* familyName,
+    int weight,
+    int slant,
+    double size)
+{
+    CGFloat ctWeight = ct_weight_from_opentype(weight);
+
+    CFNumberRef weightNumber =
+        CFNumberCreate(
+            kCFAllocatorDefault,
+            kCFNumberCGFloatType,
+            &ctWeight);
+
+    CGFloat slant = slant ? 1.0 : 0.0;
+
+    CFNumberRef slantNumber =
+        CFNumberCreate(
+            kCFAllocatorDefault,
+            kCFNumberCGFloatType,
+            &slant);
+
+    const void* traitKeys[] = {
+        kCTFontWeightTrait,
+        kCTFontSlantTrait
+    };
+
+    const void* traitValues[] = {
+        weightNumber,
+        slantNumber
+    };
+
+    CFDictionaryRef traits =
+        CFDictionaryCreate(
+            kCFAllocatorDefault,
+            traitKeys,
+            traitValues,
+            2,
+            &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks);
+
+    const void* attrKeys[] = {
+        kCTFontFamilyNameAttribute,
+        kCTFontTraitsAttribute
+    };
+
+    const void* attrValues[] = {
+        familyName,
+        traits
+    };
+
+    CFDictionaryRef attrs =
+        CFDictionaryCreate(
+            kCFAllocatorDefault,
+            attrKeys,
+            attrValues,
+            2,
+            &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks);
+
+    CTFontDescriptorRef descriptor =
+        CTFontDescriptorCreateWithAttributes(attrs);
+
+    CTFontRef font =
+        CTFontCreateWithFontDescriptor(
+            descriptor,
+            size,
+            nullptr);
+
+    CFRelease(descriptor);
+    CFRelease(attrs);
+    CFRelease(traits);
+    CFRelease(weightNumber);
+    CFRelease(slantNumber);
+    CFRelease(familyName);
+
+    return font;
+}
+
 void Fl_Quartz_Graphics_Driver::set_fontname_in_fontdesc(Fl_Fontdesc *f) {
   CFStringRef cfname = CFStringCreateWithCString(NULL, f->name, kCFStringEncodingUTF8);
-  CTFontRef ctfont = cfname ? CTFontCreateWithName(cfname, 0, NULL) : NULL;
+
+  CTFontRef ctfont = cfname ? create_font(cfname, f->weight, f->style, 0) : NULL;
   if (cfname) { CFRelease(cfname); cfname = NULL; }
   if (ctfont) {
     cfname = CTFontCopyFullName(ctfont);
     CFRelease(ctfont);
     if (cfname) {
-      CFStringGetCString(cfname, f->fontname, ENDOFBUFFER, kCFStringEncodingUTF8);
+      CFStringGetCString(cfname, f->fontname, sizeof(f->fontname), kCFStringEncodingUTF8);
       CFRelease(cfname);
     }
   }
-  if (!cfname) strlcpy(f->fontname, f->name, ENDOFBUFFER);
+  if (!cfname) strlcpy(f->fontname, f->name, sizeof(f->fontname));
 }
 
 const char *Fl_Quartz_Graphics_Driver::font_name(int num) {
@@ -248,9 +353,11 @@ const char *Fl_Quartz_Graphics_Driver::font_name(int num) {
   return fl_fonts[num].name;
 }
 
-void Fl_Quartz_Graphics_Driver::font_name(int num, const char *name) {
+void Fl_Quartz_Graphics_Driver::font_name(int num, const char *name, int weight, int style, bool) {
   Fl_Fontdesc *s = fl_fonts + num;
   if (s->name) {
+    s->weight = weight;
+    s->style = style;
     if (!strcmp(s->name, name)) {s->name = name; return;}
     for (Fl_Font_Descriptor* f = s->first; f;) {
       Fl_Font_Descriptor* n = f->next; delete f; f = n;
@@ -259,6 +366,8 @@ void Fl_Quartz_Graphics_Driver::font_name(int num, const char *name) {
   }
   s->name = name;
   s->fontname[0] = 0;
+  s->weight = weight;
+  s->style = style;
   s->first = 0;
 }
 
@@ -273,7 +382,7 @@ void Fl_Quartz_Graphics_Driver::descriptor_init(const char* name,
                                                       Fl_Fontsize size, Fl_Quartz_Font_Descriptor *d)
 {
   CFStringRef str = CFStringCreateWithCString(NULL, name, kCFStringEncodingUTF8);
-  d->fontref = CTFontCreateWithName(str, size, NULL);
+  d->fontref = create_font(str, d->weight, d->style, size);
   CGGlyph glyph[2];
   const UniChar A[2]={'W','.'};
   CTFontGetGlyphsForCharacters(d->fontref, A, glyph, 2);
@@ -285,7 +394,7 @@ void Fl_Quartz_Graphics_Driver::descriptor_init(const char* name,
     // slightly rescale fixed-width fonts so the character width has an integral value
     CFRelease(d->fontref);
     CGFloat fsize = size / ( w/floor(w + 0.5) );
-    d->fontref = CTFontCreateWithName(str, fsize, NULL);
+    d->fontref = create_font(str, d->weight, d->style, fsize);
     w = CTFontGetAdvancesForGlyphs(d->fontref, kCTFontOrientationHorizontal, glyph, NULL, 1);
   }
   CFRelease(str);

--- a/src/drivers/Quartz/Fl_Quartz_Graphics_Driver_font.cxx
+++ b/src/drivers/Quartz/Fl_Quartz_Graphics_Driver_font.cxx
@@ -75,7 +75,7 @@ const char* Fl_Quartz_Graphics_Driver::get_font_name(Fl_Font fnum, int* ap) {
   return f->fontname;
 }
 
-const char* Fl_Quartz_Graphics_Driver::get_font_name2(Fl_Font fnum, int* weight, int* style) {
+const char* Fl_Quartz_Graphics_Driver::get_font_family(Fl_Font fnum, int* weight, int* style) {
   Fl_Fontdesc *f = fl_fonts + fnum;
   const char* p = f->name;
   if (!p || !*p) {

--- a/src/drivers/Xlib/Fl_Font.H
+++ b/src/drivers/Xlib/Fl_Font.H
@@ -41,7 +41,7 @@ public:
         XftFont* font;
 #    endif
   int angle;
-  FL_EXPORT Fl_Xlib_Font_Descriptor(const char* xfontname, Fl_Fontsize size, int angle);
+  FL_EXPORT Fl_Xlib_Font_Descriptor(const char* xfontname, Fl_Fontsize size, int angle, int weight, int style, bool legacy);
 #  else
   XUtf8FontStruct* font;        // X UTF-8 font information
   FL_EXPORT Fl_Xlib_Font_Descriptor(const char* xfontname);

--- a/src/drivers/Xlib/Fl_Xlib_Graphics_Driver.H
+++ b/src/drivers/Xlib/Fl_Xlib_Graphics_Driver.H
@@ -209,13 +209,14 @@ protected:
   void color(uchar r, uchar g, uchar b) FL_OVERRIDE;
   float scale_font_for_PostScript(Fl_Font_Descriptor *desc, int s) FL_OVERRIDE;
   const char* get_font_name(Fl_Font fnum, int* ap) FL_OVERRIDE;
+  const char* get_font_name2(Fl_Font fnum, int* weight, int* style) FL_OVERRIDE;
   int get_font_sizes(Fl_Font fnum, int*& sizep) FL_OVERRIDE;
 #if !USE_XFT
   unsigned font_desc_size() FL_OVERRIDE;
   float scale_bitmap_for_PostScript() FL_OVERRIDE;
 #endif
   const char *font_name(int num) FL_OVERRIDE;
-  void font_name(int num, const char *name) FL_OVERRIDE;
+  void font_name(int num, const char *name, int weight, int style, bool legacy) FL_OVERRIDE;
   Fl_Font set_fonts(const char* xstarname) FL_OVERRIDE;
 };
 

--- a/src/drivers/Xlib/Fl_Xlib_Graphics_Driver.H
+++ b/src/drivers/Xlib/Fl_Xlib_Graphics_Driver.H
@@ -209,7 +209,7 @@ protected:
   void color(uchar r, uchar g, uchar b) FL_OVERRIDE;
   float scale_font_for_PostScript(Fl_Font_Descriptor *desc, int s) FL_OVERRIDE;
   const char* get_font_name(Fl_Font fnum, int* ap) FL_OVERRIDE;
-  const char* get_font_name2(Fl_Font fnum, int* weight, int* style) FL_OVERRIDE;
+  const char* get_font_family(Fl_Font fnum, int* weight, int* style) FL_OVERRIDE;
   int get_font_sizes(Fl_Font fnum, int*& sizep) FL_OVERRIDE;
 #if !USE_XFT
   unsigned font_desc_size() FL_OVERRIDE;

--- a/src/drivers/Xlib/Fl_Xlib_Graphics_Driver.cxx
+++ b/src/drivers/Xlib/Fl_Xlib_Graphics_Driver.cxx
@@ -110,7 +110,7 @@ const char *Fl_Xlib_Graphics_Driver::font_name(int num) {
 #endif
 }
 
-void Fl_Xlib_Graphics_Driver::font_name(int num, const char *name) {
+void Fl_Xlib_Graphics_Driver::font_name(int num, const char *name, int weight, int style, bool legacy) {
 #if USE_XFT
 #  if USE_PANGO
   init_built_in_fonts();
@@ -124,6 +124,8 @@ void Fl_Xlib_Graphics_Driver::font_name(int num, const char *name) {
     Fl_Xlib_Fontdesc *s = ((Fl_Xlib_Fontdesc*)fl_fonts) + num;
 #endif
   if (s->name) {
+    s->weight = weight;
+    s->style = style;
     if (!strcmp(s->name, name)) {s->name = name; return;}
 #if !USE_XFT
     if (s->xlist && s->n >= 0) XFreeFontNames(s->xlist);
@@ -137,6 +139,10 @@ void Fl_Xlib_Graphics_Driver::font_name(int num, const char *name) {
   s->fontname[0] = 0;
 #if !USE_XFT
   s->xlist = 0;
+#else
+  s->weight = weight;
+  s->style = style;
+  s->legacy = legacy;
 #endif
   s->first = 0;
 }

--- a/src/drivers/Xlib/Fl_Xlib_Graphics_Driver_font_x.cxx
+++ b/src/drivers/Xlib/Fl_Xlib_Graphics_Driver_font_x.cxx
@@ -384,7 +384,7 @@ int Fl_Xlib_Graphics_Driver::get_font_sizes(Fl_Font fnum, int*& sizep) {
 
 #ifndef FL_DOXYGEN
 
-Fl_Xlib_Font_Descriptor::Fl_Xlib_Font_Descriptor(const char* name) : Fl_Font_Descriptor(name, 0) {
+Fl_Xlib_Font_Descriptor::Fl_Xlib_Font_Descriptor(const char* name) : Fl_Font_Descriptor(name, 0, 0, 0) {
   font = XCreateUtf8FontStruct(fl_display, name);
   if (!font) {
     Fl::warning("bad font: %s", name);

--- a/src/drivers/Xlib/Fl_Xlib_Graphics_Driver_font_xft.cxx
+++ b/src/drivers/Xlib/Fl_Xlib_Graphics_Driver_font_xft.cxx
@@ -482,7 +482,7 @@ void Fl_Xlib_Graphics_Driver::font_unscaled(Fl_Font fnum, Fl_Fontsize size) {
   fl_xft_font(this, fnum, size, 0);
 }
 
-static XftFont* fontopen(const char* name, /*Fl_Fontsize*/double size, bool core, int angle) {
+static XftFont* fontopen(const char* name, /*Fl_Fontsize*/double size, bool core, int angle, int weight, int style, int legacy) {
   // Check: does it look like we have been passed an old-school XLFD fontname?
   bool is_xlfd = false;
   int hyphen_count = 0;
@@ -500,26 +500,31 @@ static XftFont* fontopen(const char* name, /*Fl_Fontsize*/double size, bool core
   if(!is_xlfd) { // Not an XLFD - open as a XFT style name
     XftFont *the_font = NULL; // the font we will return;
     XftPattern *fnt_pat = XftPatternCreate(); // the pattern we will use for matching
-    int slant = XFT_SLANT_ROMAN;
-    int weight = XFT_WEIGHT_MEDIUM;
 
-    /* This "converts" FLTK-style font names back into "regular" names, extracting
-     * the BOLD and ITALIC codes as it does so - all FLTK font names are prefixed
-     * by 'I' (italic) 'B' (bold) 'P' (bold italic) or ' ' (regular) modifiers.
-     * This gives a fairly limited font selection ability, but is retained for
-     * compatibility reasons. If you really need a more complex choice, you are best
-     * calling Fl::set_fonts(*) then selecting the font by font-index rather than by
-     * name anyway. Probably.
-     * If you want to load a font who's name does actually begin with I, B or P, you
-     * MUST use a leading space OR simply use lowercase for the name...
-     */
-    /* This may be efficient, but it is non-obvious. */
-    switch (*name++) {
-    case 'I': slant = XFT_SLANT_ITALIC; break; // italic
-    case 'P': slant = XFT_SLANT_ITALIC;        // bold-italic (falls-through)
-    case 'B': weight = XFT_WEIGHT_BOLD; break; // bold
-    case ' ': break;                           // regular
-    default: name--;                           // no prefix, restore name
+    int slant;
+
+    switch (style) {
+      case FL_STYLE_NORMAL:
+          slant = XFT_SLANT_ROMAN;
+          break;
+        case FL_STYLE_ITALIC:
+          slant = XFT_SLANT_ITALIC;
+          break;
+        case FL_STYLE_OBLIQUE:
+          slant = XFT_SLANT_OBLIQUE;
+          break;
+    };
+
+    weight = FcWeightFromOpenType(weight);
+
+    if (legacy) {
+      switch (*name) {
+        case 'I':
+        case 'P':
+        case 'B':
+        case ' ':
+          name++;
+      }
     }
 
     if(comma_count) { // multiple comma-separated names were passed
@@ -540,12 +545,14 @@ static XftFont* fontopen(const char* name, /*Fl_Fontsize*/double size, bool core
         // Now do a cut-down version of the FLTK name conversion.
         // NOTE: we only use the slant and weight of the first name,
         // subsequent names we ignore this for... But we still need to do the check.
-        switch (*curr++) {
-        case 'I': break; // italic
-        case 'P':        // bold-italic (falls-through)
-        case 'B': break; // bold
-        case ' ': break; // regular
-        default: curr--; // no prefix, restore name
+        if (legacy) {
+          switch (*curr++) {
+          case 'I': break; // italic
+          case 'P':        // bold-italic (falls-through)
+          case 'B': break; // bold
+          case ' ': break; // regular
+          default: curr--; // no prefix, restore name
+          }
         }
 
         comma_count--; // decrement name sections count
@@ -669,10 +676,10 @@ puts("Font Opened"); fflush(stdout);
   }
 } // end of fontopen
 
-Fl_Xlib_Font_Descriptor::Fl_Xlib_Font_Descriptor(const char* name, Fl_Fontsize fsize, int fangle) : Fl_Font_Descriptor(name, fsize) {
+Fl_Xlib_Font_Descriptor::Fl_Xlib_Font_Descriptor(const char* name, Fl_Fontsize fsize, int fangle, int weight, int style, bool legacy) : Fl_Font_Descriptor(name, fsize, weight, style) {
 //  encoding = fl_encoding_;
   angle = fangle;
-  font = fontopen(name, fsize, false, angle);
+  font = fontopen(name, fsize, false, angle, weight, style, legacy);
 }
 
 
@@ -885,8 +892,18 @@ int Fl_Xlib_Graphics_Driver::get_font_sizes(Fl_Font fnum, int*& sizep) {
   if (!s->name) s = fl_fonts; // empty slot in table, use entry 0
 
   fl_open_display();
+  const char* p = s->name;
+  if (s->legacy) {
+    switch (*p) {
+      case 'B':
+      case 'I':
+      case 'P':
+      case ' ':
+        p++;
+    }
+  }
   XftFontSet* fs = XftListFonts(fl_display, fl_screen,
-                                XFT_FAMILY, XftTypeString, s->name+1,
+                                XFT_FAMILY, XftTypeString, p,
                                 (void *)0,
                                 XFT_PIXEL_SIZE,
                                 (void *)0);
@@ -920,40 +937,45 @@ float Fl_Xlib_Graphics_Driver::scale_font_for_PostScript(Fl_Font_Descriptor *des
   return ps_size;
 }
 
-// Bug: older versions calculated the value for *ap as a side effect of
-// making the name, and then forgot about it. To avoid having to change
-// the header files I decided to store this value in the last character
-// of the font name array.
-#define ENDOFBUFFER 127 // sizeof(Fl_Font.fontname)-1
-
-// turn a stored font name in "fltk format" into a pretty name:
 const char* Fl_Xlib_Graphics_Driver::get_font_name(Fl_Font fnum, int* ap) {
   Fl_Fontdesc *f = fl_fonts + fnum;
   if (!f->fontname[0]) {
     const char* p = f->name;
-    int type;
-#if USE_PANGO
-    type = 0;
-    if (strstr(p, " Bold")) type = FL_BOLD;
-    if (strstr(p, " Italic") || strstr(p, " Oblique")) type += FL_ITALIC;
-    strlcpy(f->fontname, p, ENDOFBUFFER);
-#else
-    switch (p[0]) {
-      case 'B': type = FL_BOLD; break;
-      case 'I': type = FL_ITALIC; break;
-      case 'P': type = FL_BOLD | FL_ITALIC; break;
-      default:  type = 0; break;
+    if (!p || !*p) {if (ap) *ap = 0; return "";}
+    switch (*p) {
+      case 'B':
+      case 'I':
+      case 'P':
+      case ' ':
+      p++;
+      break;
     }
-  // NOTE: This can cause duplications in fonts that already have Bold or Italic in
-  // their "name". Maybe we need to find a cleverer way?
-    strlcpy(f->fontname, p+1, ENDOFBUFFER);
-    if (type & FL_BOLD) strlcat(f->fontname, " bold", ENDOFBUFFER);
-    if (type & FL_ITALIC) strlcat(f->fontname, " italic", ENDOFBUFFER);
-#endif // USE_PANGO
-    f->fontname[ENDOFBUFFER] = (char)type;
+    strlcpy(f->fontname, p, sizeof(f->fontname));
   }
-  if (ap) *ap = f->fontname[ENDOFBUFFER];
+
+  if (ap) {
+    *ap = 0;
+
+    if (f->weight == FL_WEIGHT_BOLD)
+      *ap |= FL_BOLD;
+    if (f->style == FL_STYLE_ITALIC)
+      *ap |= FL_ITALIC;
+  }
   return f->fontname;
+}
+
+const char* Fl_Xlib_Graphics_Driver::get_font_name2(Fl_Font fnum, int* weight, int* style) {
+  Fl_Fontdesc *f = fl_fonts + fnum;
+  const char* p = f->name;
+  if (!p || !*p) {
+    if (weight) *weight = 0;
+    if (style) *style = 0;
+    return "";
+  }
+
+  if (weight) *weight = f->weight;
+  if (style) *style = f->style;
+  return p;
 }
 
 Fl_Xlib_Font_Descriptor::~Fl_Xlib_Font_Descriptor() {
@@ -988,7 +1010,7 @@ static void fl_xft_font(Fl_Xlib_Graphics_Driver *driver, Fl_Font fnum, Fl_Fontsi
       break;
   }
   if (!f) {
-    f = new Fl_Xlib_Font_Descriptor(font->name, size, angle);
+    f = new Fl_Xlib_Font_Descriptor(font->name, size, angle, font->weight, font->style, font->legacy);
     f->next = font->first;
     font->first = f;
   }
@@ -1040,13 +1062,20 @@ static XFontStruct* load_xfont_for_xft2(Fl_Graphics_Driver *driver) {
   while (*p) { *p = tolower(*p); p++; }
 #endif // USE_PANGO
   const char *name = pc;    // keep a handle to the original name for freeing later
-  // Parse the "fltk-name" of the font
-  switch (*name++) {
-    case 'I': slant = 'i'; break;       // italic
-    case 'P': slant = 'i';              // bold-italic (falls-through)
-    case 'B': weight = wt_bold; break;  // bold
-    case ' ': break;                    // regular
-    default: name--;                    // no prefix, restore name
+  if (fl_fonts[fnum].style)
+    slant = 'i';
+
+  if (fl_fonts[fnum].weight >= FL_WEIGHT_BOLD)
+    weight = wt_bold;
+
+  if (fl_fonts[fnum].legacy) {
+    switch (*name) {
+      case 'I':
+      case 'P':
+      case 'B':
+      case ' ':
+        name++;
+    }
   }
 
   // first, we do a query with no prefered size, to see if the font exists at all
@@ -1125,7 +1154,7 @@ static XFontStruct* fl_xxfont(Fl_Graphics_Driver *driver) {
   }
   static XftFont* xftfont;
   if (xftfont) XftFontClose (fl_display, xftfont);
-  xftfont = fontopen(fl_fonts[driver->font()].name, ((Fl_Xlib_Graphics_Driver*)driver)->size_unscaled(), true, 0); // else request XFT to load a suitable "core" font instead.
+  xftfont = fontopen(fl_fonts[driver->font()].name, ((Fl_Xlib_Graphics_Driver*)driver)->size_unscaled(), true, 0, true); // else request XFT to load a suitable "core" font instead.
   return xftfont->u.core.font;
 #  endif // XFT_MAJOR > 1
 }
@@ -1182,7 +1211,11 @@ void Fl_Xlib_Graphics_Driver::font_unscaled(Fl_Font fnum, Fl_Fontsize size) {
     pfd_array_length = new_length;
   }
   if (!pfd_array[fnum]) {
-    pfd_array[fnum] = pango_font_description_from_string(Fl::get_font_name(fnum));
+    int style, weight;
+    const char* name = Fl::get_font_name2(fnum, &weight, &style);
+    pfd_array[fnum] = pango_font_description_from_string(name);
+    pango_font_description_set_weight(pfd_array[fnum], (PangoWeight)weight);
+    pango_font_description_set_style(pfd_array[fnum], (PangoStyle)style);
   }
   pango_font_description_set_absolute_size(pfd_array[fnum], size*PANGO_SCALE); // 1.8
   if (!pctxt_) context();
@@ -1368,28 +1401,16 @@ int Fl_Xlib_Graphics_Driver::descent_unscaled() {
   else return -1;
 }
 
-// FIXME: this (static) function should likely be in Fl_Graphics_Driver.
-// The code is the same as in src/drivers/Cairo/Fl_Cairo_Graphics_Driver.cxx
-
-static int font_name_process(const char *name, char &face) {
-  int l = strlen(name);
-  face = ' ';
-  if      (l >  8 && !memcmp(name + l -  8, " Regular", 8)) l -= 8;
-  else if (l >  6 && !memcmp(name + l -  6, " Plain", 6)) l -= 6;
-  else if (l > 12 && !memcmp(name + l - 12, " Bold Italic", 12)) {l -= 12; face = 'P';}
-  else if (l >  7 && !memcmp(name + l -  7, " Italic", 7)) {l -= 7; face = 'I';}
-  else if (l >  5 && !memcmp(name + l -  5, " Bold", 5)) {l -= 5; face = 'B';}
-  return l;
-}
-
 typedef int (*sort_f_type)(const void *aa, const void *bb);
 
-static int font_sort(Fl_Fontdesc *fa, Fl_Fontdesc *fb) {
-  char face_a, face_b;
-  int la = font_name_process(fa->name, face_a);
-  int lb = font_name_process(fb->name, face_b);
-  int c = strncasecmp(fa->name, fb->name, la >= lb ? lb : la);
-  return (c == 0 ? face_a - face_b : c);
+static int font_sort(const Fl_Fontdesc* fa, const Fl_Fontdesc* fb) {
+  int c = strcasecmp(fa->name, fb->name);
+  if (c != 0) return c;
+
+  if (fa->style != fb->style)
+    return fa->style - fb->style;
+
+  return fa->weight - fb->weight;
 }
 
 Fl_Font Fl_Xlib_Graphics_Driver::set_fonts(const char* pattern_name)
@@ -1459,7 +1480,7 @@ int Fl_Xlib_Graphics_Driver::get_font_sizes(Fl_Font fnum, int*& sizep) {
   return 1;
 }
 
-Fl_Xlib_Font_Descriptor::Fl_Xlib_Font_Descriptor(const char* name, Fl_Fontsize fsize, int fangle) : Fl_Font_Descriptor(name, fsize) {
+Fl_Xlib_Font_Descriptor::Fl_Xlib_Font_Descriptor(const char* name, Fl_Fontsize fsize, int fangle, int weight, int style, bool) : Fl_Font_Descriptor(name, fsize, weight, style) {
   fl_open_display();
   angle = fangle;
   height_ = 0;

--- a/src/drivers/Xlib/Fl_Xlib_Graphics_Driver_font_xft.cxx
+++ b/src/drivers/Xlib/Fl_Xlib_Graphics_Driver_font_xft.cxx
@@ -964,7 +964,7 @@ const char* Fl_Xlib_Graphics_Driver::get_font_name(Fl_Font fnum, int* ap) {
   return f->fontname;
 }
 
-const char* Fl_Xlib_Graphics_Driver::get_font_name2(Fl_Font fnum, int* weight, int* style) {
+const char* Fl_Xlib_Graphics_Driver::get_font_family(Fl_Font fnum, int* weight, int* style) {
   Fl_Fontdesc *f = fl_fonts + fnum;
   const char* p = f->name;
   if (!p || !*p) {
@@ -1212,7 +1212,7 @@ void Fl_Xlib_Graphics_Driver::font_unscaled(Fl_Font fnum, Fl_Fontsize size) {
   }
   if (!pfd_array[fnum]) {
     int style, weight;
-    const char* name = Fl::get_font_name2(fnum, &weight, &style);
+    const char* name = Fl::get_font_family(fnum, &weight, &style);
     pfd_array[fnum] = pango_font_description_from_string(name);
     pango_font_description_set_weight(pfd_array[fnum], (PangoWeight)weight);
     pango_font_description_set_style(pfd_array[fnum], (PangoStyle)style);

--- a/src/fl_set_font.cxx
+++ b/src/fl_set_font.cxx
@@ -62,8 +62,58 @@ void Fl::set_font(Fl_Font fnum, const char* name) {
       memset((char*)fl_fonts + i * width, 0, width);
     }
   }
-  d.font_name(fnum, name);
+
+  int weight = FL_WEIGHT_NORMAL;
+  int style = FL_STYLE_NORMAL;
+
+  #if USE_PANGO || defined(__APPLE__)
+    if (strstr(name, "Bold")) {
+      weight = FL_WEIGHT_BOLD;
+    }
+
+    if (strstr(name, "Italic")) {
+      style = FL_STYLE_ITALIC;
+    }
+  #else
+    switch (*name) {
+      case 'B':
+        weight = FL_WEIGHT_BOLD;
+        break;
+      case 'I':
+        style = FL_STYLE_ITALIC;
+        break;
+      case 'P':
+        weight = FL_WEIGHT_BOLD;
+        style = FL_STYLE_ITALIC;
+        break;
+    }
+  #endif
+  d.font_name(fnum, name, weight, style, true);
   d.font(-1, 0);
+}
+
+void Fl::set_font_by_family(Fl_Font fnum, const char* family, int weight, int style) {
+    Fl_Graphics_Driver &d = Fl_Graphics_Driver::default_driver();
+    unsigned width = d.font_desc_size();
+    if (!fl_fonts) fl_fonts = d.calc_fl_fonts();
+    while (fnum >= table_size) {
+      int i = table_size;
+      if (!i) {   // don't realloc the built-in table
+        table_size = 2*FL_FREE_FONT;
+        i = FL_FREE_FONT;
+        Fl_Fontdesc* t = (Fl_Fontdesc*)malloc(table_size*width);
+        memcpy(t, fl_fonts, FL_FREE_FONT*width);
+        fl_fonts = t;
+      } else {
+        table_size = 2*table_size;
+        fl_fonts=(Fl_Fontdesc*)realloc(fl_fonts, table_size*width);
+      }
+      for (; i < table_size; i++) {
+        memset((char*)fl_fonts + i * width, 0, width);
+      }
+    }
+    d.font_name(fnum, family, weight, style, false);
+    d.font(-1, 0);
 }
 
 /** Copies one face to another. */


### PR DESCRIPTION
Text of this PR was written by hand, then fed into Claude and asked to make it a little bit more concise, eliminate repeated points and make clearer.

## Changes

- New `Fl::set_font_by_family` and `Fl::get_font_name2` public functions.
- Driver internals now take explicit `weight` and `style` arguments instead of inferring them from the font name string.
- `Fl::set_font` now pre-parses weight and slant from the passed font name.
- Fixed a buffer overflow in `Fl_Cairo_Graphics_Driver::get_font_name` (`strcpy` changed to `strlcpy`).
- `get_font_name` no longer appends `bold`/`italic` to `f->fontname`. See rationale below.
- Code that blindly used `f->name + 1` (stripping the first character on platforms where FLTK font names carry an `I`/`B`/`P`/space prefix) now actually checks whether the first character is one of those before stripping. This may not cover all such call sites - flagging in case there are others.

## Found bug

`Fl_Xlib_Graphics_Driver::get_font_sizes` calls `XftListFonts` and unconditionally skips the first character of the font name, regardless of whether it's actually a prefix character. Compare with `fontopen`, which only strips `I`/`B`/`P`/space and leaves everything else alone. `get_font_sizes` looks wrong here, and this wrong behavior is present in the GDI driver, for example.

I fixed this bug by checking the first character against `B`/`I`/`P`/` ` first, but I may be wrong about it being a bug. Maybe it's somehow how it supposed to be.

## Testing

- **Linux (Pango / Xft / plain X11):** all three build and produce consistent `Fl::set_font` behavior.
- **macOS:** untested - no Mac, no Obj-C experience. `ct_weight_from_opentype` and `create_font` (replacing the `CTFontCreateWithName` calls) are AI-generated and need review from someone who knows CoreText.
- **Windows:** tested with mingw-w64 + wine. Builds and produces consistent `Fl::set_font` behavior.

Testing/troubleshooting help welcome, especially for macOS and Windows.

## Design rationale

**Naming:** `set_font_by_family` over `set_font_by_name` - the OS resolves a font using family + weight + slant, not a bare name, so `_by_family` is the accurate description.

**Not appending bold/italic in `get_font_name`:** the attributes are already returned via the optional integer out-param, so synthesizing them into the name string is redundant and, as noted in the existing source comments, unreliable - the font name may already contain "bold"/"italic" as part of its actual name. It's up to the user to indicate whether a certain font bold or italic, or anything else.

**`Fl_Fontdesc` shouldn't store the user-passed name:** currently it does, and `get_font_name` dynamically re-strips the prefix character from it on every call. I don't see what the stored raw name is for - the caller already knows what they passed in. What `Fl_Fontdesc` actually needs is the family (+ weight/slant) that the OS *resolved*, not the request string. Practically: the prefix-stripping and weight/slant parsing should happen once, in `Fl::set_font`/`Fl::set_font_by_family`, and the result stored directly as `int weight`/`int slant` fields on `Fl_Fontdesc` - not re-derived from a stashed string on every `get_font_name` call.

This ties into font-loading success propagation: right now fonts aren't actually loaded until used, so there's no trivial way to report load success/failure at `set_font` time. If `set_font`/`set_font_by_family` loaded the font immediately via the OS API, failure could be propagated to the caller, and `get_font_name` could return the actually-resolved family - which it currently can't do, since both `Fl::font_name` and `Fl::get_font_name` just echo back what the user passed in. I haven't attempted this in the current PR, this is possibly breaking.

`Fl::get_font` has the same issue conceptually - its docs imply the string differs per face, but two distinct `Fl_Font` indices (e.g. `FL_FREE_FONT` and `FL_FREE_FONT + 1`) can carry identical names, so the int index is the only reliable identity. `get_font_name`'s contract makes no consistency guarantee either way, so changing what it returns shouldn't break anything.

## Documentation gap

`Fl::set_font`'s docs don't cover the XLFD and comma handling when Xft is used: if XLFD name is passed and Xft is active, XLFD name actually gets parsed right. If commas are in the parsed font name and Xft is used, the name will be split by comma into multiple font names. This behavior is not true on any other backend, including X11+Pango.

## Future work / out of scope for this PR

- **Drop legacy XLFD handling and `Fl::set_fonts`** in the next major release. XLFD loading only fires when Xft/Pango are both disabled, or when Xft is enabled and an XLFD name is explicitly passed - fontconfig has been present on Linux for 20+ years, and `Fl::set_fonts`'s own docs already say it's not relevant anymore.
- Once immediate font loading lands, `Fl_Fontdesc.name` could be dropped entirely in favor of just the resolved family buffer.
- `Fl_Fontdesc.fontname` needs to be either changed to be bigger than 128 bytes, because in some cases it may not fit the font name if it's bigger, or the best way is to make this buffer dynamically-allocated, fitting the font name exactly.

## TL;DR

Adds `Fl::set_font_by_family`, moves weight/slant parsing into `Fl::set_font` instead of leaving it to be re-derived later, and fixes a buffer overflow + a prefix-stripping bug along the way. Bigger structural issue (fonts not loaded until use, so success can't be propagated) is flagged but not addressed here. It needs further discussion.
