### PR TITLE
all: remove excess check before free and delete

### DIFF
--- a/FL/Fl_Tree_Prefs.H
+++ b/FL/Fl_Tree_Prefs.H
@@ -320,7 +320,7 @@ public:
   inline void usericon(Fl_Image *val) {
     _userimage = val;
     // Update deactivated version of icon..
-    if ( _userdeimage ) delete _userdeimage;
+    delete _userdeimage;
     if ( _userimage ) {
       _userdeimage = _userimage->copy();
       _userdeimage->inactive();

--- a/fluid/Fluid.cxx
+++ b/fluid/Fluid.cxx
@@ -290,10 +290,8 @@ void Application::quit() {
     save_position(shell_run_window,"shell_run_Window_pos");
   }
 
-  if (about_panel)
-    delete about_panel;
-  if (help_dialog)
-    delete help_dialog;
+  delete about_panel;
+  delete help_dialog;
 
   if (g_shell_config)
     g_shell_config->write(preferences, fluid::Tool_Store::USER);

--- a/fluid/app/Snap_Action.cxx
+++ b/fluid/app/Snap_Action.cxx
@@ -405,8 +405,7 @@ void Layout_Suite::update_label() {
     case fluid::Tool_Store::FILE: sym.assign("@fd_file  "); break;
   }
   sym.append(name_);
-  if (menu_label)
-    ::free(menu_label);
+  ::free(menu_label);
   menu_label = fl_strdup(sym.c_str());
   Fluid.layout_list.update_menu_labels();
 }
@@ -416,8 +415,7 @@ void Layout_Suite::update_label() {
  Also updates the FLUID user interface.
  */
 void Layout_Suite::name(const char *n) {
-  if (name_)
-    ::free(name_);
+  ::free(name_);
   if (n)
     name_ = fl_strdup(n);
   else
@@ -440,7 +438,7 @@ void Layout_Suite::init() {
  */
 Layout_Suite::~Layout_Suite() {
   if (storage_ == fluid::Tool_Store::INTERNAL) return;
-  if (name_) ::free(name_);
+  ::free(name_);
   for (int i = 0; i < 3; ++i) {
     delete layout[i];
   }

--- a/fluid/io/Project_Reader.cxx
+++ b/fluid/io/Project_Reader.cxx
@@ -109,8 +109,7 @@ Project_Reader::Project_Reader(Project &proj)
 Project_Reader::~Project_Reader()
 {
   // fname is not copied, so do not free it
-  if (buffer)
-    ::free(buffer);
+  ::free(buffer);
 }
 
 /**

--- a/fluid/nodes/Function_Node.cxx
+++ b/fluid/nodes/Function_Node.cxx
@@ -1134,7 +1134,7 @@ void Data_Node::write_code1(fluid::io::Code_Writer& f) {
   if (message && !f.write_codeview) {
     fluid_alert("%s\n%s\n", message, fn.c_str());
   }
-  if (data) free(data);
+  free(data);
 }
 
 

--- a/fluid/nodes/Grid_Node.cxx
+++ b/fluid/nodes/Grid_Node.cxx
@@ -61,7 +61,7 @@ Fl_Grid_Proxy::~Fl_Grid_Proxy() {
   int i;
   if (transient_) {
     for (i=0; i<num_transient_; i++) {
-      if (transient_[i].cell) ::free(transient_[i].cell);
+      ::free(transient_[i].cell);
     }
     ::free(transient_);
   }

--- a/nanosvg/nanosvg.h
+++ b/nanosvg/nanosvg.h
@@ -646,7 +646,7 @@ static NSVGparser* nsvg__createParser(void)
 
 error:
 	if (p) {
-		if (p->image) free(p->image);
+		free(p->image);
 		free(p);
 	}
 	return NULL;
@@ -656,8 +656,7 @@ static void nsvg__deletePaths(NSVGpath* path)
 {
 	while (path) {
 		NSVGpath *next = path->next;
-		if (path->pts != NULL)
-			free(path->pts);
+		free(path->pts);
 		free(path);
 		path = next;
 	}
@@ -1023,7 +1022,7 @@ static void nsvg__addShape(NSVGparser* p)
 	return;
 
 error:
-	if (shape) free(shape);
+	free(shape);
 }
 
 static void nsvg__addPath(NSVGparser* p, char closed)
@@ -1081,7 +1080,7 @@ static void nsvg__addPath(NSVGparser* p, char closed)
 
 error:
 	if (path != NULL) {
-		if (path->pts != NULL) free(path->pts);
+		free(path->pts);
 		free(path);
 	}
 }
@@ -3050,8 +3049,8 @@ NSVGimage* nsvgParseFromFile(const char* filename, const char* units, float dpi)
 
 error:
 	if (fp) fclose(fp);
-	if (data) free(data);
-	if (image) nsvgDelete(image);
+	free(data);
+	nsvgDelete(image);
 	return NULL;
 }
 

--- a/nanosvg/nanosvgrast.h
+++ b/nanosvg/nanosvgrast.h
@@ -194,10 +194,10 @@ void nsvgDeleteRasterizer(NSVGrasterizer* r)
 		p = next;
 	}
 
-	if (r->edges) free(r->edges);
-	if (r->points) free(r->points);
-	if (r->points2) free(r->points2);
-	if (r->scanline) free(r->scanline);
+	free(r->edges);
+	free(r->points);
+	free(r->points2);
+	free(r->scanline);
 
 	free(r);
 }

--- a/src/Fl_Anim_GIF_Image.cxx
+++ b/src/Fl_Anim_GIF_Image.cxx
@@ -1043,9 +1043,7 @@ bool Fl_Anim_GIF_Image::load(const char *name, const unsigned char *imgdata /* =
   DEBUG(("\nFl_Anim_GIF_Image::load '%s'\n", name));
   clear_frames();
   if (name_ != name) {
-    if (name_) {
-      ::free(name_);
-    }
+    ::free(name_);
     if (name) {
       name_ = fl_strdup(name);
     } else {

--- a/src/Fl_Flex.cxx
+++ b/src/Fl_Flex.cxx
@@ -130,8 +130,7 @@ void Fl_Flex::init(int t) {
 }
 
 Fl_Flex::~Fl_Flex() {
-  if (fixed_size_)
-    free(fixed_size_);
+  free(fixed_size_);
 }
 
 /*

--- a/src/Fl_GIF_Image.cxx
+++ b/src/Fl_GIF_Image.cxx
@@ -90,8 +90,7 @@ struct ColorMap {
 */
 static int gif_error(Fl_Image_Reader &rdr, int line, uchar *Image) {
   if (rdr.error()) {
-    if (Image)
-      delete[] Image; // delete temporary image array
+    delete[] Image; // delete temporary image array
 
     Fl::error("[%d] Fl_GIF_Image: %s - unexpected EOF or read error at offset %ld",
               line, rdr.name(), rdr.tell());

--- a/src/Fl_Graphics_Driver.cxx
+++ b/src/Fl_Graphics_Driver.cxx
@@ -63,7 +63,7 @@ Fl_Graphics_Driver::Fl_Graphics_Driver()
 
 /** Destructor */
 Fl_Graphics_Driver::~Fl_Graphics_Driver() {
-  if (xpoint) free(xpoint);
+  free(xpoint);
 }
 
 

--- a/src/Fl_ICO_Image.cxx
+++ b/src/Fl_ICO_Image.cxx
@@ -168,7 +168,7 @@ void Fl_ICO_Image::load_ico_(Fl_Image_Reader &rdr, int id)
     if (loaded < 0) {
       w(0); h(0); d(0);
       ld(loaded);
-      if (png) delete png;
+      delete png;
       return;
     }
 

--- a/src/Fl_Image_Reader.cxx
+++ b/src/Fl_Image_Reader.cxx
@@ -84,8 +84,7 @@ Fl_Image_Reader::~Fl_Image_Reader() {
   if (is_file_ && file_) {
     fclose(file_);
   }
-  if (name_)
-    free(name_);
+  free(name_);
 }
 
 // Read a single byte from memory or a file

--- a/src/Fl_Input_.cxx
+++ b/src/Fl_Input_.cxx
@@ -45,8 +45,7 @@ public:
   undoyankcut(0)
   { }
   ~Fl_Input_Undo_Action() {
-    if (undobuffer)
-      ::free(undobuffer);
+    ::free(undobuffer);
   }
 
   char *undobuffer;

--- a/src/Fl_Native_File_Chooser.cxx
+++ b/src/Fl_Native_File_Chooser.cxx
@@ -286,7 +286,7 @@ char *Fl_Native_File_Chooser_Driver::strnew(const char *val) {
 //    Value can be NULL
 //
 char *Fl_Native_File_Chooser_Driver::strfree(char *val) {
-  if ( val ) delete [] val;
+  delete [] val;
   return(NULL);
 }
 

--- a/src/Fl_Native_File_Chooser_GTK.cxx
+++ b/src/Fl_Native_File_Chooser_GTK.cxx
@@ -493,7 +493,7 @@ static char *extract_dir_from_path(const char *path)
     return (char*)path;
   }
   if (*path != '/') return NULL;
-  if (dir) free(dir);
+  free(dir);
   dir = fl_strdup(path);
   do {
     char *p = strrchr(dir, '/');

--- a/src/Fl_Native_File_Chooser_Kdialog.cxx
+++ b/src/Fl_Native_File_Chooser_Kdialog.cxx
@@ -49,9 +49,9 @@ Fl_Kdialog_Native_File_Chooser_Driver::Fl_Kdialog_Native_File_Chooser_Driver(int
 Fl_Kdialog_Native_File_Chooser_Driver::~Fl_Kdialog_Native_File_Chooser_Driver() {
   for (int i = 0; i < _tpathnames; i++) delete[] _pathnames[i];
   delete[] _pathnames;
-  if (_preset_file) free(_preset_file);
-  if (_directory) free(_directory);
-  if (_title) free(_title);
+  free(_preset_file);
+  free(_directory);
+  free(_title);
 }
 
 
@@ -280,7 +280,7 @@ void Fl_Kdialog_Native_File_Chooser_Driver::filter(const char *f) {
 }
 
 void Fl_Kdialog_Native_File_Chooser_Driver::preset_file(const char *val) {
-  if (_preset_file) free(_preset_file);
+  free(_preset_file);
   _preset_file = strdup(val);
 }
 
@@ -289,7 +289,7 @@ const char *Fl_Kdialog_Native_File_Chooser_Driver::preset_file() const {
 }
 
 void Fl_Kdialog_Native_File_Chooser_Driver::directory(const char *val) {
-  if (_directory) free(_directory);
+  free(_directory);
   _directory = strdup(val);
 }
 
@@ -299,7 +299,7 @@ const char *Fl_Kdialog_Native_File_Chooser_Driver::directory() const {
 
 void Fl_Kdialog_Native_File_Chooser_Driver::title(const char *val)
 {
-  if (_title) free(_title);
+  free(_title);
   _title = strdup(val);
 }
 

--- a/src/Fl_Preferences.cxx
+++ b/src/Fl_Preferences.cxx
@@ -1695,8 +1695,7 @@ void Fl_Preferences::Node::set( const char *name, const char *value )
     if ( strcmp( name, entry_[i].name ) == 0 ) {
       if ( !value ) return; // annotation
       if ( strcmp( value, entry_[i].value ) != 0 ) {
-        if ( entry_[i].value )
-          free( entry_[i].value );
+        free( entry_[i].value );
         entry_[i].value = fl_strdup( value );
         dirty_ = 1;
       }
@@ -1934,8 +1933,7 @@ void Fl_Preferences::Node::updateIndex() {
 }
 
 void Fl_Preferences::Node::deleteIndex() {
-  if (index_)
-    ::free(index_);
+  ::free(index_);
   index_ = NULL;
   NIndex_ = nIndex_ = 0;
   indexed_ = 0;

--- a/src/Fl_Sys_Menu_Bar.cxx
+++ b/src/Fl_Sys_Menu_Bar.cxx
@@ -31,7 +31,7 @@ Fl_Sys_Menu_Bar::Fl_Sys_Menu_Bar(int x,int y,int w,int h,const char *l)
 : Fl_Menu_Bar(x,y,w,h,l)
 {
   if (driver()) {
-    if (fl_sys_menu_bar) delete fl_sys_menu_bar;
+    delete fl_sys_menu_bar;
     fl_sys_menu_bar = this;
     driver()->bar = this;
     // Remove macOS menubar from its parent Fl_Group so it's activated

--- a/src/Fl_Terminal.cxx
+++ b/src/Fl_Terminal.cxx
@@ -752,7 +752,7 @@ void Fl_Terminal::RingBuffer::new_copy(int drows, int dcols, int hrows, const Ch
     --dst_row;
   }
   // Install new buffer: dump old, install new, adjust internals
-  if (ring_chars_) delete[] ring_chars_;
+  delete[] ring_chars_;
   ring_chars_ = new_ring_chars;
   ring_rows_  = new_ring_rows;
   ring_cols_  = dcols;
@@ -765,7 +765,7 @@ void Fl_Terminal::RingBuffer::new_copy(int drows, int dcols, int hrows, const Ch
 
 // Clear the class, delete previous ring if any
 void Fl_Terminal::RingBuffer::clear(void) {
-  if (ring_chars_) delete[] ring_chars_; // dump our ring
+  delete[] ring_chars_; // dump our ring
   ring_chars_ = 0;
   ring_rows_  = 0;
   ring_cols_  = 0;
@@ -798,7 +798,7 @@ Fl_Terminal::RingBuffer::RingBuffer(int drows, int dcols, int hrows) {
 
 // Dtor
 Fl_Terminal::RingBuffer::~RingBuffer(void) {
-  if (ring_chars_) delete[] ring_chars_;
+  delete[] ring_chars_;
   ring_chars_ = NULL;
 }
 

--- a/src/Fl_Text_Buffer.cxx
+++ b/src/Fl_Text_Buffer.cxx
@@ -94,8 +94,7 @@ public:
     undoyankcut(0)
   { }
   ~Fl_Text_Undo_Action() {
-    if (undobuffer)
-      ::free(undobuffer);
+    ::free(undobuffer);
   }
 
   char *undobuffer;

--- a/src/Fl_Text_Display.cxx
+++ b/src/Fl_Text_Display.cxx
@@ -220,7 +220,7 @@ Fl_Text_Display::~Fl_Text_Display() {
     mBuffer->remove_modify_callback(buffer_modified_cb, this);
     mBuffer->remove_predelete_callback(buffer_predelete_cb, this);
   }
-  if (mLineStarts) delete[] mLineStarts;
+  delete[] mLineStarts;
   if (linenumber_format_) {
     free((void*)linenumber_format_);
     linenumber_format_ = 0;
@@ -592,7 +592,7 @@ void Fl_Text_Display::recalc_display() {
     if (nvlines < 1) nvlines = 1;
     if (mNVisibleLines != nvlines) {
       mNVisibleLines = nvlines;
-      if (mLineStarts) delete[] mLineStarts;
+      delete[] mLineStarts;
       mLineStarts = new int [mNVisibleLines];
     }
 
@@ -1078,8 +1078,7 @@ void Fl_Text_Display::overstrike(const char* text) {
   mCursorToHint = startPos + textLen;
   buf->replace( startPos, endPos, paddedText == NULL ? text : paddedText );
   mCursorToHint = NO_HINT;
-  if ( paddedText != NULL )
-    delete [] paddedText;
+  delete [] paddedText;
 }
 
 

--- a/src/Fl_Tile.cxx
+++ b/src/Fl_Tile.cxx
@@ -934,6 +934,5 @@ Fl_Tile::Fl_Tile(int X,int Y,int W,int H,const char*L)
  Destructor.
  */
 Fl_Tile::~Fl_Tile() {
-  if (size_range_)
-    ::free(size_range_);
+  ::free(size_range_);
 }

--- a/src/Fl_Tooltip.cxx
+++ b/src/Fl_Tooltip.cxx
@@ -180,8 +180,7 @@ int Fl_Tooltip::override_text(const char *new_text) {
   if (new_text != override_text_) {
     if (window && window->label()==override_text_)
       ((Fl_Widget *) window)->label(nullptr);
-    if (override_text_)
-      ::free(override_text_);
+    ::free(override_text_);
     override_text_ = nullptr;
     if (new_text)
       override_text_ = fl_strdup(new_text);

--- a/src/Fl_Tree.cxx
+++ b/src/Fl_Tree.cxx
@@ -53,7 +53,7 @@ static char **parse_path(const char *path) {
 // INTERNAL: Free an array 'arr' returned by parse_path()
 static void free_path(char **arr) {
   if ( arr ) {
-    if ( arr[0] ) { delete[] arr[0]; }  // deletes cp in parse_path
+    delete[] arr[0];                    // deletes cp in parse_path
     delete[] arr;                       // deletes ptr array
   }
 }

--- a/src/Fl_Tree_Prefs.cxx
+++ b/src/Fl_Tree_Prefs.cxx
@@ -63,7 +63,7 @@ int Fl_System_Driver::tree_connector_style() {
 void Fl_Tree_Prefs::openicon(Fl_Image *val) {
   _openimage = val ? val : 0;
   // Update deactivated version of icon..
-  if ( _opendeimage ) delete _opendeimage;
+  delete _opendeimage;
   if ( _openimage ) {
     _opendeimage = _openimage->copy();
     _opendeimage->inactive();
@@ -80,7 +80,7 @@ void Fl_Tree_Prefs::openicon(Fl_Image *val) {
 void Fl_Tree_Prefs::closeicon(Fl_Image *val) {
   _closeimage = val ? val : 0;
   // Update deactivated version of icon..
-  if ( _closedeimage ) delete _closedeimage;
+  delete _closedeimage;
   if ( _closeimage ) {
     _closedeimage = _closeimage->copy();
     _closedeimage->inactive();
@@ -125,7 +125,7 @@ Fl_Tree_Prefs::Fl_Tree_Prefs() {
 
 /// Fl_Tree_Prefs destructor
 Fl_Tree_Prefs::~Fl_Tree_Prefs() {
-  if ( _opendeimage )  delete _opendeimage;
-  if ( _closedeimage ) delete _closedeimage;
-  if ( _userdeimage )  delete _userdeimage;
+  delete _opendeimage;
+  delete _closedeimage;
+  delete _userdeimage;
 }

--- a/src/Fl_Window.cxx
+++ b/src/Fl_Window.cxx
@@ -88,9 +88,7 @@ Fl_Group((Fl_Group::current(0),0), 0, W, H, l)
 
 Fl_Window::~Fl_Window() {
   hide();
-  if (xclass_) {
-    free(xclass_);
-  }
+  free(xclass_);
   free_icons();
   delete pWindowDriver;
 }

--- a/src/drivers/OpenGL/Fl_OpenGL_Graphics_Driver_image.cxx
+++ b/src/drivers/OpenGL/Fl_OpenGL_Graphics_Driver_image.cxx
@@ -96,7 +96,7 @@ static GLuint compute_texture_rectangle(Fl_RGB_Image *rgb)
   // restore saved GL parameters
   glPixelStorei(GL_UNPACK_ROW_LENGTH, row_length);
   glPixelStorei(GL_UNPACK_ALIGNMENT, alignment);
-  if (temp_rgb4) delete temp_rgb4;
+  delete temp_rgb4;
   return texName;
 }
 

--- a/src/drivers/PostScript/Fl_PostScript.cxx
+++ b/src/drivers/PostScript/Fl_PostScript.cxx
@@ -100,7 +100,7 @@ int Fl_PostScript_File_Device::begin_job(int pagecount, int* from, int* to, char
 
 Fl_PostScript_File_Device::~Fl_PostScript_File_Device() {
   Fl_PostScript_Graphics_Driver *ps = driver();
-  if (ps) delete ps;
+  delete ps;
 }
 
 void Fl_PostScript_File_Device::set_current() {
@@ -163,7 +163,7 @@ Fl_PostScript_Graphics_Driver::Fl_PostScript_Graphics_Driver(void)
 
 /** \brief The destructor. */
 Fl_PostScript_Graphics_Driver::~Fl_PostScript_Graphics_Driver() {
-  if(ps_filename_) free(ps_filename_);
+  free(ps_filename_);
 }
 
 
@@ -1594,7 +1594,7 @@ class Fl_PDF_Pango_File_Surface : public Fl_PostScript_File_Device
 public:
   char *doc_fname;
   Fl_PDF_Pango_File_Surface();
-  ~Fl_PDF_Pango_File_Surface() { if (doc_fname) free(doc_fname); }
+  ~Fl_PDF_Pango_File_Surface() { free(doc_fname); }
   int begin_job(const char *defaultname,
                 char **perr_message = NULL);
   int begin_job(int, int*, int *, char **) FL_OVERRIDE {return 1;} // don't use

--- a/src/drivers/SVG/Fl_SVG_File_Surface.cxx
+++ b/src/drivers/SVG/Fl_SVG_File_Surface.cxx
@@ -145,14 +145,14 @@ Fl_SVG_Graphics_Driver::Fl_SVG_Graphics_Driver(FILE *f) {
 
 Fl_SVG_Graphics_Driver::~Fl_SVG_Graphics_Driver()
 {
-  if (user_dash_array_) free(user_dash_array_);
-  if (dasharray_) free(dasharray_);
+  free(user_dash_array_);
+  free(dasharray_);
   while (clip_){
     Clip * c= clip_;
     clip_= clip_->prev;
     delete c;
   }
-  if (last_rgb_name_) free(last_rgb_name_);
+  free(last_rgb_name_);
 }
 
 
@@ -229,7 +229,7 @@ Fl_Font Fl_SVG_Graphics_Driver::font() { return Fl_Graphics_Driver::font(); }
 void Fl_SVG_Graphics_Driver::compute_dasharray(float s, char *dashes) {
   if (user_dash_array_ && user_dash_array_ != dashes) {free(user_dash_array_); user_dash_array_ = NULL;}
   if (dashes && *dashes) {
-    if (dasharray_) free(dasharray_);
+    free(dasharray_);
     int array_len = int(10*strlen(dashes) + 1);
     dasharray_ = (char*)calloc(array_len, 1);
     for (char *p = dashes; *p; p++) {
@@ -252,7 +252,7 @@ void Fl_SVG_Graphics_Driver::compute_dasharray(float s, char *dashes) {
     float dot = (is_flat ? width_/s : width_*0.6f/s);
     float gap = (is_flat ? width_/s : width_*1.5f/s);
     float big = (is_flat ? 3*width_/s : width_*2.5f/s);
-    if (dasharray_) free(dasharray_);
+    free(dasharray_);
     dasharray_ = (char*)malloc(61);
     if (dash_part == FL_DOT) snprintf(dasharray_, 61, "%.3f,%.3f", dot, gap);
     else if (dash_part == FL_DASH) snprintf(dasharray_, 61, "%.3f,%.3f", big, gap);
@@ -493,7 +493,7 @@ void Fl_SVG_Graphics_Driver::define_rgb_png(Fl_RGB_Image *rgb, const char *name,
     return;
   }
   if (name) {
-    if (last_rgb_name_) free(last_rgb_name_);
+    free(last_rgb_name_);
     last_rgb_name_ = fl_strdup(name);
   }
   float f = rgb->data_w() > rgb->data_h() ? float(rgb->w()) / rgb->data_w(): float(rgb->h()) / rgb->data_h();
@@ -582,7 +582,7 @@ static void term_destination(jpeg_compress_struct *cinfo) {
 
 void Fl_SVG_Graphics_Driver::define_rgb_jpeg(Fl_RGB_Image *rgb, const char *name, int x, int y) {
   if (name) {
-    if (last_rgb_name_) free(last_rgb_name_);
+    free(last_rgb_name_);
     last_rgb_name_ = fl_strdup(name);
   }
   float f = rgb->data_w() > rgb->data_h() ? float(rgb->w()) / rgb->data_w(): float(rgb->h()) / rgb->data_h();

--- a/src/drivers/X11/Fl_X11_Screen_Driver.cxx
+++ b/src/drivers/X11/Fl_X11_Screen_Driver.cxx
@@ -737,7 +737,7 @@ Fl_RGB_Image *Fl_X11_Screen_Driver::read_win_rectangle(int X, int Y, int w, int 
       image = XCreateImage(fl_display, fl_visual->visual,
                            fl_visual->depth, ZPixmap, 0, buf, ws, hs, bpp, 0);
       if (!image) {
-        if (buf) free(buf);
+        free(buf);
         return 0;
       }
 

--- a/src/drivers/X11/Fl_X11_Window_Driver.cxx
+++ b/src/drivers/X11/Fl_X11_Window_Driver.cxx
@@ -257,7 +257,7 @@ void Fl_X11_Window_Driver::shape_alpha_(Fl_Image* img, int offset) {
 
 void Fl_X11_Window_Driver::shape(const Fl_Image* img) {
   if (shape_data_) {
-    if (shape_data_->effective_bitmap_) { delete shape_data_->effective_bitmap_; }
+    delete shape_data_->effective_bitmap_;
   }
   else {
     shape_data_ = new shape_data_type;

--- a/src/filename_list.cxx
+++ b/src/filename_list.cxx
@@ -84,8 +84,7 @@ void fl_filename_free_list(struct dirent ***list, int n)
 
   int i;
   for (i = 0; i < n; i ++) {
-    if ((*list)[i])
-      free((*list)[i]);
+    free((*list)[i]);
   }
   free(*list);
   *list = 0;

--- a/src/fl_encoding_mac_roman.cxx
+++ b/src/fl_encoding_mac_roman.cxx
@@ -66,7 +66,7 @@ const char *Fl_System_Driver::local_to_mac_roman(const char *t, int n)
   if (n==-1) n = (int) strlen(t);
   if (n<=n_buf) {
     n_buf = (n + 257) & 0x7fffff00;
-    if (buf) free(buf);
+    free(buf);
     buf = (char*)malloc(n_buf);
   }
   const uchar *src = (const uchar*)t;
@@ -87,7 +87,7 @@ const char *Fl_System_Driver::mac_roman_to_local(const char *t, int n)
   if (n==-1) n = (int) strlen(t);
   if (n<=n_buf) {
     n_buf = (n + 257) & 0x7fffff00;
-    if (buf) free(buf);
+    free(buf);
     buf = (char*)malloc(n_buf);
   }
   const uchar *src = (const uchar*)t;

--- a/src/fl_write_jpeg.cxx
+++ b/src/fl_write_jpeg.cxx
@@ -185,8 +185,7 @@ int fl_write_jpeg(const char *filename, const char *pixels, int w, int h, int d,
   jpeg_finish_compress(&cinfo);
   jpeg_destroy_compress(&cinfo);
 
-  if (row_buf)
-    free(row_buf);
+  free(row_buf);
 
   fclose(fp);
   return 0;

--- a/src/freeglut_geometry.cxx
+++ b/src/freeglut_geometry.cxx
@@ -139,8 +139,8 @@ static void fghCircleTable(double **sint,double **cost,const int n)
 
     if (!(*sint) || !(*cost))
     {
-      if (*sint) free(*sint);
-      if (*cost) free(*cost);
+      free(*sint);
+      free(*cost);
       return;
     }
 

--- a/src/gl_draw.cxx
+++ b/src/gl_draw.cxx
@@ -307,7 +307,7 @@ gl_texture_fifo::gl_texture_fifo(int max)
 gl_texture_fifo::~gl_texture_fifo()
 {
   for (int i = 0; i < size_; i++) {
-    if (fifo[i].utf8) free(fifo[i].utf8);
+    free(fifo[i].utf8);
     if (textures_generated) glDeleteTextures(1, &fifo[i].texName);
   }
   free(fifo);
@@ -415,7 +415,7 @@ int gl_texture_fifo::compute_texture(const char* str, int n)
 {
   current = (current + 1) % size_;
   if (current > last) last = current;
-  if ( fifo[current].utf8 ) free(fifo[current].utf8);
+  free(fifo[current].utf8);
   fifo[current].utf8 = (char *)malloc(n + 1);
   memcpy(fifo[current].utf8, str, n);
   fifo[current].utf8[n] = 0;
@@ -491,7 +491,7 @@ void gl_texture_reset()
 */
 void gl_texture_pile_height(int max)
 {
-  if (gl_fifo) delete gl_fifo;
+  delete gl_fifo;
   gl_fifo = new gl_texture_fifo(max);
 }
 


### PR DESCRIPTION
@MatthiasWM double code review my PR changes that I've cleaned up unnecessary if checks everywhere.

More info: https://stackoverflow.com/questions/13818803/check-for-null-before-delete-in-c-good-practice

In C this became possible after C89 standard, code is cleaner and this will make it much easier to read the code in future.

In C++ same behavior.

```
 C89: 4.10.3.2 The free function.

The free function causes the space pointed to by ptr to be deallocated, that is,
made available for further allocation. If ptr is a null pointer, no action occurs.
```