### PR TITLE
Fl_Text_Display: make members as const for micro-op

### DIFF
--- a/FL/Fl_Text_Display.H
+++ b/FL/Fl_Text_Display.H
@@ -539,8 +539,8 @@ protected:
   void maintain_absolute_top_line_number(int state);
 public:
   int get_absolute_top_line_number() const;
-  int scroll_row() { return mTopLineNum; }
-  int scroll_col() { return mHorizOffset; }
+  int scroll_row() const { return mTopLineNum; }
+  int scroll_col() const { return mHorizOffset; }
 protected:
   void absolute_top_line_number(int oldFirstChar);
   int maintaining_absolute_top_line_number() const;


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/5827799/is-it-good-practice-to-add-const-at-end-of-member-functions-where-appropriate