### PR TITLE
Fl_Group: make members as const for micro-op

### DIFF
--- a/FL/Fl_Group.H
+++ b/FL/Fl_Group.H
@@ -236,7 +236,7 @@ public:
 
     \see void Fl_Group::clip_children(int c)
   */
-  unsigned int clip_children() { return (flags() & CLIP_CHILDREN) != 0; }
+  unsigned int clip_children() const { return (flags() & CLIP_CHILDREN) != 0; }
 
   // Note: Doxygen docs in Fl_Widget.H to avoid redundancy.
   Fl_Group* as_group() override { return this; }


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/5827799/is-it-good-practice-to-add-const-at-end-of-member-functions-where-appropriate