### PR TITLE
fltk: use default constructors and destructors for micro-op

### DIFF
--- a/FL/Fl_Grid.H
+++ b/FL/Fl_Grid.H
@@ -194,7 +194,7 @@ public:
       \todo Fl_Grid's cell destructor should remove the cell from the grid.
             Currently it does nothing!
     */
-    ~Cell() {}
+    ~Cell() = default;
 
     /**
       Returns the next widget cell of the same row of this cell.

--- a/fluid/app/shell_command.cxx
+++ b/fluid/app/shell_command.cxx
@@ -130,8 +130,7 @@ bool shell_command_running() {
 /**
  Create a process manager
  */
-Fl_Process::Fl_Process() {
-}
+Fl_Process::Fl_Process() = default;
 
 /**
  Destroy the project manager.
@@ -634,9 +633,7 @@ void Fd_Shell_Command::write(class fluid::io::Project_Writer *out) {
 /**
  Manage a list of shell commands and their parameters.
  */
-Fd_Shell_Command_List::Fd_Shell_Command_List()
-{
-}
+Fd_Shell_Command_List::Fd_Shell_Command_List() = default;
 
 /**
  Release all shell commands and destroy this class.

--- a/src/Fl_Grid.cxx
+++ b/src/Fl_Grid.cxx
@@ -39,7 +39,7 @@ class Fl_Grid::Col {
     weight_ = 50;
     gap_    = -1;
   }
-  ~Col() {}
+  ~Col() = default;
 };
 
 // private class Row for row management

--- a/src/Fl_Timeout.h
+++ b/src/Fl_Timeout.h
@@ -73,7 +73,7 @@ protected:
   }
 
   // destructor
-  ~Fl_Timeout() {}
+  ~Fl_Timeout() = default;
 
   // get a new timer entry from the pool or allocate a new one
   static Fl_Timeout *get(double time, Fl_Timeout_Handler cb, void *data);


### PR DESCRIPTION
References:
- https://stackoverflow.com/questions/59261490/why-is-there-performance-variation-using-default-constructor-instead-of
- https://stackoverflow.com/questions/56272431/how-can-a-compiler-generated-default-constructor-be-more-efficient-than-a-self-w