### PR TITLE
Fix for #1571, smooth scrolling

### DIFF
--- a/FL/Fl_Scrollbar.H
+++ b/FL/Fl_Scrollbar.H
@@ -42,6 +42,8 @@ class FL_EXPORT Fl_Scrollbar : public Fl_Slider {
 
   int linesize_;
   int pushed_;
+  // error for fractional scrolling
+  float scroll_err_ = 0.5f;
   static void timeout_cb(void*);
   void increment_cb();
 protected:

--- a/FL/core/events.H
+++ b/FL/core/events.H
@@ -47,6 +47,10 @@ FL_EXPORT extern int                e_x_root;           ///< Mouse X position (s
 FL_EXPORT extern int                e_y_root;           ///< Mouse Y position (screen absolute)
 FL_EXPORT extern int                e_dx;               ///< Mouse wheel horizontal delta
 FL_EXPORT extern int                e_dy;               ///< Mouse wheel vertical delta
+FL_EXPORT extern float              e_dx_err;           ///< internal error var for conversion from hires to integer dx
+FL_EXPORT extern float              e_dy_err;           ///< internal error var for conversion from hires to integer dy
+FL_EXPORT extern float              e_dx_f;             ///< Mouse wheel and touchpad horizontal hires delta
+FL_EXPORT extern float              e_dy_f;             ///< Mouse wheel and touchpad vertical hires delta
 
 // Mouse click handling
 FL_EXPORT extern int                e_clicks;           ///< Number of consecutive clicks
@@ -139,6 +143,18 @@ FL_EXPORT inline int event_dx()                 { return e_dx; }
   FL_MOUSEWHEEL event. Down is positive.
 */
 FL_EXPORT inline int event_dy()                 { return e_dy; }
+
+/**
+  Returns the current horizontal mouse scrolling associated with the
+  FL_MOUSEWHEEL event. Right is positive.
+*/
+FL_EXPORT inline float event_dx_f()             { return e_dx_f; }
+
+/**
+  Returns the current vertical mouse scrolling associated with the
+  FL_MOUSEWHEEL event. Down is positive.
+*/
+FL_EXPORT inline float event_dy_f()             { return e_dy_f; }
 
 //
 // Mouse Query Functions

--- a/src/Fl.cxx
+++ b/src/Fl.cxx
@@ -62,6 +62,11 @@ int             Fl::damage_,
                 Fl::scrollbar_size_ = 16,
                 Fl::menu_linespacing_ = 4;      // 4: was a local macro in Fl_Menu.cxx called "LEADING"
 
+float           Fl::e_dx_err = 0.5f;
+float           Fl::e_dy_err = 0.5f;
+float           Fl::e_dx_f = 0.0f;
+float           Fl::e_dy_f = 0.0f;
+
 char            *Fl::e_text = (char *)"";
 int             Fl::e_length;
 const char      *Fl::e_clipboard_type = "";

--- a/src/Fl_Scrollbar.cxx
+++ b/src/Fl_Scrollbar.cxx
@@ -130,14 +130,24 @@ int Fl_Scrollbar::handle(int event) {
     return Fl_Slider::handle(event, X,Y,W,H);
   case FL_MOUSEWHEEL :
     if (horizontal()) {
-      if (Fl::e_dx==0) return 0;
+      // use hires scrolling input and map it to scrollbar line resolution
+      if (Fl::e_dx_f==0.0f) return 0;
+      // map pixel scrolling to line scrolling
       int ls = maximum()>=minimum() ? linesize_ : -linesize_;
-      handle_drag(clamp(value() + ls * Fl::e_dx));
+      scroll_err_ += Fl::e_dx_f * ls;
+      float dxi = floorf(scroll_err_);
+      scroll_err_ -= dxi;
+      handle_drag(clamp(value() + int(dxi)));
       return 1;
     } else {
-      if (Fl::e_dy==0) return 0;
+      // use hires scrolling input and map it to scrollbar line resolution
+      if (Fl::e_dy_f==0.0f) return 0;
+      // map pixel scrolling to line scrolling
       int ls = maximum()>=minimum() ? linesize_ : -linesize_;
-      handle_drag(clamp(value() + ls * Fl::e_dy));
+      scroll_err_ += Fl::e_dy_f * ls;
+      float dyi = floorf(scroll_err_);
+      scroll_err_ -= dyi;
+      handle_drag(clamp(value() + int(dyi)));
       return 1;
     }
   case FL_SHORTCUT:

--- a/src/Fl_cocoa.mm
+++ b/src/Fl_cocoa.mm
@@ -959,7 +959,7 @@ static void cocoaMouseWheelHandler(NSEvent *theEvent)
   fl_lock_function();
   Fl_Window *window = (Fl_Window*)[(FLWindow*)[theEvent window] getFl_Window];
   Fl::first_window(window);
-  // Under OSX, mousewheel deltas are floats, separate into low res and hire scrolling
+  // Under OSX, mousewheel deltas are floats, separate into low res and high res scrolling
   float s = Fl::screen_driver()->scale(0);
   BOOL precise = [theEvent hasPreciseScrollingDeltas]; // macOS 10.7 and later
   float edx = -(precise ? [theEvent scrollingDeltaX] / 10.0 : [theEvent deltaX]) / s;

--- a/src/Fl_cocoa.mm
+++ b/src/Fl_cocoa.mm
@@ -959,10 +959,11 @@ static void cocoaMouseWheelHandler(NSEvent *theEvent)
   fl_lock_function();
   Fl_Window *window = (Fl_Window*)[(FLWindow*)[theEvent window] getFl_Window];
   Fl::first_window(window);
-  // Under OSX, mousewheel deltas are floats, but fltk only supports ints.
+  // Under OSX, mousewheel deltas are floats, separate into low res and hire scrolling
   float s = Fl::screen_driver()->scale(0);
-  float edx = [theEvent deltaX];
-  float edy = [theEvent deltaY];
+  BOOL precise = [theEvent hasPreciseScrollingDeltas]; // macOS 10.7 and later
+  float edx = -(precise ? [theEvent scrollingDeltaX] / 10.0 : [theEvent deltaX]) / s;
+  float edy = -(precise ? [theEvent scrollingDeltaY] / 10.0 : [theEvent deltaY]) / s;
 
   if (Fl::event_shift()) {
     std::swap(edx, edy);
@@ -972,18 +973,22 @@ static void cocoaMouseWheelHandler(NSEvent *theEvent)
   if (edx != 0.0f) {
     // accumulate dx floating point value and convert to int
     Fl::e_dx_f = edx;
+    Fl::e_dy_f = 0.0f;
     Fl::e_dx_err += edx;
     float dxi = floorf(Fl::e_dx_err);
     Fl::e_dx_err -= dxi;
     Fl::e_dx = (int)dxi;
+    Fl::e_dy = 0;
     Fl::handle( FL_MOUSEWHEEL, window );
   }
-    if (edy != 0.0f) {
+  if (edy != 0.0f) {
+    Fl::e_dx_f = 0.0f;
     Fl::e_dy_f = edy;
     // accumulate dy floating point value and convert to int
     Fl::e_dy_err += edy;
     float dyi = floorf(Fl::e_dy_err);
     Fl::e_dy_err -= dyi;
+    Fl::e_dx = 0;
     Fl::e_dy = (int)dyi;
     Fl::handle( FL_MOUSEWHEEL, window );
   }

--- a/src/Fl_cocoa.mm
+++ b/src/Fl_cocoa.mm
@@ -47,6 +47,7 @@ extern "C" {
 #include <dlfcn.h>
 #include <string.h>
 #include <pwd.h>
+#include <utility> // std::swap()
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_7 || \
     MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_7
@@ -962,20 +963,28 @@ static void cocoaMouseWheelHandler(NSEvent *theEvent)
   float s = Fl::screen_driver()->scale(0);
   float edx = [theEvent deltaX];
   float edy = [theEvent deltaY];
-  int dx = roundf(edx / s);
-  int dy = roundf(edy / s);
-  // make sure that even small wheel movements count at least as one unit
-  if (edx>0.0f) dx++; else if (edx<0.0f) dx--;
-  if (edy>0.0f) dy++; else if (edy<0.0f) dy--;
+
+  if (Fl::event_shift()) {
+    std::swap(edx, edy);
+  }
+
   // allow both horizontal and vertical movements to be processed by the widget
-  if (dx) {
-    Fl::e_dx = -dx;
-    Fl::e_dy = 0;
+  if (edx != 0.0f) {
+    // accumulate dx floating point value and convert to int
+    Fl::e_dx_f = edx;
+    Fl::e_dx_err += edx;
+    float dxi = floorf(Fl::e_dx_err);
+    Fl::e_dx_err -= dxi;
+    Fl::e_dx = (int)dxi;
     Fl::handle( FL_MOUSEWHEEL, window );
   }
-  if (dy) {
-    Fl::e_dx = 0;
-    Fl::e_dy = -dy;
+    if (edy != 0.0f) {
+    Fl::e_dy_f = edy;
+    // accumulate dy floating point value and convert to int
+    Fl::e_dy_err += edy;
+    float dyi = floorf(Fl::e_dy_err);
+    Fl::e_dy_err -= dyi;
+    Fl::e_dy = (int)dyi;
     Fl::handle( FL_MOUSEWHEEL, window );
   }
   fl_unlock_function();

--- a/src/Fl_win32.cxx
+++ b/src/Fl_win32.cxx
@@ -1728,7 +1728,7 @@ content  key    keyboard layout
       } // case WM_DEADCHAR ... WM_SYSCHAR
 
       case WM_MOUSEWHEEL: {
-        float delta = GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA; // HIWORD is of type SHORT or int16_t
+        float delta = -GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA; // HIWORD is of type SHORT or int16_t
         if (delta == 0.0f) // nothing to do
           return 0;
         if (Fl::event_shift()) { // shift key pressed: send vertical mousewheel event
@@ -1753,7 +1753,7 @@ content  key    keyboard layout
       }
 
       case WM_MOUSEHWHEEL: {
-        float delta = GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA; // HIWORD is of type SHORT or int16_t
+        float delta = -GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA; // HIWORD is of type SHORT or int16_t
         if (delta == 0.0f) // nothing to do
           return 0;
         if (Fl::event_shift()) { // shift key pressed: send vertical mousewheel event

--- a/src/Fl_win32.cxx
+++ b/src/Fl_win32.cxx
@@ -1731,7 +1731,7 @@ content  key    keyboard layout
         float delta = -GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA; // HIWORD is of type SHORT or int16_t
         if (delta == 0.0f) // nothing to do
           return 0;
-        if (Fl::event_shift()) { // shift key pressed: send vertical mousewheel event
+        if (Fl::event_shift()) { // shift key pressed: send horizontal mousewheel event
           Fl::e_dx_f = delta;
           Fl::e_dy_f = 0.0f;
           Fl::e_dx_err += Fl::e_dx_f;

--- a/src/Fl_win32.cxx
+++ b/src/Fl_win32.cxx
@@ -1728,7 +1728,7 @@ content  key    keyboard layout
       } // case WM_DEADCHAR ... WM_SYSCHAR
 
       case WM_MOUSEWHEEL: {
-        float delta = (HIWORD(wParam)) / WHEEL_DELTA; // HIWORD is of type SHORT or int16_t
+        float delta = GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA; // HIWORD is of type SHORT or int16_t
         if (delta == 0.0f) // nothing to do
           return 0;
         if (Fl::event_shift()) { // shift key pressed: send vertical mousewheel event
@@ -1750,9 +1750,10 @@ content  key    keyboard layout
         }
         Fl::handle(FL_MOUSEWHEEL, window);
         return 0;
+      }
 
       case WM_MOUSEHWHEEL: {
-        float delta = (HIWORD(wParam)) / WHEEL_DELTA; // HIWORD is of type SHORT or int16_t
+        float delta = GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA; // HIWORD is of type SHORT or int16_t
         if (delta == 0.0f) // nothing to do
           return 0;
         if (Fl::event_shift()) { // shift key pressed: send vertical mousewheel event

--- a/src/Fl_win32.cxx
+++ b/src/Fl_win32.cxx
@@ -215,7 +215,7 @@ static Fl_Window *track_mouse_win = 0; // current TrackMouseEvent() window
 #endif
 
 #ifndef WHEEL_DELTA
-#  define WHEEL_DELTA 120       // according to MSDN.
+#  define WHEEL_DELTA 120.0f       // according to MSDN.
 #endif
 
 // This is only defined on Vista and upwards...
@@ -1728,35 +1728,48 @@ content  key    keyboard layout
       } // case WM_DEADCHAR ... WM_SYSCHAR
 
       case WM_MOUSEWHEEL: {
-        static int delta = 0; // running total of all vertical mousewheel motion
-        delta += (SHORT)(HIWORD(wParam));
-        int dy = -delta / WHEEL_DELTA;
-        delta += dy * WHEEL_DELTA;
-        if (dy == 0) // nothing to do
+        float delta = (HIWORD(wParam)) / WHEEL_DELTA; // HIWORD is of type SHORT or int16_t
+        if (delta == 0.0f) // nothing to do
           return 0;
-        if (Fl::event_shift()) { // shift key pressed: send horizontal mousewheel event
-          Fl::e_dx = dy;
+        if (Fl::event_shift()) { // shift key pressed: send vertical mousewheel event
+          Fl::e_dx_f = delta;
+          Fl::e_dy_f = 0.0f;
+          Fl::e_dx_err += Fl::e_dx_f;
+          float dxi = floorf(Fl::e_dx_err);
+          Fl::e_dx_err -= dxi;
+          Fl::e_dx = (int)dxi;
           Fl::e_dy = 0;
-        } else { // shift key not pressed (normal behavior): send vertical mousewheel event
+        } else { // shift key not pressed (normal behavior): send horizontal mousewheel event
+          Fl::e_dx_f = 0.0f;
+          Fl::e_dy_f = delta;
           Fl::e_dx = 0;
-          Fl::e_dy = dy;
+          Fl::e_dy_err += Fl::e_dy_f;
+          float dyi = floorf(Fl::e_dy_err);
+          Fl::e_dy_err -= dyi;
+          Fl::e_dy = (int)dyi;
         }
         Fl::handle(FL_MOUSEWHEEL, window);
         return 0;
-      }
 
       case WM_MOUSEHWHEEL: {
-        static int delta = 0; // running total of all horizontal mousewheel motion
-        delta += (SHORT)(HIWORD(wParam));
-        int dx = delta / WHEEL_DELTA;
-        delta -= dx * WHEEL_DELTA;
-        if (dx == 0) // nothing to do
+        float delta = (HIWORD(wParam)) / WHEEL_DELTA; // HIWORD is of type SHORT or int16_t
+        if (delta == 0.0f) // nothing to do
           return 0;
-        if (Fl::event_shift()) { // shift key pressed: send *vertical* mousewheel event
+        if (Fl::event_shift()) { // shift key pressed: send vertical mousewheel event
+          Fl::e_dx_f = 0.0f;
+          Fl::e_dy_f = delta;
           Fl::e_dx = 0;
-          Fl::e_dy = dx;
+          Fl::e_dy_err += Fl::e_dy_f;
+          float dyi = floorf(Fl::e_dy_err);
+          Fl::e_dy_err -= dyi;
+          Fl::e_dy = (int)dyi;
         } else { // shift key not pressed (normal behavior): send horizontal mousewheel event
-          Fl::e_dx = dx;
+          Fl::e_dx_f = delta;
+          Fl::e_dy_f = 0.0f;
+          Fl::e_dx_err += Fl::e_dx_f;
+          float dxi = floorf(Fl::e_dx_err);
+          Fl::e_dx_err -= dxi;
+          Fl::e_dx = (int)dxi;
           Fl::e_dy = 0;
         }
         Fl::handle(FL_MOUSEWHEEL, window);

--- a/src/Fl_x.cxx
+++ b/src/Fl_x.cxx
@@ -2054,18 +2054,23 @@ int fl_handle(const XEvent& thisevent)
     Fl::e_keysym = 0;       // init: not used (zero) for scroll wheel events
     set_event_xy(window);
     Fl::e_dx = Fl::e_dy = 0;
+    Fl::e_dx_f = Fl::e_dy_f = 0.0f;
 
     if (mb == Button4 && !Fl::event_shift()) {
       Fl::e_dy = -1;                            // up
+      Fl::e_dy_f = -1.0f;
       event = FL_MOUSEWHEEL;
     } else if (mb == Button5 && !Fl::event_shift()) {
       Fl::e_dy = +1;                            // down
+      Fl::e_dy_f = +1.0f;
       event = FL_MOUSEWHEEL;
     } else if (mb == 6 || (mb == Button4 && Fl::event_shift())) {
       Fl::e_dx = -1;                            // left
+      Fl::e_dx_f = -1.0f;
       event = FL_MOUSEWHEEL;
     } else if (mb == 7 || (mb == Button5 && Fl::event_shift())) {
       Fl::e_dx = +1;                            // right
+      Fl::e_dx_f = +1.0f;
       event = FL_MOUSEWHEEL;
     } else if (mb < 4 || mb > 7) {              // real mouse *buttons*, not scroll wheel
       if (mb > 7)                               // 8 = back, 9 = forward

--- a/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
+++ b/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
@@ -52,6 +52,7 @@
 #include <poll.h>
 #include <errno.h>
 #include <string.h> // for strerror()
+#include <math.h> // floorf()
 #include <map>
 
 extern "C" {
@@ -394,27 +395,52 @@ static void pointer_axis(void *data, struct wl_pointer *wl_pointer,
   Fl_Window *win = Fl_Wayland_Window_Driver::surface_to_window(seat->pointer_focus);
   if (!win) return;
   wld_event_time = time;
-  int delta = wl_fixed_to_int(value);
-  if (abs(delta) >= 10) delta /= 10;
-  // fprintf(stderr, "FL_MOUSEWHEEL: %c delta=%d\n", axis==WL_POINTER_AXIS_HORIZONTAL_SCROLL?'H':'V', delta);
+  // Delta values on Wayland are in "pixels". A line is assumed to be 10 pixels, so mouse wheel
+  // increments are often +/-10.0 pixels per detent. FLTK expects deltas to be in "lines", so we divide by 10.
+  // Note that this is a heuristic, and the actual number of pixels per line may vary depending on 
+  // the device and user settings.
+  // Also note that there are mice with hires wheels (no detents but smooth scrolling)
+  // and touchpads with two-finger scrolling, which can produce fractional pixel values.
+  float delta = (float)wl_fixed_to_double(value) / 10.0f;
+  // fprintf(stderr, "FL_MOUSEWHEEL: %c delta=%f\n", axis==WL_POINTER_AXIS_HORIZONTAL_SCROLL?'H':'V', delta);
   // allow both horizontal and vertical movements to be processed by the widget
   if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
     if (Fl::event_shift()) { // shift key pressed: send vertical mousewheel event
+      Fl::e_dx_f = 0.0f;
+      Fl::e_dy_f = delta;
       Fl::e_dx = 0;
-      Fl::e_dy = delta;
+      Fl::e_dy_err += Fl::e_dy_f;
+      float dyi = floorf(Fl::e_dy_err);
+      Fl::e_dy_err -= dyi;
+      Fl::e_dy = (int)dyi;
     } else { // shift key not pressed (normal behavior): send horizontal mousewheel event
-      Fl::e_dx = delta;
+      Fl::e_dx_f = delta;
+      Fl::e_dy_f = 0.0f;
+      Fl::e_dx_err += Fl::e_dx_f;
+      float dxi = floorf(Fl::e_dx_err);
+      Fl::e_dx_err -= dxi;
+      Fl::e_dx = (int)dxi;
       Fl::e_dy = 0;
     }
     Fl::handle(FL_MOUSEWHEEL, win->top_window());
   }
   if (axis == WL_POINTER_AXIS_VERTICAL_SCROLL) {
     if (Fl::event_shift()) { // shift key pressed: send horizontal mousewheel event
-      Fl::e_dx = delta;
+      Fl::e_dx_f = delta;
+      Fl::e_dy_f = 0.0f;
+      Fl::e_dx_err += Fl::e_dx_f;
+      float dxi = floorf(Fl::e_dx_err);
+      Fl::e_dx_err -= dxi;
+      Fl::e_dx = (int)dxi;
       Fl::e_dy = 0;
     } else {// shift key not pressed (normal behavior): send vertical mousewheel event
+      Fl::e_dx_f = 0.0f;
+      Fl::e_dy_f = delta;
       Fl::e_dx = 0;
-      Fl::e_dy = delta;
+      Fl::e_dy_err += Fl::e_dy_f;
+      float dyi = floorf(Fl::e_dy_err);
+      Fl::e_dy_err -= dyi;
+      Fl::e_dy = (int)dyi;
     }
     Fl::handle(FL_MOUSEWHEEL, win->top_window());
   }
@@ -427,6 +453,12 @@ static struct wl_pointer_listener pointer_listener = {
   pointer_motion,
   pointer_button,
   pointer_axis
+  /* since Wayland INterface Version 5:
+  frame,
+  pointer_axis_source, // could be used to differentiate scroll wheel and touch pad.
+  axis_stop,
+  axis_discrete
+  */
 };
 
 

--- a/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
+++ b/src/drivers/Wayland/Fl_Wayland_Screen_Driver.cxx
@@ -397,7 +397,7 @@ static void pointer_axis(void *data, struct wl_pointer *wl_pointer,
   wld_event_time = time;
   // Delta values on Wayland are in "pixels". A line is assumed to be 10 pixels, so mouse wheel
   // increments are often +/-10.0 pixels per detent. FLTK expects deltas to be in "lines", so we divide by 10.
-  // Note that this is a heuristic, and the actual number of pixels per line may vary depending on 
+  // Note that this is a heuristic, and the actual number of pixels per line may vary depending on
   // the device and user settings.
   // Also note that there are mice with hires wheels (no detents but smooth scrolling)
   // and touchpads with two-finger scrolling, which can produce fractional pixel values.
@@ -453,9 +453,9 @@ static struct wl_pointer_listener pointer_listener = {
   pointer_motion,
   pointer_button,
   pointer_axis
-  /* since Wayland INterface Version 5:
+  /* since Wayland Interface Version 5:
   frame,
-  pointer_axis_source, // could be used to differentiate scroll wheel and touch pad.
+  pointer_axis_source, // could be used to differentiate scroll wheel and touchpad.
   axis_stop,
   axis_discrete
   */


### PR DESCRIPTION
This patch gives access to finer scrolling data for FL_MOSEWHEEL events via `float Fl::event_dx_f()` and `float Fl::event_dy_f()`

dx_f and dy_f use the same increment of one line of text per one unit, but also at a fractional resolution, if the connected device provides that. A delta of 0.1 roughly corresponds to 1 FLTK pixel unit.

This also fixes very slow scroll motion on a touchpad by adding up the error in fractional deltas until an integer value can be created for `int Fl::event_dx()` and `int Fl::event_dy()`.

This patch is tested on all platforms. It is fully back compatible with existing FLTK apps and widgets. Expect to receive more FL_MOUSEHWEEL events, but many will have dx and dy set to 0 while dx_f and dy_f give only values -1 < x < 1.

Note: this does not fix or improve any existing widgets, but it's now possible to write or upgrade widgets to pixel resolution scrolling.