### PR TITLE
Node: move out of loop strlen call

### DIFF
--- a/fluid/nodes/Node.cxx
+++ b/fluid/nodes/Node.cxx
@@ -1186,10 +1186,11 @@ void Node::copy_properties() {
   the parameter types match.
  */
 int Node::user_defined(const char* cbname) const {
+  size_t cbname_len = strlen(cbname);
   for (Node* p = Fluid.proj.tree.first; p ; p = p->next)
     if (dynamic_cast<Function_Node*>(p) && p->name() != nullptr)
-      if (strncmp(p->name(), cbname, strlen(cbname)) == 0)
-        if (p->name()[strlen(cbname)] == '(')
+      if (strncmp(p->name(), cbname, cbname_len) == 0)
+        if (p->name()[cbname_len] == '(')
           return 1;
   return 0;
 }


### PR DESCRIPTION
Fix common C/C++ compiler flaw is that it doesn't optimize strlen calls inside loops.

Reference: https://stackoverflow.com/questions/78827988/why-doesnt-the-compiler-optimize-strlen-calls-in-a-loop-despite-it-being-a-p