### PR TITLE
Fl_Image_Surface: make members as const for micro-op

### DIFF
--- a/FL/Fl_Image_Surface.H
+++ b/FL/Fl_Image_Surface.H
@@ -124,7 +124,7 @@ protected:
   static Fl_Image_Surface_Driver *newImageSurfaceDriver(int w, int h, int high_res, Fl_Offscreen off);
 public:
   /** Returns pointer to the associated Fl_Image_Surface object */
-  Fl_Image_Surface *image_surface() { return image_surface_; }
+  Fl_Image_Surface *image_surface() const { return image_surface_; }
 };
 
 /**


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/5827799/is-it-good-practice-to-add-const-at-end-of-member-functions-where-appropriate