### PR TITLE
Window_Driver: migrate rgba from heap to stack

### DIFF
--- a/src/Fl_Window_Driver.cxx
+++ b/src/Fl_Window_Driver.cxx
@@ -115,9 +115,8 @@ void Fl_Window_Driver::destroy_double_buffer() {
 }
 
 void Fl_Window_Driver::shape_pixmap_(Fl_Image* pixmap) {
-  Fl_RGB_Image* rgba = new Fl_RGB_Image((Fl_Pixmap*)pixmap);
-  shape_alpha_(rgba, 3);
-  delete rgba;
+  Fl_RGB_Image rgba((Fl_Pixmap*)pixmap);
+  shape_alpha_(&rgba, 3);
 }
 
 void Fl_Window_Driver::capture_titlebar_and_borders(Fl_RGB_Image*& top, Fl_RGB_Image*& left, Fl_RGB_Image*& bottom, Fl_RGB_Image*& right) {


### PR DESCRIPTION
Parent PR for more info:
https://github.com/fltk/fltk/pull/1527

Reference with benchmarks:

- https://stackoverflow.com/questions/24057331/is-accessing-data-in-the-heap-faster-than-from-the-stack