### PR TITLE
Fl_PDF_File_Surface: make members as const for micro-op

### DIFF
--- a/FL/Fl_PDF_File_Surface.H
+++ b/FL/Fl_PDF_File_Surface.H
@@ -81,7 +81,7 @@ public:
   int end_page(void) override {return platform_surface_->end_page();}
   void end_job(void) override {return platform_surface_->end_job();}
   /** Returns the name of the PDF document */
-  inline const char *pdf_filename() { return *out_filename_; }
+  inline const char *pdf_filename() const { return *out_filename_; }
   void set_current() override { if (platform_surface_) platform_surface_->set_current(); }
   bool is_current() override { return surface() == platform_surface_; }
 };


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/5827799/is-it-good-practice-to-add-const-at-end-of-member-functions-where-appropriate