### PR TITLE
Fl_File_Input: make members as const for micro-op

### DIFF
--- a/FL/Fl_File_Input.H
+++ b/FL/Fl_File_Input.H
@@ -96,7 +96,7 @@ public:
     Returns the current value, which is a pointer to an internal buffer
     and is valid only until the next event is handled.
   */
-  const char    *value() { return Fl_Input_::value(); }
+  const char    *value() const { return Fl_Input_::value(); }
 };
 
 #endif // !Fl_File_Input_H


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/5827799/is-it-good-practice-to-add-const-at-end-of-member-functions-where-appropriate