### PR TITLE
JPEG_Image: migrate lstat from heap to stack

### DIFF
--- a/src/Fl_JPEG_Image.cxx
+++ b/src/Fl_JPEG_Image.cxx
@@ -242,7 +242,7 @@ void Fl_JPEG_Image::load_jpg_(const char *filename, const char *sharename, const
   fl_jpeg_error_mgr       jerr;     // Error handler info
   JSAMPROW                row;      // Sample row pointer
 
-  struct load_stat *lstat = new load_stat();
+  struct load_stat lstat;
 
   // Clear data...
   alloc_array = 0;
@@ -250,15 +250,13 @@ void Fl_JPEG_Image::load_jpg_(const char *filename, const char *sharename, const
 
   // Open the image file if we read from the file system
   if (filename) {
-    if ((lstat->fp = fl_fopen(filename, "rb")) == NULL) {
+    if ((lstat.fp = fl_fopen(filename, "rb")) == NULL) {
       ld(ERR_FILE_ACCESS);
-      delete lstat;
       return;
     }
   } else {
     if (data==0L) {
       ld(ERR_FILE_ACCESS);
-      delete lstat;
       return;
     }
   }
@@ -278,9 +276,9 @@ void Fl_JPEG_Image::load_jpg_(const char *filename, const char *sharename, const
 
     // if any of the cleanup routines hits another error, we would end up
     // in a loop. So instead, we decrement max_err for some upper cleanup limit.
-    if ( ((lstat->max_finish_decompress_err)-- > 0) && array)
+    if ( ((lstat.max_finish_decompress_err)-- > 0) && array)
       jpeg_finish_decompress(&dinfo);
-    if ( (lstat->max_destroy_decompress_err)-- > 0)
+    if ( (lstat.max_destroy_decompress_err)-- > 0)
       jpeg_destroy_decompress(&dinfo);
 
     w(0);
@@ -294,13 +292,12 @@ void Fl_JPEG_Image::load_jpg_(const char *filename, const char *sharename, const
     }
 
     ld(ERR_FORMAT);
-    delete lstat;
     return;
   }
 
   jpeg_create_decompress(&dinfo);
-  if (lstat->fp) {
-    jpeg_stdio_src(&dinfo, lstat->fp);
+  if (lstat.fp) {
+    jpeg_stdio_src(&dinfo, lstat.fp);
   } else {
     if (data_length==-1)
       jpeg_unprotected_mem_src(&dinfo, data);
@@ -335,8 +332,6 @@ void Fl_JPEG_Image::load_jpg_(const char *filename, const char *sharename, const
 
   jpeg_finish_decompress(&dinfo);
   jpeg_destroy_decompress(&dinfo);
-
-  delete lstat;
 
   if (sharename && w() && h()) {
     Fl_Shared_Image *si = new Fl_Shared_Image(sharename, this);


### PR DESCRIPTION
@MatthiasWM 

In the old code, the programmer had to manually call delete lstat in every place where the function could terminate ahead of time (for example, if there was an error opening the ERR_FILE_ACCESS file or an error in the ERR_FORMAT format). If at least one delete was skipped (or the code did not reach it), a memory leak occurred.

Removing all delete lstat calls has made the function cleaner and more reliable. Now the logic of exiting the function (via return) has become safe, since the stack is cleared automatically by C/C++ compiler.

Allocating memory on the stack is significantly faster than allocating memory on the heap via new, as it boils down to simply changing the CPU stack pointer rather than searching for a free block on the heap.

Reference with benchmarks:
- https://stackoverflow.com/questions/24057331/is-accessing-data-in-the-heap-faster-than-from-the-stack