### PR TITLE
fluid: ask: zenity: use clear() and empty() for std containers

### DIFF
--- a/fluid/Project.cxx
+++ b/fluid/Project.cxx
@@ -72,7 +72,7 @@ void Project::reset() {
   code_file_set = 0;
   header_file_name = ".h";
   code_file_name = ".cxx";
-  include_guard = "";
+  include_guard.clear();
   write_mergeback_data = 0;
 }
 

--- a/fluid/proj/i18n.cxx
+++ b/fluid/proj/i18n.cxx
@@ -31,13 +31,13 @@ void I18n::reset() {
   type = fluid::I18n_Type::NONE;
 
   gnu_include = "<libintl.h>";
-  gnu_conditional = "";
+  gnu_conditional.clear();
   gnu_function = "gettext";
   gnu_static_function = "gettext_noop";
 
   posix_include = "<nl_types.h>";
-  posix_conditional = "";
-  posix_file = "";
+  posix_conditional.clear();
+  posix_file.clear();
   posix_set = "1";
 }
 

--- a/src/Fl_Native_File_Chooser_Zenity.cxx
+++ b/src/Fl_Native_File_Chooser_Zenity.cxx
@@ -121,7 +121,7 @@ void Fl_Zenity_Native_File_Chooser_Driver::build_command(std::string& command) {
   }
   command += " ";
   command += option;
-  if (preset != "") {
+  if (!preset.empty()) {
     command += " ";
     command += preset;
   }

--- a/src/fl_ask.cxx
+++ b/src/fl_ask.cxx
@@ -396,7 +396,7 @@ std::string fl_input_str(int &ret, int maxchar, const char *fmt, const char *def
   const char *r = msg.input_innards(fmt, ap, defstr, FL_NORMAL_INPUT, maxchar, true);
   va_end(ap);
   ret = (r == NULL) ? -1 : 0;
-  return (r == NULL) ? std::string("") : std::string(r);
+  return (r == NULL) ? std::string() : std::string(r);
 }
 
 /** Shows an input dialog displaying the \p fmt message with variable arguments.
@@ -410,7 +410,7 @@ std::string fl_input_str(int maxchar, const char *fmt, const char *defstr, ...) 
   va_start(ap, defstr);
   const char *r = msg.input_innards(fmt, ap, defstr, FL_NORMAL_INPUT, maxchar, true);
   va_end(ap);
-  return (r == NULL) ? std::string("") : std::string(r);
+  return (r == NULL) ? std::string() : std::string(r);
 }
 
 
@@ -492,7 +492,7 @@ std::string fl_password_str(int &ret, int maxchar, const char *fmt, const char *
   const char *r = msg.input_innards(fmt, ap, defstr, FL_SECRET_INPUT, maxchar, true);
   va_end(ap);
   ret = (r == NULL) ? -1 : 0;
-  return (r == NULL) ? std::string("") : std::string(r);
+  return (r == NULL) ? std::string() : std::string(r);
 }
 
 /** Shows an input dialog displaying the \p fmt message with variable arguments.
@@ -506,7 +506,7 @@ std::string fl_password_str(int maxchar, const char *fmt, const char *defstr, ..
   va_start(ap, defstr);
   const char *r = msg.input_innards(fmt, ap, defstr, FL_SECRET_INPUT, maxchar, true);
   va_end(ap);
-  return (r == NULL) ? std::string("") : std::string(r);
+  return (r == NULL) ? std::string() : std::string(r);
 }
 
 


### PR DESCRIPTION
@MatthiasWM
according to C++ std standard, special methods clear() and empty() must be used because it is readable and better optimized by C++ compilers

std::string() without init empty const char str faster

<img width="1534" height="911" alt="image" src="https://github.com/user-attachments/assets/f615be00-b346-42dc-9042-f57ac9906cfc" />

