### PR TITLE
Fl_Color_Chooser: make members as const for micro-op

### DIFF
--- a/FL/Fl_Color_Chooser.H
+++ b/FL/Fl_Color_Chooser.H
@@ -133,7 +133,7 @@ public:
    Returns which Fl_Color_Chooser variant is currently active
    \return color modes are rgb(0), byte(1), hex(2), or hsv(3)
    */
-  int mode() {return choice.value();}
+  int mode() const { return choice.value();}
 
   /**
    Set which Fl_Color_Chooser variant is currently active


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/5827799/is-it-good-practice-to-add-const-at-end-of-member-functions-where-appropriate