### PR TITLE
Fl_Tile: make members as const for micro-op

### DIFF
--- a/FL/Fl_Tile.H
+++ b/FL/Fl_Tile.H
@@ -47,7 +47,7 @@ protected:
     \see Fl_Tile::set_cursor(int)
   */
 
-  Fl_Cursor cursor(int n) {
+  Fl_Cursor cursor(int n) const {
     return cursors_[n];
   }
 


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/5827799/is-it-good-practice-to-add-const-at-end-of-member-functions-where-appropriate