### PR TITLE
Fl_Table: make members as const for micro-op

### DIFF
--- a/FL/Fl_Table.H
+++ b/FL/Fl_Table.H
@@ -372,7 +372,7 @@ protected:
   /**
    Does the table contain any child fltk widgets?
   */
-  int is_fltk_container() {                     // does table contain fltk widgets?
+  int is_fltk_container() const {               // does table contain fltk widgets?
     return( Fl_Group::children() > 3 );         // (ie. more than box and 2 scrollbars?)
   }
 
@@ -435,7 +435,7 @@ public:
   /**
    Returns the current box type used for the data table.
   */
-  inline Fl_Boxtype table_box( void ) {
+  inline Fl_Boxtype table_box( void ) const {
     return(table->box());
   }
 
@@ -453,7 +453,7 @@ public:
   /**
    Get the number of columns in the table.
   */
-  inline int cols() {
+  inline int cols() const {
     return(_cols);
   }
 
@@ -485,7 +485,7 @@ public:
     - leftcol = 100
     - rightcol = 120
   */
-  inline void visible_cells(int& r1, int& r2, int& c1, int& c2) {
+  inline void visible_cells(int& r1, int& r2, int& c1, int& c2) const {
     r1 = toprow;
     r2 = botrow;
     c1 = leftcol;
@@ -496,14 +496,14 @@ public:
     Returns 1 if someone is interactively resizing a row or column.
     You can currently call this only from within your callback().
   */
-  int is_interactive_resize() {
+  int is_interactive_resize() const {
     return(_resizing_row != -1 || _resizing_col != -1);
   }
 
   /**
     Returns if row resizing by the user is allowed.
   */
-  inline int row_resize() {
+  inline int row_resize() const {
     return(_row_resize);
   }
 
@@ -520,7 +520,7 @@ public:
   /**
     Returns if column resizing by the user is allowed.
   */
-  inline int col_resize() {
+  inline int col_resize() const {
     return(_col_resize);
   }
 
@@ -537,7 +537,7 @@ public:
   /**
     Returns the current column minimum resize value.
   */
-  inline int col_resize_min() {                 // column minimum resizing width
+  inline int col_resize_min() const {           // column minimum resizing width
     return(_col_resize_min);
   }
 
@@ -553,7 +553,7 @@ public:
   /**
     Returns the current row minimum resize value.
   */
-  inline int row_resize_min() {                 // column minimum resizing width
+  inline int row_resize_min() const {          // column minimum resizing width
     return(_row_resize_min);
   }
 
@@ -569,7 +569,7 @@ public:
   /**
     Returns if row headers are enabled or not.
   */
-  inline int row_header() {                     // set/get row header enable flag
+  inline int row_header() const {               // set/get row header enable flag
     return(_row_header);
   }
 
@@ -586,7 +586,7 @@ public:
   /**
     Returns if column headers are enabled or not.
   */
-  inline int col_header() {                     // set/get col header enable flag
+  inline int col_header() const {               // set/get col header enable flag
     return(_col_header);
   }
 
@@ -612,7 +612,7 @@ public:
   /**
     Gets the column header height.
   */
-  inline int col_header_height() {
+  inline int col_header_height() const {
     return(_col_header_h);
   }
 
@@ -628,7 +628,7 @@ public:
   /**
     Returns the current row header width (in pixels).
   */
-  inline int row_header_width() {
+  inline int row_header_width() const {
     return(_row_header_w);
   }
 
@@ -643,7 +643,7 @@ public:
   /**
     Returns the current row header color.
   */
-  inline Fl_Color row_header_color() {
+  inline Fl_Color row_header_color() const {
     return(_row_header_color);
   }
 
@@ -658,7 +658,7 @@ public:
   /**
     Gets the color for column headers.
   */
-  inline Fl_Color col_header_color() {
+  inline Fl_Color col_header_color() const {
     return(_col_header_color);
   }
 
@@ -698,14 +698,14 @@ public:
   /**
     Returns the current row scroll position as a row number.
   */
-  int row_position() {
+  int row_position() const {
     return(_row_position);
   }
 
   /**
     Returns the current column scroll position as a column number.
   */
-  int col_position() {
+  int col_position() const {
     return(_col_position);
   }
 
@@ -722,7 +722,7 @@ public:
     Returns the current top row shown in the table.
     This row may be partially obscured.
   */
-  inline int top_row() {
+  inline int top_row() const {
     return(row_position());
   }
   int is_selected(int r, int c);                // selected cell
@@ -822,7 +822,7 @@ public:
     Returns a pointer to the array of children. <I>This pointer is only
     valid until the next time a child is added or removed.</I>
   */
-  Fl_Widget*const* array() {
+  Fl_Widget*const* array() const {
     return(table->array());
   }
 
@@ -873,7 +873,7 @@ public:
 
     This function should only be used from within the user's callback function.
   */
-  int callback_row() {
+  int callback_row() const {
     return(_callback_row);
   }
 
@@ -882,7 +882,7 @@ public:
 
     This function should only be used from within the user's callback function.
   */
-  int callback_col() {
+  int callback_col() const {
     return(_callback_col);
   }
 
@@ -891,7 +891,7 @@ public:
 
     This function should only be used from within the user's callback function.
   */
-  TableContext callback_context() {
+  TableContext callback_context() const {
     return(_callback_context);
   }
 


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/5827799/is-it-good-practice-to-add-const-at-end-of-member-functions-where-appropriate