### PR TITLE
Fl_Bitmap: make members as const for micro-op

### DIFF
--- a/FL/Fl_Bitmap.H
+++ b/FL/Fl_Bitmap.H
@@ -61,8 +61,8 @@ public:
   void label(Fl_Widget*w) override;
   void label(Fl_Menu_Item*m) override;
   void uncache() override;
-  int cache_w() {return cache_w_;}
-  int cache_h() {return cache_h_;}
+  int cache_w() const { return cache_w_;}
+  int cache_h() const { return cache_h_;}
 };
 
 #endif


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/5827799/is-it-good-practice-to-add-const-at-end-of-member-functions-where-appropriate