### PR TITLE
Fl_Text_Editor: make members as const for micro-op

### DIFF
--- a/FL/Fl_Text_Editor.H
+++ b/FL/Fl_Text_Editor.H
@@ -62,7 +62,7 @@ class FL_EXPORT Fl_Text_Editor : public Fl_Text_Display {
         is inserted before the current cursor position. Otherwise, new
         text replaces text at the current cursor position.
     */
-    int insert_mode() { return insert_mode_; }
+    int insert_mode() const { return insert_mode_; }
     void tab_nav(int val);
     int tab_nav() const;
     void add_key_binding(int key, int state, Key_Func f, Key_Binding** list);


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/5827799/is-it-good-practice-to-add-const-at-end-of-member-functions-where-appropriate