### PR TITLE
Breaking change: Use floats for Fl::e_dx and Fl::e_dy

### DIFF
--- a/FL/core/events.H
+++ b/FL/core/events.H
@@ -45,8 +45,8 @@ FL_EXPORT extern int                e_x;                ///< Mouse X position (w
 FL_EXPORT extern int                e_y;                ///< Mouse Y position (window relative)
 FL_EXPORT extern int                e_x_root;           ///< Mouse X position (screen absolute)
 FL_EXPORT extern int                e_y_root;           ///< Mouse Y position (screen absolute)
-FL_EXPORT extern int                e_dx;               ///< Mouse wheel horizontal delta
-FL_EXPORT extern int                e_dy;               ///< Mouse wheel vertical delta
+FL_EXPORT extern float              e_dx;               ///< Mouse wheel horizontal delta
+FL_EXPORT extern float              e_dy;               ///< Mouse wheel vertical delta
 
 // Mouse click handling
 FL_EXPORT extern int                e_clicks;           ///< Number of consecutive clicks
@@ -132,13 +132,13 @@ FL_EXPORT inline int event_y_root()             { return e_y_root; }
   Returns the current horizontal mouse scrolling associated with the
   FL_MOUSEWHEEL event. Right is positive.
 */
-FL_EXPORT inline int event_dx()                 { return e_dx; }
+FL_EXPORT inline float event_dx()               { return e_dx; }
 
 /**
   Returns the current vertical mouse scrolling associated with the
   FL_MOUSEWHEEL event. Down is positive.
 */
-FL_EXPORT inline int event_dy()                 { return e_dy; }
+FL_EXPORT inline float event_dy()               { return e_dy; }
 
 //
 // Mouse Query Functions

--- a/src/Fl.cxx
+++ b/src/Fl.cxx
@@ -52,8 +52,6 @@ int             Fl::damage_,
                 Fl::e_y,
                 Fl::e_x_root,
                 Fl::e_y_root,
-                Fl::e_dx,
-                Fl::e_dy,
                 Fl::e_state,
                 Fl::e_clicks,
                 Fl::e_is_click,
@@ -61,6 +59,10 @@ int             Fl::damage_,
                 Fl::e_original_keysym,
                 Fl::scrollbar_size_ = 16,
                 Fl::menu_linespacing_ = 4;      // 4: was a local macro in Fl_Menu.cxx called "LEADING"
+
+// Displacement in linesize units
+float           Fl::e_dx,
+                Fl::e_dy;
 
 char            *Fl::e_text = (char *)"";
 int             Fl::e_length;

--- a/src/Fl_cocoa.mm
+++ b/src/Fl_cocoa.mm
@@ -962,11 +962,8 @@ static void cocoaMouseWheelHandler(NSEvent *theEvent)
   float s = Fl::screen_driver()->scale(0);
   float edx = [theEvent deltaX];
   float edy = [theEvent deltaY];
-  int dx = roundf(edx / s);
-  int dy = roundf(edy / s);
-  // make sure that even small wheel movements count at least as one unit
-  if (edx>0.0f) dx++; else if (edx<0.0f) dx--;
-  if (edy>0.0f) dy++; else if (edy<0.0f) dy--;
+  float dx = edx / s;
+  float dy = edy / s;
   // allow both horizontal and vertical movements to be processed by the widget
   if (dx) {
     Fl::e_dx = -dx;
@@ -993,7 +990,7 @@ static void cocoaMagnifyHandler(NSEvent *theEvent)
     return;
   }
   Fl::first_window(window);
-  Fl::e_dy = [theEvent magnification]*1000; // 10.5.2
+  Fl::e_dy = [theEvent magnification]*1000.0; // 10.5.2
   if ( Fl::e_dy) {
     NSPoint pos = [theEvent locationInWindow];
     pos.y = window->h() - pos.y;

--- a/src/Fl_win32.cxx
+++ b/src/Fl_win32.cxx
@@ -1728,12 +1728,10 @@ content  key    keyboard layout
       } // case WM_DEADCHAR ... WM_SYSCHAR
 
       case WM_MOUSEWHEEL: {
-        static int delta = 0; // running total of all vertical mousewheel motion
-        delta += (SHORT)(HIWORD(wParam));
-        int dy = -delta / WHEEL_DELTA;
-        delta += dy * WHEEL_DELTA;
-        if (dy == 0) // nothing to do
+        int delta = (SHORT)(HIWORD(wParam));
+        if (delta == 0) // nothing to do
           return 0;
+        float dy = (float) -delta / (float) WHEEL_DELTA;
         if (Fl::event_shift()) { // shift key pressed: send horizontal mousewheel event
           Fl::e_dx = dy;
           Fl::e_dy = 0;
@@ -1746,12 +1744,10 @@ content  key    keyboard layout
       }
 
       case WM_MOUSEHWHEEL: {
-        static int delta = 0; // running total of all horizontal mousewheel motion
-        delta += (SHORT)(HIWORD(wParam));
-        int dx = delta / WHEEL_DELTA;
-        delta -= dx * WHEEL_DELTA;
-        if (dx == 0) // nothing to do
+        int delta = (SHORT)(HIWORD(wParam));
+        if (delta == 0) // nothing to do
           return 0;
+        float dx = (float) delta / (float) WHEEL_DELTA;
         if (Fl::event_shift()) { // shift key pressed: send *vertical* mousewheel event
           Fl::e_dx = 0;
           Fl::e_dy = dx;

--- a/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
+++ b/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
@@ -394,9 +394,8 @@ static void pointer_axis(void *data, struct wl_pointer *wl_pointer,
   Fl_Window *win = Fl_Wayland_Window_Driver::surface_to_window(seat->pointer_focus);
   if (!win) return;
   wld_event_time = time;
-  int delta = wl_fixed_to_int(value);
-  if (abs(delta) >= 10) delta /= 10;
-  // fprintf(stderr, "FL_MOUSEWHEEL: %c delta=%d\n", axis==WL_POINTER_AXIS_HORIZONTAL_SCROLL?'H':'V', delta);
+  float delta = wl_fixed_to_double(value) / 10.0f;
+  // fprintf(stderr, "FL_MOUSEWHEEL: %c delta=%f\n", axis==WL_POINTER_AXIS_HORIZONTAL_SCROLL?'H':'V', delta);
   // allow both horizontal and vertical movements to be processed by the widget
   if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
     if (Fl::event_shift()) { // shift key pressed: send vertical mousewheel event


### PR DESCRIPTION
Allow floating point displacements for smooth scrolling.

**NOTE**: Only tested in Wayland with a touch pad and mouse wheel (works fine).
TODO: Test in other platforms.

Fixes #1571 