### PR TITLE
Fl_GIF_Image: GIF_FRAME make data pointer as const read-only

### DIFF
--- a/FL/Fl_GIF_Image.H
+++ b/FL/Fl_GIF_Image.H
@@ -66,8 +66,8 @@ protected:
     const struct CPAL {
       uchar r, g, b;
     } *cpal;
-    GIF_FRAME(int frame, uchar *data) : ifrm(frame), bptr(data) {}
-    GIF_FRAME(int frame, int W, int H, int fx, int fy, int fw, int fh, uchar *data) :
+    GIF_FRAME(int frame, const uchar *data) : ifrm(frame), bptr(data) {}
+    GIF_FRAME(int frame, int W, int H, int fx, int fy, int fw, int fh, const uchar *data) :
       ifrm(frame), width(W), height(H), x(fx), y(fy), w(fw), h(fh), bptr(data) {}
     void disposal(int mode, int time) { dispose = mode; this->delay = time; }
     void colors(int nclrs, int bg, int tp) { clrs = nclrs; bkgd = bg; trans = tp; }


### PR DESCRIPTION
Using const where the data should not change improve code readablity, make use safe API ABI and allows C/C++ compiler to minor optimize code better.

Reference:
- https://stackoverflow.com/questions/68526590/const-pointer-vs-pointer-c
- https://www.reddit.com/r/C_Programming/comments/ghoku0/what_are_the_benefits_to_use_const_pointers_or/