### PR TITLE
Wayland Driver: keep track of decimal portion of past scroll events

### DIFF
--- a/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
+++ b/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
@@ -409,13 +409,13 @@ static void pointer_axis(void *data, struct wl_pointer *wl_pointer,
   int delta = (int) delta_whole;
   
   // add the fractional part to carryover
-  carryover = carryover + delta_fractional;
+  carryover +=  delta_fractional;
 
   // if carryover has reached |1|, add it to the total delta
-  delta += (int) (carryover / 1.0);
+  delta += (int) carryover;
 
   // keep any remaining fractional portion
-  carryover = std::fmod(carryover, (double) 1);
+  carryover -= (int) carryover;
 
   if (abs(delta) >= 10) delta /= 10;
   // fprintf(stderr, "FL_MOUSEWHEEL: %c delta=%d\n", axis==WL_POINTER_AXIS_HORIZONTAL_SCROLL?'H':'V', delta);

--- a/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
+++ b/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
@@ -393,7 +393,26 @@ static void pointer_axis(void *data, struct wl_pointer *wl_pointer,
   Fl_Window *win = Fl_Wayland_Window_Driver::surface_to_window(seat->pointer_focus);
   if (!win) return;
   wld_event_time = time;
+
+
+  // This variable will persist across function calls,
+  // keeping track of any scroll inputs that havent quite crossed the
+  // threshold to scroll by one unit
+  static int carryover = 0;
+
+  // the integer part of the value
   int delta = wl_fixed_to_int(value);
+
+
+  // add the decimal part to carryover
+  carryover +=  (!(value & 0x80000000)) ? (value & 0xFF) : -(value & 0xFF);
+
+  // if carryover has reached |1|, add it to the total delta
+  delta += carryover / 256;
+
+  // keep any remaining decimal region
+  carryover = carryover % 256;
+
   if (abs(delta) >= 10) delta /= 10;
   // fprintf(stderr, "FL_MOUSEWHEEL: %c delta=%d\n", axis==WL_POINTER_AXIS_HORIZONTAL_SCROLL?'H':'V', delta);
   // allow both horizontal and vertical movements to be processed by the widget

--- a/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
+++ b/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
@@ -398,20 +398,24 @@ static void pointer_axis(void *data, struct wl_pointer *wl_pointer,
   // This variable will persist across function calls,
   // keeping track of any scroll inputs that havent quite crossed the
   // threshold to scroll by one unit
-  static int carryover = 0;
+  static double carryover = 0;
 
-  // the integer part of the value
-  int delta = wl_fixed_to_int(value);
+  double delta_full = wl_fixed_to_double(value);
 
+  double delta_whole = 0;
+  double delta_fractional = std::modf(delta_full, &delta_whole);
 
-  // add the decimal part to carryover
-  carryover +=  (!(value & 0x80000000)) ? (value & 0xFF) : -(value & 0xFF);
+  // the whole part of the value
+  int delta = (int) delta_whole;
+  
+  // add the fractional part to carryover
+  carryover = carryover + delta_fractional;
 
   // if carryover has reached |1|, add it to the total delta
-  delta += carryover / 256;
+  delta += (int) (carryover / 1.0);
 
-  // keep any remaining decimal region
-  carryover = carryover % 256;
+  // keep any remaining fractional portion
+  carryover = std::fmod(carryover, (double) 1);
 
   if (abs(delta) >= 10) delta /= 10;
   // fprintf(stderr, "FL_MOUSEWHEEL: %c delta=%d\n", axis==WL_POINTER_AXIS_HORIZONTAL_SCROLL?'H':'V', delta);


### PR DESCRIPTION
I noticed that under certain Wayland compositors, touchpad scroll events are sent such that slow scrolling results in only fractional (i.e. 0.5) values being passed into fltk. The current Wayland driver simply chops off the decimal portion, meaning that slow scrolling with a touchpad is impossible. Naturally, this is very annoying to use and prevents precise scrolling in large text displays or list groups. 

To remedy this, I have the function pointer_axis keep a sum of the decimal portion of past scrolling values, and whenever the sum crosses beyond 1 in the positive or negative direction, it will add 1 unit in the proper direction to the delta. In this patch this is implemented with a static variable in the function, which I do not think is very clean code, but I wanted to ask the more experienced developers here where I should add that state to. A couple of minutes of browsing through the code leads me to think putting it in the wayland seat struct would make sense, but I do not have the familiarity with the codebase to be sure. 

Apologies if I have missed some important convention to contributing, I am not a big open source contributor but want to make sure other people can take advantage of my fix. The patch has been tested on Gentoo Linux running Hyprland.