### PR TITLE
Fl_Grid: make members as const for micro-op

### DIFF
--- a/FL/Fl_Grid.H
+++ b/FL/Fl_Grid.H
@@ -199,7 +199,7 @@ public:
     /**
       Returns the next widget cell of the same row of this cell.
     */
-    Cell *next() {
+    Cell *next() const {
       return next_;
     }
 


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/5827799/is-it-good-practice-to-add-const-at-end-of-member-functions-where-appropriate