### PR TITLE
Command line argument for scaling apps

### DIFF
--- a/FL/Fl.H
+++ b/FL/Fl.H
@@ -571,6 +571,8 @@ FL_EXPORT extern void screen_work_area(int &X, int &Y, int &W, int &H, int n); /
 FL_EXPORT extern void screen_work_area(int &X, int &Y, int &W, int &H); // via screen driver
 FL_EXPORT extern float screen_scale(int n); // via screen driver
 FL_EXPORT extern void screen_scale(int n, float factor); // via screen driver
+FL_EXPORT extern float normalized_screen_scale(int n);
+FL_EXPORT extern void normalized_screen_scale(int n, float factor);
 FL_EXPORT extern int screen_scaling_supported();
 FL_EXPORT extern void keyboard_screen_scaling(int value);
 

--- a/src/Fl.cxx
+++ b/src/Fl.cxx
@@ -2508,6 +2508,25 @@ float Fl::screen_scale(int n) {
   return Fl::screen_driver()->scale(n);
 }
 
+/**
+ Gets the normalized GUI scaling factor of screen number \p n.
+
+ Calculate the scale of the windows and their graphics on a screen in relation
+ to the initial scale of the screen. The initial scale is the scale of the
+ screen when the application was started. This is the samle value that is
+ shown in the transient popup windows during interactive app scaling.
+
+ \param[in] n screen index between 0 and Fl::screen_count() - 1
+ \return screen scaling factor in relation to the initial scale
+ \see Fl::screen_scale(int)
+ \since 1.5.0
+*/
+float Fl::normalized_screen_scale(int n) {
+  if (!Fl::screen_scaling_supported() || n < 0 || n >= Fl::screen_count())
+    return 1.;
+  return Fl::screen_driver()->scale(n) / Fl::screen_driver()->base_scale(n);
+}
+
 /** Sets the GUI scaling factor of screen number \p n.
 
   The valid range of \p n is 0 .. Fl::screen_count() - 1.
@@ -2535,6 +2554,28 @@ void Fl::screen_scale(int n, float factor) {
     }
   } else
     Fl::screen_driver()->rescale_all_windows_from_screen(n, factor, factor);
+}
+
+/**
+ Sets the normalized GUI scaling factor of screen number \p n.
+
+ Set the scale of the windows and their graphics on a screen in relation
+ to the initial scale of the screen.
+
+ \param[in] n Screen index between 0 and Fl::screen_count() - 1. Set this to
+            -1 to scale all screens.
+ \param[in] factor Scaling factor for the given screen.
+ \see Fl::screen_scale(int, float)
+ \since 1.5.0
+*/
+void Fl::normalized_screen_scale(int n, float factor) {
+  if (n == -1) {
+    for (int s = 0; s < Fl::screen_count(); s++) {
+      Fl::screen_scale(s, factor * Fl::screen_driver()->base_scale(s));
+    }
+  } else {
+    Fl::screen_scale(n, factor * Fl::screen_driver()->base_scale(n));
+  }
 }
 
 /**

--- a/src/Fl_Window.cxx
+++ b/src/Fl_Window.cxx
@@ -548,7 +548,16 @@ void Fl_Window::label(const char *name, const char *mininame) {
   pWindowDriver->label(name, mininame);
 }
 
+extern float fl_scaling_factor;
+
 void Fl_Window::show() {
+  static bool first_show = true;
+  if (first_show && !parent()) {
+    first_show = false;
+    if (fl_scaling_factor != 1.0f)
+      Fl::normalized_screen_scale(-1, fl_scaling_factor);
+  }
+
   image(Fl::scheme_bg_);
   if (Fl::scheme_bg_) {
     labeltype(FL_NORMAL_LABEL);

--- a/src/Fl_arg.cxx
+++ b/src/Fl_arg.cxx
@@ -41,6 +41,8 @@ static const char *title;
 extern const char *fl_fg;
 extern const char *fl_bg;
 extern const char *fl_bg2;
+// user selected application scaling
+float fl_scaling_factor = 1.0f;
 
 /**
   Parse a single switch from \p argv, starting at word \p i.
@@ -206,6 +208,9 @@ int Fl::arg(int argc, char **argv, int &i) {
   } else if (fl_match(s, "fg", 2) || fl_match(s, "foreground", 10)) {
     fl_fg = v;
 
+  } else if (fl_match(s, "scaling", 2) || fl_match(s, "scaling_factor", 14)) {
+    fl_scaling_factor = (float)atof(v);
+
   } else if (fl_match(s, "scheme", 1)) {
     Fl::scheme(v);
 
@@ -349,6 +354,7 @@ static const char * const helpmsg =
 " -nok[bd]\n"
 " -not[ooltips]\n"
 " -s[cheme] scheme\n"
+" -scaling[_factor] factor\n"
 " -ti[tle] windowtitle\n"
 " -to[oltips]";
 

--- a/test/browser.cxx
+++ b/test/browser.cxx
@@ -231,7 +231,7 @@ int main(int argc, char **argv) {
   tty->ansi(true);
 
   window.resizable(browser);
-  window.show(argc,argv);
+  window.show();
   return Fl::run();
 }
 

--- a/test/cairo_test.cxx
+++ b/test/cairo_test.cxx
@@ -209,6 +209,7 @@ int main(int argc, char **argv) {
 #include <FL/fl_ask.H>
 
 int main(int argc, char **argv) {
+  Fl::args(argc, argv);
   fl_message_title("This program needs a Cairo enabled FLTK library");
   fl_message(
     "Please configure FLTK with Cairo enabled, i.e. use one of the\n"

--- a/test/demo.cxx
+++ b/test/demo.cxx
@@ -112,7 +112,7 @@ char app_path     [FL_PATH_MAX];          // directory of all demo binaries
 char fluid_path   [FL_PATH_MAX];          // binary directory of fluid
 char options_path [FL_PATH_MAX];          // binary directory of fltk-options
 char data_path    [FL_PATH_MAX];          // working directory of all demos
-char command      [2 * FL_PATH_MAX + 40]; // command to be executed
+char command      [2 * FL_PATH_MAX + 80]; // command to be executed
 
 // platform specific suffix for executable files
 
@@ -392,12 +392,20 @@ void dobut(Fl_Widget *, long arg) {
     path = options_path;
 
   // format commandline with optional parameters
+  char scaling_arg[40];
+  scaling_arg[0] = 0;
+  float scaling_factor = Fl::normalized_screen_scale(0);
+  if (scaling_factor != 1.0f) {
+    snprintf(scaling_arg, sizeof(scaling_arg) - 1, " -scaling_factor %.1f", scaling_factor);
+  }
 
 #if defined(USE_MAC_OS) // macOS
 
   if (params[0]) {
     // we assume that we have only one argument which is a filename in 'data_path'
-    snprintf(command, sizeof(command), "open '%s/%s%s' --args '%s/%s'", path, cmdbuf, suffix, data_path, params);
+    snprintf(command, sizeof(command), "open '%s/%s%s' --args%s '%s/%s'", path, cmdbuf, suffix, scaling_arg, data_path, params);
+  } else if (scaling_arg[0]) {
+    snprintf(command, sizeof(command), "open '%s/%s%s' --args%s", path, cmdbuf, suffix, scaling_arg);
   } else {
     snprintf(command, sizeof(command), "open '%s/%s%s'", path, cmdbuf, suffix);
   }
@@ -405,9 +413,9 @@ void dobut(Fl_Widget *, long arg) {
 #else // other platforms
 
   if (params[0])
-    snprintf(command, sizeof(command), "%s/%s%s %s", path, cmdbuf, suffix, params);
+    snprintf(command, sizeof(command), "%s/%s%s%s %s", path, cmdbuf, suffix, scaling_arg, params);
   else
-    snprintf(command, sizeof(command), "%s/%s%s", path, cmdbuf, suffix);
+    snprintf(command, sizeof(command), "%s/%s%s%s", path, cmdbuf, suffix, scaling_arg);
 
 #endif
 

--- a/test/forms.cxx
+++ b/test/forms.cxx
@@ -184,6 +184,7 @@ int main(int argc, char *argv[]) {
 #include <FL/fl_ask.H>
 
 int main(int argc, char **argv) {
+  Fl::args(argc, argv);
   fl_message_title("This program needs the Forms compatibility library");
   fl_message(
     "Please configure FLTK with Forms enabled, i.e.\n"

--- a/test/utf8.cxx
+++ b/test/utf8.cxx
@@ -703,9 +703,12 @@ Fl_Grid *make_grid(int off) {
 int main(int argc, char** argv) {
 
   int off = 2;
-  if (argc > 1) {
-    off = (int)strtoul(argv[1], NULL, 0);
-    argc = 1;
+
+  Fl::args_to_utf8(argc, argv);
+  int n = 0;
+  Fl::args(argc, argv, n);
+  if (n < argc) {
+    off = (int)strtoul(argv[n], NULL, 0);
   }
 
   make_font_chooser();
@@ -795,7 +798,7 @@ int main(int argc, char** argv) {
 
   // fl_set_status(0, 370, 100, 30);
 
-  main_win->show(argc, argv);
+  main_win->show();
 
   fnt_chooser_win->show();
 


### PR DESCRIPTION
#1522 #1407

- Adding command line argument `-scaling_factor 1.5` to the standard command line arguments.
- Added normalized scaling calls to the `Fl` namespace that use 1.0 as the reference scale at startup.
- Added scaling forwarding from `test/demo`
- tested on macOS and Wayland, no Windows machine here, no multiple screen setup here

To try this out, launch `demo`, scale it up using `Ctrl-+`, then launch the test apps from demo. All test apps start at the same scale as the demo app.