### PR TITLE
Add lambdas with captures as callback option.

### DIFF
--- a/FL/Fl_Callback_Interface.H
+++ b/FL/Fl_Callback_Interface.H
@@ -21,6 +21,7 @@
 
 #include <functional>
 #include <new>
+#include <cstddef>
 
 
 #ifndef Fl_Callback_User_Data_H

--- a/FL/Fl_Callback_Interface.H
+++ b/FL/Fl_Callback_Interface.H
@@ -58,7 +58,28 @@ public:
 
 
 /**
- Add callback functionality to the class T.
+ An interface template class that adds callback functionality to the class T.
+
+ This interface adds modern C++ and classic FLTK callback functionality to any
+ class T. Use this interface by adding it as one base class in the declaration
+ of class T with T itself as the template parameter.
+
+ ```cpp
+ class MyClass : public Fl_Callback_Interface<MyClass> {
+    // ...
+ };
+ ```
+ The interface adds member functions set a type-safe std::function callback
+ or classic FLTK callback functions and user data that require type casting.
+
+ Fl_Callback_Interface needs to store a single bit of infomation in the derived
+ class. To do this, `MyClass` must implement the following functions:
+
+ ```cpp
+ bool callback_is_stdf() const;
+ void set_callback_stdf();
+ void clear_callback_stdf();
+ ```
 
  Classes that use this interface must implement the following functions that
  simply get, set, and clear a bit, must be false initially:
@@ -70,36 +91,64 @@ template <typename T>
 class Fl_Callback_Interface
 {
   // -- types
-  typedef void (Callback_voidp)(T*, void*);
-  typedef void (Callback_long)(T*, long);
-  typedef void (Callback_empty)(T*);
-  typedef void (Callback_flud)(T*, Fl_Callback_User_Data*);
+  typedef void (Callback_T_voidp)(T*, void*);
+  typedef void (Callback_T_long)(T*, long);
+  typedef void (Callback_T_empty)(T*);
+  typedef void (Callback_voidp)(void*);
+  typedef void (Callback_long)(long);
+  // typedef void (Callback_empty)(); // Would be ambiguous with std::function
 
   // -- implementation calls to avoid naming conflicts
-  class Callback_Interface {
+  class Callback_Data
+  {
   public:
+    static void dummy_callback(T*, void*) {}
+    // The following structure looks large, but only takes 32 bytes due to the use of unions.
     union {
       struct {
-        Callback_voidp* callback_;
         union {
+          // Store the callback function pointer in the matching member of the
+          // union and mark cb_type_ accordingly.
+          Callback_T_voidp* callback_t_voidp_;  // (1): void(T*, void*)
+          Callback_T_long*  callback_t_long_;   // (2): void(T*, long)
+          Callback_T_empty* callback_t_empty_;  // (3): void(T*)
+          Callback_voidp*   callback_voidp_;    // (4): void(void*)
+          Callback_long*    callback_long_;     // (5): void(long)
+        };
+        union {
+          // Store the user data destructor function pointer in the matching
+          // member of the union and mark cb_type_ accordingly.
           Fl_Callback_User_Data_Dtor* dtor_callback_;
           Fl_Callback_Free* free_callback_;
         };
+        // We use void* user_data_ for all types because we can safely cast
+        // the void* to long and Fl_Callback_User_Data*.
         void* user_data_;
+        // Remember which type of callback is currently stored in the union.
+        uint8_t cb_type_;   // 0 = none, 1 = callback_t_voidp_, etc.
+        // Remember which type of user data dtor is currently stored in the union.
         uint8_t dtor_type_; // 0 = none, 1 = dtor_callback_, 2 = free_callback_
       };
       std::function<void()> stdf_callback_;
     };
-    static void dummy_callback(T*, void*) {}
-
-    Callback_Interface()
-      : callback_(nullptr)
+    // Constructor, members of unions must be explicitly initialized
+    Callback_Data()
+      : callback_t_voidp_(nullptr)
       , dtor_callback_(nullptr) // union: also clears free_callback_
       , user_data_(nullptr)
       , dtor_type_(0)
+      , cb_type_(0)
     {
     }
-    ~Callback_Interface() {};
+    // Can't copy, because we can't duplicate user_data_ safely.
+    Callback_Data(const Callback_Data&) = delete;
+    Callback_Data& operator=(const Callback_Data&) = delete;
+    // Don't allowing moving either because we can't control the stdf flag.
+    Callback_Data(Callback_Data&&) = delete;
+    Callback_Data& operator=(Callback_Data&&) = delete;
+    // Not enough information. Let Fl_Callback_Interface handle destruction.
+    ~Callback_Data() {};
+    // Run the user data destructor callback if it exists.
     void do_dtor_callback(T* t) {
       if (!t->callback_is_stdf()) {
         if (dtor_type_ == 1) { // dtor_callback_
@@ -111,6 +160,7 @@ class Fl_Callback_Interface
         }
       }
     }
+    // Clear the user data and reset the destructor callback.
     void clear_user_data(T* t) {
       if (!t->callback_is_stdf()) {
         do_dtor_callback(t);
@@ -119,119 +169,136 @@ class Fl_Callback_Interface
         dtor_type_ = 0;
       }
     }
+    // Clear all callback data, including the std::function callback if active.
     void clear(T* t) {
       if (t->callback_is_stdf()) {
-        // stdf_callback_ is the active union member: end its lifetime
-        // explicitly before the struct alternative below is reactivated.
+        // Explicity clear the std::function object to avoid memory leaks
         stdf_callback_.~function();
+        // Clear the bit that indicates stdf_callback_ is active
         t->clear_callback_stdf();
-        callback_ = nullptr;
-        dtor_callback_ = nullptr; // union: also clears free_callback_
-        user_data_ = nullptr;
-        dtor_type_ = 0;
       } else {
         clear_user_data(t);
-        callback_ = nullptr;
       }
+      // Restore the union to a safe state by calling the ctor in place.
+      new(&callback_t_voidp_) Callback_Data();
     }
   };
 
 protected:
+  // Storage for the callback data, including user data and std::function callback.
+  Callback_Data callback_data_;
+
   // -- ctor and dtor
-  Callback_Interface callback_interface_;
+  // Constructor has no extra jobs.
   Fl_Callback_Interface() = default;
+  // Destructor clears the callback data to avoid memory leaks.
   ~Fl_Callback_Interface() {
-    callback_interface_.clear(static_cast<T*>(this));
+    callback_data_.clear(static_cast<T*>(this));
   }
 
 public:
+  // -- non-copyable and non-movable
+  // Not copyable, can't copy callback_data_.
+  Fl_Callback_Interface(const Fl_Callback_Interface&) = delete;
+  Fl_Callback_Interface& operator=(const Fl_Callback_Interface&) = delete;
+  // Not movable either, because we can't control the stdf flag safely.
+  Fl_Callback_Interface(Fl_Callback_Interface&&) = delete;
+  Fl_Callback_Interface& operator=(Fl_Callback_Interface&& other) = delete;
+
   // -- public interface
-  void callback(Callback_voidp* cb, void* p, Fl_Callback_Free* free_cb = nullptr) {
-    callback_interface_.clear(static_cast<T*>(this));
-    callback_interface_.callback_ = cb;
+  void callback(nullptr_t) {
+    callback_data_.clear(static_cast<T*>(this));
+  }
+  void callback(Callback_T_voidp* cb, void* p=nullptr, Fl_Callback_Free* free_cb = nullptr) {
+    callback_data_.clear(static_cast<T*>(this));
+    callback_data_.callback_t_voidp_ = cb;
+    callback_data_.cb_type_ = 1;
+    user_data(p, free_cb);
+  }
+  void callback(Callback_T_voidp* cb, Fl_Callback_User_Data* p, bool auto_free) {
+    callback_data_.clear(static_cast<T*>(this));
+    callback_data_.callback_t_voidp_ = cb;
+    callback_data_.cb_type_ = 1;
+    user_data(p, auto_free);
+  }
+  void callback(Callback_T_long* cb, long p = 0) {
+    callback_data_.clear(static_cast<T*>(this));
+    callback_data_.callback_t_long_ = cb; // stored and later called through its own type -- no cast
+    callback_data_.cb_type_ = 2;
+    user_data(fl_voidptr(p));
+  }
+  void callback(Callback_T_empty* cb) {
+    callback_data_.clear(static_cast<T*>(this));
+    callback_data_.callback_t_empty_ = cb; // stored and later called through its own type -- no cast
+    callback_data_.cb_type_ = 3;
+    user_data(nullptr); // original does not clear user_data!
+  }
+  void callback(Callback_voidp* cb, void* p=nullptr, Fl_Callback_Free* free_cb = nullptr) {
+    callback_data_.clear(static_cast<T*>(this));
+    callback_data_.callback_voidp_ = cb;
+    callback_data_.cb_type_ = 4;
     user_data(p, free_cb);
   }
   void callback(Callback_voidp* cb, Fl_Callback_User_Data* p, bool auto_free) {
-    callback_interface_.clear(static_cast<T*>(this));
-    callback_interface_.callback_ = cb;
+    callback_data_.clear(static_cast<T*>(this));
+    callback_data_.callback_voidp_ = cb;
+    callback_data_.cb_type_ = 4;
     user_data(p, auto_free);
   }
-  void callback(Callback_voidp* cb, Fl_Callback_User_Data* p, Fl_Callback_User_Data_Dtor* dtor) {
-    callback_interface_.clear(static_cast<T*>(this));
-    callback_interface_.callback_ = cb;
-    user_data(p, dtor);
-  }
-  void callback(Callback_voidp* cb){
-    callback_interface_.clear(static_cast<T*>(this));
-    callback_interface_.callback_ = cb;
-    user_data(nullptr); // original does not clear user_data!
-  }
-  void callback(Callback_empty* cb) {
-    callback_interface_.clear(static_cast<T*>(this));
-    callback_interface_.callback_ = (Callback_voidp*)(fl_intptr_t)(cb);
-    user_data(nullptr); // original does not clear user_data!
-  }
   void callback(Callback_long* cb, long p = 0) {
-    callback_interface_.clear(static_cast<T*>(this));
-    callback_interface_.callback_ = (Callback_voidp*)(fl_intptr_t)(cb);
+    callback_data_.clear(static_cast<T*>(this));
+    callback_data_.callback_long_ = cb; // stored and later called through its own type -- no cast
+    callback_data_.cb_type_ = 5;
     user_data(fl_voidptr(p));
   }
   void callback(std::function<void()> cb) {
-    // clear() always leaves the struct alternative active (and stdf false),
-    // so the union storage here is raw and safe to placement-new into.
-    callback_interface_.clear(static_cast<T*>(this));
+    callback_data_.clear(static_cast<T*>(this));
     static_cast<T*>(this)->set_callback_stdf();
-    new (&callback_interface_.stdf_callback_) std::function<void()>(std::move(cb));
+    new (&callback_data_.stdf_callback_) std::function<void()>(std::move(cb));
   }
   void user_data(void* v, Fl_Callback_Free* free_cb = nullptr) {
     // user data has no meaning while the union's active member is
     // stdf_callback_; skip so we don't write over the live std::function.
     if (static_cast<T*>(this)->callback_is_stdf()) return;
-    callback_interface_.clear_user_data(static_cast<T*>(this));
-    callback_interface_.user_data_ = v;
+    callback_data_.clear_user_data(static_cast<T*>(this));
+    callback_data_.user_data_ = v;
     if (free_cb) {
-      callback_interface_.free_callback_ = free_cb;
-      callback_interface_.dtor_type_ = 2;
+      callback_data_.free_callback_ = free_cb;
+      callback_data_.dtor_type_ = 2;
     }
   }
   void user_data(Fl_Callback_User_Data* v, bool auto_free) {
     if (static_cast<T*>(this)->callback_is_stdf()) return;
-    callback_interface_.clear_user_data(static_cast<T*>(this));
-    callback_interface_.user_data_ = v;
+    callback_data_.clear_user_data(static_cast<T*>(this));
+    callback_data_.user_data_ = v;
     if (auto_free) {
-      callback_interface_.dtor_callback_ = Fl_Callback_User_Data::default_dtor_callback;
-      callback_interface_.dtor_type_ = 1;
-    }
-  }
-  void user_data(Fl_Callback_User_Data* v, Fl_Callback_User_Data_Dtor* dtor) {
-    if (static_cast<T*>(this)->callback_is_stdf()) return;
-    callback_interface_.clear_user_data(static_cast<T*>(this));
-    callback_interface_.user_data_ = v;
-    if (dtor) {
-      callback_interface_.dtor_callback_ = dtor;
-      callback_interface_.dtor_type_ = 1;
+      callback_data_.dtor_callback_ = Fl_Callback_User_Data::default_dtor_callback;
+      callback_data_.dtor_type_ = 1;
     }
   }
   void argument(long v) {
     user_data(fl_voidptr(v));
   }
   // -- Callback getters
-  Callback_voidp* callback() const {
+  // The return value of this method should only ever be compared to nullptr!
+  Callback_T_voidp* callback() const {
     if (static_cast<const T*>(this)->callback_is_stdf()) {
-      if (!callback_interface_.stdf_callback_) {
+      // For std::function, only a comparison to nullptr is meaningful.
+      if (!callback_data_.stdf_callback_) {
         return nullptr;
       } else {
-        return callback_interface_.dummy_callback;
+        return callback_data_.dummy_callback;
       }
     } else {
-      return callback_interface_.callback_;
+      // Returned for backward compatibility.
+      return callback_data_.callback_t_voidp_;
     }
   }
   void* user_data() const {
     if (static_cast<const T*>(this)->callback_is_stdf()) {
       return nullptr;
     } else {
-      return callback_interface_.user_data_;
+      return callback_data_.user_data_;
     }
   }
   long argument() const {
@@ -249,13 +316,24 @@ public:
   void do_callback(T *widget, void *arg = 0, Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {
     // default implementation, specialisation in Fl_Widget
     T* self = static_cast<T*>(this);
-    Fl::callback_reason_ = reason;
     if (self->callback_is_stdf()) {
-      if (!callback_interface_.stdf_callback_) return;
-      callback_interface_.stdf_callback_();
+      if (!callback_data_.stdf_callback_) return;
+      Fl::callback_reason_ = reason;
+      callback_data_.stdf_callback_();
     } else {
-      if (!callback_interface_.callback_) return;
-      callback_interface_.callback_(widget, arg);
+      // Return early if the callback is nullptr. Legal, because all callback
+      // pointers are the same element in a union.
+      if (!callback_data_.callback_t_voidp_) return;
+      Fl::callback_reason_ = reason;
+      // Dispatch strictly by cb_type_ to avoid C++ undefined behavior.
+      switch (callback_data_.cb_type_) {
+        case 1: callback_data_.callback_t_voidp_(widget, arg); break;
+        case 2: callback_data_.callback_t_long_(widget, fl_long(arg)); break;
+        case 3: callback_data_.callback_t_empty_(widget); break;
+        case 4: callback_data_.callback_voidp_(arg); break;
+        case 5: callback_data_.callback_long_(fl_long(arg)); break;
+        default: break; // Ignore.
+      }
     }
   }
 };

--- a/FL/Fl_Callback_Interface.H
+++ b/FL/Fl_Callback_Interface.H
@@ -91,7 +91,12 @@ class Fl_Callback_Interface
     };
     static void dummy_callback(T*, void*) {}
 
-    Callback_Interface() = default;
+    Callback_Interface() {
+      callback_ = nullptr;
+      dtor_callback_ = nullptr; // union: also clears free_callback_
+      user_data_ = nullptr;
+      dtor_type_ = 0;
+    }
     ~Callback_Interface() {};
     void do_dtor_callback(T* t) {
       if (!t->callback_is_stdf()) {

--- a/FL/Fl_Callback_Interface.H
+++ b/FL/Fl_Callback_Interface.H
@@ -40,8 +40,11 @@
  */
 class FL_EXPORT Fl_Callback_User_Data {
 protected:
-  Fl_Callback_User_Data() {} ///< Protected constructor
+  Fl_Callback_User_Data() {} ///< Protected constructor forces user to derive from this class
 public:
+  static void default_dtor_callback(Fl_Callback_User_Data* self) {
+    delete self;
+  }
   virtual ~Fl_Callback_User_Data() { } ///< Destructor
 };
 
@@ -63,20 +66,27 @@ class Fl_Callback_Interface
   typedef void (Callback_long)(T*, long);
   typedef void (Callback_empty)(T*);
   typedef void (Callback_flud)(T*, Fl_Callback_User_Data*);
+  typedef void (Callback_flud_dtor)(Fl_Callback_User_Data*);
 
   // -- implementation calls to avoid naming conflicts
   class Callback_Interface {
   public:
-    Callback_voidp* callback_;
-    void* user_data_;
-    unsigned int auto_delete_:1;
+    Callback_voidp* callback_ = nullptr;
+    Callback_flud_dtor* dtor_callback_ = nullptr;
+    void* user_data_ = nullptr;
 
-    Callback_Interface()
-    : auto_delete_(0) {
-    }
+    Callback_Interface() = default;
     ~Callback_Interface() {
-      if (auto_delete_ && user_data_)
-        delete (Fl_Callback_User_Data*)user_data_;
+      clear_user_data();
+    }
+    void do_dtor_callback() {
+      if (dtor_callback_)
+        dtor_callback_((Fl_Callback_User_Data*)user_data_);
+    }
+    void clear_user_data() {
+      do_dtor_callback();
+      dtor_callback_ = nullptr;
+      user_data_ = nullptr;
     }
   };
   Callback_Interface callback_interface_;
@@ -98,28 +108,27 @@ public:
   }
   void callback(Callback_voidp* cb){
     callback_interface_.callback_ = cb;
+    user_data(nullptr); // original does not clear user_data!
   }
   void callback(Callback_empty* cb) {
     callback_interface_.callback_ = (Callback_voidp*)(fl_intptr_t)(cb);
+    user_data(nullptr); // original does not clear user_data!
   }
   void callback(Callback_long* cb, long p = 0) {
     callback_interface_.callback_ = (Callback_voidp*)(fl_intptr_t)(cb);
-    user_data((void*)(fl_intptr_t)p);
-
+    user_data(fl_voidptr(p));
   }
   void user_data(void* v) {
-    if (callback_interface_.auto_delete_ && callback_interface_.user_data_)
-    delete (Fl_Callback_User_Data*)callback_interface_.user_data_;
-    callback_interface_.auto_delete_ = 0;
+    callback_interface_.clear_user_data();
     callback_interface_.user_data_ = v;
   }
   void user_data(Fl_Callback_User_Data* v, bool auto_free) {
     user_data((void*)v);
     if (auto_free)
-      callback_interface_.auto_delete_ = 1;
+      callback_interface_.dtor_callback_ = Fl_Callback_User_Data::default_dtor_callback;
   }
   void argument(long v) {
-    user_data((void*)(fl_intptr_t)v);
+    user_data(fl_voidptr(v));
   }
   // -- Callback getters
   Callback_voidp* callback() const {
@@ -129,14 +138,14 @@ public:
     return callback_interface_.user_data_;
   }
   long argument() const {
-    return (long)(fl_intptr_t)callback_interface_.user_data_;
+    return fl_long(callback_interface_.user_data_);
   }
   // -- callback actions
   void do_callback(Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {
     static_cast<T*>(this)->do_callback(static_cast<T*>(this), callback_interface_.user_data_, reason);
   }
   void do_callback(T *widget, long arg, Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {
-    static_cast<T*>(this)->do_callback(widget, (void*)(fl_intptr_t)arg, reason);
+    static_cast<T*>(this)->do_callback(widget, fl_voidptr(arg), reason);
   }
   void do_callback(T *widget, void *arg = 0, Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {
     // default implementation, specialisation in Fl_Widget

--- a/FL/Fl_Callback_Interface.H
+++ b/FL/Fl_Callback_Interface.H
@@ -59,6 +59,8 @@ public:
 /**
  Add callback functionality to the class T.
 
+ Classes that use this interface must implement the following functions that
+ simply get, set, and clear a bit, must be false initially:
  `callback_is_stdf()`, `set_callback_stdf()`, and `clear_callback_stdf()`.
 
  \param T The class to add callback functionality to.
@@ -75,69 +77,98 @@ class Fl_Callback_Interface
   // -- implementation calls to avoid naming conflicts
   class Callback_Interface {
   public:
-    Callback_voidp* callback_ = nullptr;
     union {
-      Fl_Callback_User_Data_Dtor* dtor_callback_ = nullptr;
-      Fl_Callback_Free* free_callback_;
+      struct {
+        Callback_voidp* callback_ = nullptr;
+        union {
+          Fl_Callback_User_Data_Dtor* dtor_callback_ = nullptr;
+          Fl_Callback_Free* free_callback_;
+        };
+        void* user_data_ = nullptr;
+        uint8_t dtor_type_ = 0; // 0 = none, 1 = dtor_callback_, 2 = free_callback_
+      };
+      std::function<void()> stdf_callback_;
     };
-    void* user_data_ = nullptr;
-    uint8_t dtor_type_ = 0; // 0 = none, 1 = dtor_callback_, 2 = free_callback_
+    static void dummy_callback(T*, void*) {}
 
     Callback_Interface() = default;
-    ~Callback_Interface() {
-      clear_user_data();
-    }
-    void do_dtor_callback() {
-      if (dtor_type_ == 1) { // dtor_callback_
-        if (dtor_callback_)
-          dtor_callback_((Fl_Callback_User_Data*)user_data_);
-      } else if (dtor_type_ == 2) { // free_callback_
-        if (free_callback_)
-          free_callback_(user_data_);
+    ~Callback_Interface() {};
+    void do_dtor_callback(T* t) {
+      if (!t->callback_is_stdf()) {
+        if (dtor_type_ == 1) { // dtor_callback_
+          if (dtor_callback_)
+            dtor_callback_((Fl_Callback_User_Data*)user_data_);
+        } else if (dtor_type_ == 2) { // free_callback_
+          if (free_callback_)
+            free_callback_(user_data_);
+        }
       }
     }
-    void clear_user_data() {
-      do_dtor_callback();
-      dtor_callback_ = nullptr; // union: also clears free_callback_
-      user_data_ = nullptr;
-      dtor_type_ = 0;
+    void clear_user_data(T* t) {
+      if (!t->callback_is_stdf()) {
+        do_dtor_callback(t);
+        dtor_callback_ = nullptr; // union: also clears free_callback_
+        user_data_ = nullptr;
+        dtor_type_ = 0;
+      }
+    }
+    void clear(T* t) {
+      if (!t->callback_is_stdf()) {
+        clear_user_data(t);
+        callback_ = nullptr;
+      } else {
+        stdf_callback_ = nullptr;
+      }
     }
   };
-  Callback_Interface callback_interface_;
 
 protected:
   // -- ctor and dtor
+  Callback_Interface callback_interface_;
   Fl_Callback_Interface() = default;
-  ~Fl_Callback_Interface() = default;
+  ~Fl_Callback_Interface() {
+    callback_interface_.clear(static_cast<T*>(this));
+  }
 
 public:
   // -- public interface
   void callback(Callback_voidp* cb, void* p, Fl_Callback_Free* free_cb = nullptr) {
+    callback_interface_.clear(static_cast<T*>(this));
     callback_interface_.callback_ = cb;
     user_data(p, free_cb);
   }
   void callback(Callback_voidp* cb, Fl_Callback_User_Data* p, bool auto_free) {
+    callback_interface_.clear(static_cast<T*>(this));
     callback_interface_.callback_ = cb;
     user_data(p, auto_free);
   }
   void callback(Callback_voidp* cb, Fl_Callback_User_Data* p, Fl_Callback_User_Data_Dtor* dtor) {
+    callback_interface_.clear(static_cast<T*>(this));
     callback_interface_.callback_ = cb;
     user_data(p, dtor);
   }
   void callback(Callback_voidp* cb){
+    callback_interface_.clear(static_cast<T*>(this));
     callback_interface_.callback_ = cb;
     user_data(nullptr); // original does not clear user_data!
   }
   void callback(Callback_empty* cb) {
+    callback_interface_.clear(static_cast<T*>(this));
     callback_interface_.callback_ = (Callback_voidp*)(fl_intptr_t)(cb);
     user_data(nullptr); // original does not clear user_data!
   }
   void callback(Callback_long* cb, long p = 0) {
+    callback_interface_.clear(static_cast<T*>(this));
     callback_interface_.callback_ = (Callback_voidp*)(fl_intptr_t)(cb);
     user_data(fl_voidptr(p));
   }
+  void callback(std::function<void()> cb) {
+    callback_interface_.clear(static_cast<T*>(this));
+    static_cast<T*>(this)->set_callback_stdf();
+    callback_interface_.stdf_callback_ = cb;
+  }
   void user_data(void* v, Fl_Callback_Free* free_cb = nullptr) {
-    callback_interface_.clear_user_data();
+    callback_interface_.clear_user_data(static_cast<T*>(this));
     callback_interface_.user_data_ = v;
     if (free_cb) {
       callback_interface_.free_callback_ = free_cb;
@@ -145,14 +176,16 @@ public:
     }
   }
   void user_data(Fl_Callback_User_Data* v, bool auto_free) {
-    user_data((void*)v);
+    callback_interface_.clear_user_data(static_cast<T*>(this));
+    callback_interface_.user_data_ = v;
     if (auto_free) {
       callback_interface_.dtor_callback_ = Fl_Callback_User_Data::default_dtor_callback;
       callback_interface_.dtor_type_ = 1;
     }
   }
   void user_data(Fl_Callback_User_Data* v, Fl_Callback_User_Data_Dtor* dtor) {
-    user_data((void*)v);
+    callback_interface_.clear_user_data(static_cast<T*>(this));
+    callback_interface_.user_data_ = v;
     if (dtor) {
       callback_interface_.dtor_callback_ = dtor;
       callback_interface_.dtor_type_ = 1;
@@ -163,13 +196,25 @@ public:
   }
   // -- Callback getters
   Callback_voidp* callback() const {
-    return callback_interface_.callback_;
+    if (static_cast<const T*>(this)->callback_is_stdf()) {
+      if (callback_interface_.callback_ == nullptr) {
+        return nullptr;
+      } else {
+        return callback_interface_.dummy_callback;
+      }
+    } else {
+      return callback_interface_.callback_;
+    }
   }
   void* user_data() const {
-    return callback_interface_.user_data_;
+    if (static_cast<const T*>(this)->callback_is_stdf()) {
+      return nullptr;
+    } else {
+      return callback_interface_.user_data_;
+    }
   }
   long argument() const {
-    return fl_long(callback_interface_.user_data_);
+    return fl_long(user_data());
   }
   // -- callback actions
   void do_callback(Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {
@@ -181,12 +226,13 @@ public:
   void do_callback(T *widget, void *arg = 0, Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {
     // default implementation, specialisation in Fl_Widget
     Fl::callback_reason_ = reason;
-    if (!callback_interface_.callback_) return;
-    // Fl_Widget_Tracker wp(this);
-    callback_interface_.callback_(widget, arg);
-    // if (wp.deleted()) return;
-    // if (callback_interface_.callback_ != T::default_callback)
-    //   static_cast<T*>(this)->clear_changed();
+    if (static_cast<T*>(this)->callback_is_stdf()) {
+      if (!callback_interface_.stdf_callback_) return;
+      callback_interface_.stdf_callback_();
+    } else {
+      if (!callback_interface_.callback_) return;
+      callback_interface_.callback_(widget, arg);
+    }
   }
 };
 

--- a/FL/Fl_Callback_Interface.H
+++ b/FL/Fl_Callback_Interface.H
@@ -25,8 +25,10 @@
 #ifndef Fl_Callback_User_Data_H
 #define Fl_Callback_User_Data_H
 
-/** Callback function type that takes a Fl_Callback_User_Data pointer as its argument. */
+/** Callback function type for a user defined Fl_Callback_User_Data destructor. */
 typedef void (Fl_Callback_User_Data_Dtor)(class Fl_Callback_User_Data*);
+/** Callback function type to free `void*` based user data. */
+typedef void (Fl_Callback_Free)(void*);
 
 /** A class prototype that allows for additional data in callbacks.
 
@@ -74,21 +76,31 @@ class Fl_Callback_Interface
   class Callback_Interface {
   public:
     Callback_voidp* callback_ = nullptr;
-    Fl_Callback_User_Data_Dtor* dtor_callback_ = nullptr;
+    union {
+      Fl_Callback_User_Data_Dtor* dtor_callback_ = nullptr;
+      Fl_Callback_Free* free_callback_;
+    };
     void* user_data_ = nullptr;
+    uint8_t dtor_type_ = 0; // 0 = none, 1 = dtor_callback_, 2 = free_callback_
 
     Callback_Interface() = default;
     ~Callback_Interface() {
       clear_user_data();
     }
     void do_dtor_callback() {
-      if (dtor_callback_)
-        dtor_callback_((Fl_Callback_User_Data*)user_data_);
+      if (dtor_type_ == 1) { // dtor_callback_
+        if (dtor_callback_)
+          dtor_callback_((Fl_Callback_User_Data*)user_data_);
+      } else if (dtor_type_ == 2) { // free_callback_
+        if (free_callback_)
+          free_callback_(user_data_);
+      }
     }
     void clear_user_data() {
       do_dtor_callback();
-      dtor_callback_ = nullptr;
+      dtor_callback_ = nullptr; // union: also clears free_callback_
       user_data_ = nullptr;
+      dtor_type_ = 0;
     }
   };
   Callback_Interface callback_interface_;
@@ -100,9 +112,9 @@ protected:
 
 public:
   // -- public interface
-  void callback(Callback_voidp* cb, void* p) {
+  void callback(Callback_voidp* cb, void* p, Fl_Callback_Free* free_cb = nullptr) {
     callback_interface_.callback_ = cb;
-    user_data(p);
+    user_data(p, free_cb);
   }
   void callback(Callback_voidp* cb, Fl_Callback_User_Data* p, bool auto_free) {
     callback_interface_.callback_ = cb;
@@ -124,18 +136,27 @@ public:
     callback_interface_.callback_ = (Callback_voidp*)(fl_intptr_t)(cb);
     user_data(fl_voidptr(p));
   }
-  void user_data(void* v) {
+  void user_data(void* v, Fl_Callback_Free* free_cb = nullptr) {
     callback_interface_.clear_user_data();
     callback_interface_.user_data_ = v;
+    if (free_cb) {
+      callback_interface_.free_callback_ = free_cb;
+      callback_interface_.dtor_type_ = 2;
+    }
   }
   void user_data(Fl_Callback_User_Data* v, bool auto_free) {
     user_data((void*)v);
-    if (auto_free)
+    if (auto_free) {
       callback_interface_.dtor_callback_ = Fl_Callback_User_Data::default_dtor_callback;
+      callback_interface_.dtor_type_ = 1;
+    }
   }
   void user_data(Fl_Callback_User_Data* v, Fl_Callback_User_Data_Dtor* dtor) {
     user_data((void*)v);
-    callback_interface_.dtor_callback_ = dtor;
+    if (dtor) {
+      callback_interface_.dtor_callback_ = dtor;
+      callback_interface_.dtor_type_ = 1;
+    }
   }
   void argument(long v) {
     user_data(fl_voidptr(v));

--- a/FL/Fl_Callback_Interface.H
+++ b/FL/Fl_Callback_Interface.H
@@ -142,11 +142,11 @@ public:
     // default implementation, specialisation in Fl_Widget
     Fl::callback_reason_ = reason;
     if (!callback_interface_.callback_) return;
-    Fl_Widget_Tracker wp(this);
+    // Fl_Widget_Tracker wp(this);
     callback_interface_.callback_(widget, arg);
-    if (wp.deleted()) return;
-    if (callback_interface_.callback_ != T::default_callback)
-      static_cast<T*>(this)->clear_changed();
+    // if (wp.deleted()) return;
+    // if (callback_interface_.callback_ != T::default_callback)
+    //   static_cast<T*>(this)->clear_changed();
   }
 };
 

--- a/FL/Fl_Callback_Interface.H
+++ b/FL/Fl_Callback_Interface.H
@@ -25,6 +25,9 @@
 #ifndef Fl_Callback_User_Data_H
 #define Fl_Callback_User_Data_H
 
+/** Callback function type that takes a Fl_Callback_User_Data pointer as its argument. */
+typedef void (Fl_Callback_User_Data_Dtor)(class Fl_Callback_User_Data*);
+
 /** A class prototype that allows for additional data in callbacks.
 
  Users can derive this class and pass objects of such derived classes to widget callbacks.
@@ -66,13 +69,12 @@ class Fl_Callback_Interface
   typedef void (Callback_long)(T*, long);
   typedef void (Callback_empty)(T*);
   typedef void (Callback_flud)(T*, Fl_Callback_User_Data*);
-  typedef void (Callback_flud_dtor)(Fl_Callback_User_Data*);
 
   // -- implementation calls to avoid naming conflicts
   class Callback_Interface {
   public:
     Callback_voidp* callback_ = nullptr;
-    Callback_flud_dtor* dtor_callback_ = nullptr;
+    Fl_Callback_User_Data_Dtor* dtor_callback_ = nullptr;
     void* user_data_ = nullptr;
 
     Callback_Interface() = default;
@@ -106,6 +108,10 @@ public:
     callback_interface_.callback_ = cb;
     user_data(p, auto_free);
   }
+  void callback(Callback_voidp* cb, Fl_Callback_User_Data* p, Fl_Callback_User_Data_Dtor* dtor) {
+    callback_interface_.callback_ = cb;
+    user_data(p, dtor);
+  }
   void callback(Callback_voidp* cb){
     callback_interface_.callback_ = cb;
     user_data(nullptr); // original does not clear user_data!
@@ -126,6 +132,10 @@ public:
     user_data((void*)v);
     if (auto_free)
       callback_interface_.dtor_callback_ = Fl_Callback_User_Data::default_dtor_callback;
+  }
+  void user_data(Fl_Callback_User_Data* v, Fl_Callback_User_Data_Dtor* dtor) {
+    user_data((void*)v);
+    callback_interface_.dtor_callback_ = dtor;
   }
   void argument(long v) {
     user_data(fl_voidptr(v));

--- a/FL/Fl_Callback_Interface.H
+++ b/FL/Fl_Callback_Interface.H
@@ -79,13 +79,13 @@ class Fl_Callback_Interface
   public:
     union {
       struct {
-        Callback_voidp* callback_ = nullptr;
+        Callback_voidp* callback_;
         union {
-          Fl_Callback_User_Data_Dtor* dtor_callback_ = nullptr;
+          Fl_Callback_User_Data_Dtor* dtor_callback_;
           Fl_Callback_Free* free_callback_;
         };
-        void* user_data_ = nullptr;
-        uint8_t dtor_type_ = 0; // 0 = none, 1 = dtor_callback_, 2 = free_callback_
+        void* user_data_;
+        uint8_t dtor_type_; // 0 = none, 1 = dtor_callback_, 2 = free_callback_
       };
       std::function<void()> stdf_callback_;
     };

--- a/FL/Fl_Callback_Interface.H
+++ b/FL/Fl_Callback_Interface.H
@@ -1,0 +1,154 @@
+//
+// Callback template header file for the Fast Light Tool Kit (FLTK).
+//
+// Copyright 2026 by Bill Spitzak and others.
+//
+// This library is free software. Distribution and use rights are outlined in
+// the file "COPYING" which should have been included with this file. If this
+// file is missing or damaged, see the license at:
+//
+//     https://www.fltk.org/COPYING.php
+//
+// Please see the following page on how to report bugs and issues:
+//
+//     https://www.fltk.org/bugs.php
+//
+
+#ifndef Fl_Callback_Interface_H
+#define Fl_Callback_Interface_H
+
+#include "Fl.H"
+
+#include <functional>
+
+
+#ifndef Fl_Callback_User_Data_H
+#define Fl_Callback_User_Data_H
+
+/** A class prototype that allows for additional data in callbacks.
+
+ Users can derive this class and pass objects of such derived classes to widget callbacks.
+ Widgets can take ownership of the callback data, deleting the data when the widget
+ itself is deleted.
+
+ The destructor of this class is virtual, allowing for additional code to
+ deallocate resources when the user data is deleted.
+
+ \see FL_FUNCTION_CALLBACK_3, FL_METHOD_CALLBACK_1, FL_INLINE_CALLBACK_2
+ \see Fl_Widget::callback(Fl_Callback*, Fl_Callback_User_Data*, bool)
+ \see Fl_Widget::user_data(Fl_Callback_User_Data*, bool)
+ */
+class FL_EXPORT Fl_Callback_User_Data {
+protected:
+  Fl_Callback_User_Data() {} ///< Protected constructor
+public:
+  virtual ~Fl_Callback_User_Data() { } ///< Destructor
+};
+
+#endif // Fl_Callback_User_Data_H
+
+
+/**
+ Add callback functionality to the class T.
+
+ `callback_is_stdf()`, `set_callback_stdf()`, and `clear_callback_stdf()`.
+
+ \param T The class to add callback functionality to.
+ */
+template <typename T>
+class Fl_Callback_Interface
+{
+  // -- types
+  typedef void (Callback_voidp)(T*, void*);
+  typedef void (Callback_long)(T*, long);
+  typedef void (Callback_empty)(T*);
+  typedef void (Callback_flud)(T*, Fl_Callback_User_Data*);
+
+  // -- implementation calls to avoid naming conflicts
+  class Callback_Interface {
+  public:
+    Callback_voidp* callback_;
+    void* user_data_;
+    unsigned int auto_delete_:1;
+
+    Callback_Interface()
+    : auto_delete_(0) {
+    }
+    ~Callback_Interface() {
+      if (auto_delete_ && user_data_)
+        delete (Fl_Callback_User_Data*)user_data_;
+    }
+  };
+  Callback_Interface callback_interface_;
+
+protected:
+  // -- ctor and dtor
+  Fl_Callback_Interface() = default;
+  ~Fl_Callback_Interface() = default;
+
+public:
+  // -- public interface
+  void callback(Callback_voidp* cb, void* p) {
+    callback_interface_.callback_ = cb;
+    user_data(p);
+  }
+  void callback(Callback_voidp* cb, Fl_Callback_User_Data* p, bool auto_free) {
+    callback_interface_.callback_ = cb;
+    user_data(p, auto_free);
+  }
+  void callback(Callback_voidp* cb){
+    callback_interface_.callback_ = cb;
+  }
+  void callback(Callback_empty* cb) {
+    callback_interface_.callback_ = (Callback_voidp*)(fl_intptr_t)(cb);
+  }
+  void callback(Callback_long* cb, long p = 0) {
+    callback_interface_.callback_ = (Callback_voidp*)(fl_intptr_t)(cb);
+    user_data((void*)(fl_intptr_t)p);
+
+  }
+  void user_data(void* v) {
+    if (callback_interface_.auto_delete_ && callback_interface_.user_data_)
+    delete (Fl_Callback_User_Data*)callback_interface_.user_data_;
+    callback_interface_.auto_delete_ = 0;
+    callback_interface_.user_data_ = v;
+  }
+  void user_data(Fl_Callback_User_Data* v, bool auto_free) {
+    user_data((void*)v);
+    if (auto_free)
+      callback_interface_.auto_delete_ = 1;
+  }
+  void argument(long v) {
+    user_data((void*)(fl_intptr_t)v);
+  }
+  // -- Callback getters
+  Callback_voidp* callback() const {
+    return callback_interface_.callback_;
+  }
+  void* user_data() const {
+    return callback_interface_.user_data_;
+  }
+  long argument() const {
+    return (long)(fl_intptr_t)callback_interface_.user_data_;
+  }
+  // -- callback actions
+  void do_callback(Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {
+    static_cast<T*>(this)->do_callback(static_cast<T*>(this), callback_interface_.user_data_, reason);
+  }
+  void do_callback(T *widget, long arg, Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {
+    static_cast<T*>(this)->do_callback(widget, (void*)(fl_intptr_t)arg, reason);
+  }
+  void do_callback(T *widget, void *arg = 0, Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {
+    // default implementation, specialisation in Fl_Widget
+    Fl::callback_reason_ = reason;
+    if (!callback_interface_.callback_) return;
+    Fl_Widget_Tracker wp(this);
+    callback_interface_.callback_(widget, arg);
+    if (wp.deleted()) return;
+    if (callback_interface_.callback_ != T::default_callback)
+      static_cast<T*>(this)->clear_changed();
+  }
+};
+
+
+#endif // Fl_Callback_Interface_H

--- a/FL/Fl_Callback_Interface.H
+++ b/FL/Fl_Callback_Interface.H
@@ -20,6 +20,7 @@
 #include "Fl.H"
 
 #include <functional>
+#include <new>
 
 
 #ifndef Fl_Callback_User_Data_H
@@ -91,11 +92,12 @@ class Fl_Callback_Interface
     };
     static void dummy_callback(T*, void*) {}
 
-    Callback_Interface() {
-      callback_ = nullptr;
-      dtor_callback_ = nullptr; // union: also clears free_callback_
-      user_data_ = nullptr;
-      dtor_type_ = 0;
+    Callback_Interface()
+      : callback_(nullptr)
+      , dtor_callback_(nullptr) // union: also clears free_callback_
+      , user_data_(nullptr)
+      , dtor_type_(0)
+    {
     }
     ~Callback_Interface() {};
     void do_dtor_callback(T* t) {
@@ -118,11 +120,18 @@ class Fl_Callback_Interface
       }
     }
     void clear(T* t) {
-      if (!t->callback_is_stdf()) {
+      if (t->callback_is_stdf()) {
+        // stdf_callback_ is the active union member: end its lifetime
+        // explicitly before the struct alternative below is reactivated.
+        stdf_callback_.~function();
+        t->clear_callback_stdf();
+        callback_ = nullptr;
+        dtor_callback_ = nullptr; // union: also clears free_callback_
+        user_data_ = nullptr;
+        dtor_type_ = 0;
+      } else {
         clear_user_data(t);
         callback_ = nullptr;
-      } else {
-        stdf_callback_ = nullptr;
       }
     }
   };
@@ -168,11 +177,16 @@ public:
     user_data(fl_voidptr(p));
   }
   void callback(std::function<void()> cb) {
+    // clear() always leaves the struct alternative active (and stdf false),
+    // so the union storage here is raw and safe to placement-new into.
     callback_interface_.clear(static_cast<T*>(this));
     static_cast<T*>(this)->set_callback_stdf();
-    callback_interface_.stdf_callback_ = cb;
+    new (&callback_interface_.stdf_callback_) std::function<void()>(std::move(cb));
   }
   void user_data(void* v, Fl_Callback_Free* free_cb = nullptr) {
+    // user data has no meaning while the union's active member is
+    // stdf_callback_; skip so we don't write over the live std::function.
+    if (static_cast<T*>(this)->callback_is_stdf()) return;
     callback_interface_.clear_user_data(static_cast<T*>(this));
     callback_interface_.user_data_ = v;
     if (free_cb) {
@@ -181,6 +195,7 @@ public:
     }
   }
   void user_data(Fl_Callback_User_Data* v, bool auto_free) {
+    if (static_cast<T*>(this)->callback_is_stdf()) return;
     callback_interface_.clear_user_data(static_cast<T*>(this));
     callback_interface_.user_data_ = v;
     if (auto_free) {
@@ -189,6 +204,7 @@ public:
     }
   }
   void user_data(Fl_Callback_User_Data* v, Fl_Callback_User_Data_Dtor* dtor) {
+    if (static_cast<T*>(this)->callback_is_stdf()) return;
     callback_interface_.clear_user_data(static_cast<T*>(this));
     callback_interface_.user_data_ = v;
     if (dtor) {
@@ -202,7 +218,7 @@ public:
   // -- Callback getters
   Callback_voidp* callback() const {
     if (static_cast<const T*>(this)->callback_is_stdf()) {
-      if (callback_interface_.callback_ == nullptr) {
+      if (!callback_interface_.stdf_callback_) {
         return nullptr;
       } else {
         return callback_interface_.dummy_callback;
@@ -223,15 +239,18 @@ public:
   }
   // -- callback actions
   void do_callback(Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {
-    static_cast<T*>(this)->do_callback(static_cast<T*>(this), callback_interface_.user_data_, reason);
+    T* self = static_cast<T*>(this);
+    self->do_callback(self, user_data(), reason);
   }
   void do_callback(T *widget, long arg, Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {
-    static_cast<T*>(this)->do_callback(widget, fl_voidptr(arg), reason);
+    T* self = static_cast<T*>(this);
+    self->do_callback(widget, fl_voidptr(arg), reason);
   }
   void do_callback(T *widget, void *arg = 0, Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {
     // default implementation, specialisation in Fl_Widget
+    T* self = static_cast<T*>(this);
     Fl::callback_reason_ = reason;
-    if (static_cast<T*>(this)->callback_is_stdf()) {
+    if (self->callback_is_stdf()) {
       if (!callback_interface_.stdf_callback_) return;
       callback_interface_.stdf_callback_();
     } else {

--- a/FL/Fl_File_Chooser.H
+++ b/FL/Fl_File_Chooser.H
@@ -70,6 +70,7 @@ private:
   void showChoiceCB();
   void update_favorites();
   void update_preview();
+  bool callback_is_stdf_ = false;
 public:
   Fl_File_Chooser(const char *pathname, const char *pattern, int type_val, const char *title);
 private:
@@ -134,6 +135,9 @@ private:
   static void cb_favOkButton(Fl_Return_Button*, void*);
 public:
   ~Fl_File_Chooser();
+  bool callback_is_stdf() const { return callback_is_stdf_; }
+  void set_callback_stdf() { callback_is_stdf_ = true; }
+  void clear_callback_stdf() { callback_is_stdf_ = false; }
   void color(Fl_Color c);
   Fl_Color color();
   int count();

--- a/FL/Fl_File_Chooser.H
+++ b/FL/Fl_File_Chooser.H
@@ -26,6 +26,7 @@
 #ifndef Fl_File_Chooser_H
 #define Fl_File_Chooser_H
 #include <FL/Fl.H>
+#include <FL/Fl_Callback_Interface.H>
 #include <FL/Fl_Double_Window.H>
 #include <FL/Fl_Group.H>
 #include <FL/Fl_Choice.H>
@@ -40,7 +41,7 @@
 #include <FL/Fl_Return_Button.H>
 #include <FL/fl_ask.H>
 
-class FL_EXPORT Fl_File_Chooser {
+class FL_EXPORT Fl_File_Chooser : public Fl_Callback_Interface<Fl_File_Chooser> {
 public:
   /**
    \enum Type
@@ -56,8 +57,6 @@ public:
   };
 private:
   static Fl_Preferences *prefs_;
-  void (*callback_)(Fl_File_Chooser*, void *);
-  void *data_;
   char directory_[FL_PATH_MAX];
   char pattern_[FL_PATH_MAX];
   char preview_text_[2048];
@@ -135,7 +134,6 @@ private:
   static void cb_favOkButton(Fl_Return_Button*, void*);
 public:
   ~Fl_File_Chooser();
-  void callback(void (*cb)(Fl_File_Chooser *, void *), void *d = 0);
   void color(Fl_Color c);
   Fl_Color color();
   int count();
@@ -170,8 +168,6 @@ public:
   Fl_Fontsize textsize();
   void type(int t);
   int type();
-  void * user_data() const;
-  void user_data(void *d);
   const char *value(int f = 1);
   void value(const char *filename);
   int visible();
@@ -254,4 +250,4 @@ FL_EXPORT char *fl_dir_chooser(const char *message,const char *fname,int relativ
 FL_EXPORT char *fl_file_chooser(const char *message,const char *pat,const char *fname,int relative=0);
 FL_EXPORT void fl_file_chooser_callback(void (*cb)(const char*));
 FL_EXPORT void fl_file_chooser_ok_label(const char*l);
-#endif
+#endif // Fl_File_Chooser_H

--- a/FL/Fl_Widget.H
+++ b/FL/Fl_Widget.H
@@ -744,6 +744,7 @@ public:
   void callback(Fl_Callback* cb);
   void callback(Fl_Callback0* cb);
   void callback(Fl_Callback1* cb, long p = 0);
+  void callback(std::function<void()> cb);
   void user_data(void* v, Fl_Callback_Free* free_cb = nullptr);
   void user_data(Fl_Callback_User_Data* v, bool auto_free);
   void user_data(Fl_Callback_User_Data* v, Fl_Callback_User_Data_Dtor* dtor);

--- a/FL/Fl_Widget.H
+++ b/FL/Fl_Widget.H
@@ -23,6 +23,7 @@
 #define Fl_Widget_H
 
 #include "Fl.H"
+#include "Fl_Callback_Interface.H"
 
 class Fl_Widget;
 class Fl_Window;
@@ -76,27 +77,6 @@ struct FL_EXPORT Fl_Label {
 };
 
 
-/** A class prototype that allows for additional data in callbacks.
-
- Users can derive this class and pass objects of such derived classes to widget callbacks.
- Widgets can take ownership of the callback data, deleting the data when the widget
- itself is deleted.
-
- The destructor of this class is virtual, allowing for additional code to
- deallocate resources when the user data is deleted.
-
- \see FL_FUNCTION_CALLBACK_3, FL_METHOD_CALLBACK_1, FL_INLINE_CALLBACK_2
- \see Fl_Widget::callback(Fl_Callback*, Fl_Callback_User_Data*, bool)
- \see Fl_Widget::user_data(Fl_Callback_User_Data*, bool)
- */
-class FL_EXPORT Fl_Callback_User_Data {
-protected:
-  Fl_Callback_User_Data() {} ///< Protected constructor
-public:
-  virtual ~Fl_Callback_User_Data() { } ///< Destructor
-};
-
-
 /** Fl_Widget is the base class for all widgets in FLTK.
 
     You can't create one of these because the constructor is not public.
@@ -109,12 +89,10 @@ public:
     functions, even if they change the widget's appearance. It is up to the
     user code to call redraw() after these.
  */
-class FL_EXPORT Fl_Widget {
+class FL_EXPORT Fl_Widget : public Fl_Callback_Interface<Fl_Widget> {
   friend class Fl_Group;
 
   Fl_Group* parent_;
-  Fl_Callback* callback_;
-  void* user_data_;
   int x_,y_,w_,h_;
   Fl_Label label_;
   unsigned int flags_;
@@ -745,88 +723,35 @@ public:
   void tooltip(const char *text);               // see Fl_Tooltip
   void copy_tooltip(const char *text);          // see Fl_Tooltip
 
-  /** Gets the current callback function for the widget.
-      Each widget has a single callback.
-      \return current callback
-   */
-  Fl_Callback_p callback() const {return callback_;}
-
-  /** Sets the current callback function and data for the widget.
-      Each widget has a single callback.
-      \param[in] cb new callback
-      \param[in] p user data
-   */
-  void callback(Fl_Callback* cb, void* p) {
-    callback_ = cb;
-    user_data(p);
-  }
-
-  /** Sets the current callback function and managed user data for the widget.
-   Setting auto_free will transfer ownership of the callback user data to the
-   widget. Deleting the widget will then also delete the user data.
-   \param[in] cb new callback
-   \param[in] p user data
-   \param[in] auto_free if set, the widget will free user data when destroyed
-   */
-  void callback(Fl_Callback* cb, Fl_Callback_User_Data* p, bool auto_free) {
-    callback_ = cb;
-    user_data(p, auto_free);
-  }
-
-  /** Sets the current callback function for the widget.
-      Each widget has a single callback.
-      \param[in] cb new callback
-   */
-  void callback(Fl_Callback* cb) {callback_ = cb;}
-
-  /** Sets the current callback function for the widget.
-      Each widget has a single callback.
-      \param[in] cb new callback
-   */
-  void callback(Fl_Callback0* cb) {
-    callback_ = (Fl_Callback*)(fl_intptr_t)(cb);
-  }
-
-  /** Sets the current callback function for the widget.
-      Each widget has a single callback.
-      \param[in] cb new callback
-      \param[in] p user data
-   */
-  void callback(Fl_Callback1* cb, long p = 0) {
-    callback_ = (Fl_Callback*)(fl_intptr_t)(cb);
-    user_data((void*)(fl_intptr_t)p);
-  }
-
-  /** Gets the user data for this widget.
-      Gets the current user data (void *) argument that is passed to the callback function.
-      \return user data as a pointer
-   */
-  void* user_data() const {return user_data_;}
-
-  /** \brief Sets the user data for this widget. */
+#ifdef FL_DOXYGEN
+  // These stubs are used to create Doxygen documentation.
+  // The documentation itself is at the end of Fl_Widget.cxx.
+  // -- Callback setters
+  void callback(Fl_Callback* cb, void* p);
+  void callback(Fl_Callback* cb, Fl_Callback_User_Data* p, bool auto_free);
+  void callback(Fl_Callback* cb);
+  void callback(Fl_Callback0* cb);
+  void callback(Fl_Callback1* cb, long p = 0);
   void user_data(void* v);
-
-  /** \brief Sets the user data for this widget. */
   void user_data(Fl_Callback_User_Data* v, bool auto_free);
+  void argument(long v);
+  // -- Callback getters
+  Fl_Callback_p callback() const;
+  void* user_data() const;
+  long argument() const;
+  // -- callback actions
+  void do_callback(Fl_Callback_Reason reason=FL_REASON_UNKNOWN);
+  void do_callback(Fl_Widget *widget, long arg, Fl_Callback_Reason reason=FL_REASON_UNKNOWN);
+  void do_callback(Fl_Widget *widget, void *arg = 0, Fl_Callback_Reason reason=FL_REASON_UNKNOWN);
+#else // FL_DOXYGEN
+  // These are function declarations in addition to the actual implementations
+  // in the Fl_Callback_Interface class.
 
-  /** Gets the current user data (long) argument that is passed to the callback function.
-
-    \note On platforms with <tt>sizeof(long) \< sizeof(void*)</tt>, particularly
-          on Windows 64-bit platforms, this method can truncate stored addresses
-          \p (void*) to the size of a \p long value. Use with care and only
-          if you are sure that the stored user_data value fits in a \p long
-          value because it was stored with argument(long) or another method
-          using only \p long values. You may want to use user_data() instead.
-
-    \see user_data()
-  */
-  long argument() const {return (long)(fl_intptr_t)user_data_;}
-
-  /** Sets the current user data (long) argument that is passed to the callback function.
-
-    \see argument()
-   */
-  void argument(long v) {user_data((void*)(fl_intptr_t)v);}
+  // Make sure that other versions of Fl_Callback_Interface<Fl_Widget>::do_callback() are visible in Fl_Widget
+  using Fl_Callback_Interface<Fl_Widget>::do_callback;
+  // Specialisation of Fl_Callback_Interface<Fl_Widget>::do_callback() for Fl_Widget
+  void do_callback(Fl_Widget *widget, void *arg = 0, Fl_Callback_Reason reason=FL_REASON_UNKNOWN);
+#endif // FL_DOXYGEN
 
   /** Returns the conditions under which the callback is called.
 
@@ -1085,33 +1010,6 @@ public:
     \see do_callback(Fl_Widget *widget, void *data)
    */
   static void default_callback(Fl_Widget *widget, void *data);
-
-  /** Calls the widget callback function with default arguments.
-
-    This is the same as calling
-    \code
-      do_callback(this, user_data(), reason);
-    \endcode
-
-    \param[in] reason give a reason to why this callback was called, defaults to \ref FL_REASON_UNKNOWN
-
-    \see callback()
-    \see do_callback(Fl_Widget *widget, void *data, Fl_Callback_Reason reason), Fl_Callback_Reason
-  */
-  void do_callback(Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {do_callback(this, user_data_, reason);}
-
-  /** Calls the widget callback function with arbitrary arguments.
-    \param[in] widget call the callback with \p widget as the first argument
-    \param[in] arg call the callback with \p arg as the user data (second) argument
-    \param[in] reason give a reason to why this callback was called, defaults to \ref FL_REASON_UNKNOWN
-    \see callback()
-    \see do_callback(Fl_Widget *widget, void *data), Fl_Callback_Reason
-  */
-  void do_callback(Fl_Widget *widget, long arg, Fl_Callback_Reason reason=FL_REASON_UNKNOWN) {
-    do_callback(widget, (void*)(fl_intptr_t)arg, reason);
-  }
-
-  void do_callback(Fl_Widget *widget, void *arg = 0, Fl_Callback_Reason reason=FL_REASON_UNKNOWN);
 
   /* Internal use only. */
   int test_shortcut();

--- a/FL/Fl_Widget.H
+++ b/FL/Fl_Widget.H
@@ -727,13 +727,13 @@ public:
   // These stubs are used to create Doxygen documentation.
   // The documentation itself is at the end of Fl_Widget.cxx.
   // -- Callback setters
-  void callback(Fl_Callback* cb, void* p);
+  void callback(Fl_Callback* cb, void* p, Fl_Callback_Free* free_cb = nullptr);
   void callback(Fl_Callback* cb, Fl_Callback_User_Data* p, bool auto_free);
   void callback(Fl_Callback* cb, Fl_Callback_User_Data* p, Fl_Callback_User_Data_Dtor* dtor);
   void callback(Fl_Callback* cb);
   void callback(Fl_Callback0* cb);
   void callback(Fl_Callback1* cb, long p = 0);
-  void user_data(void* v);
+  void user_data(void* v, Fl_Callback_Free* free_cb = nullptr);
   void user_data(Fl_Callback_User_Data* v, bool auto_free);
   void user_data(Fl_Callback_User_Data* v, Fl_Callback_User_Data_Dtor* dtor);
   void argument(long v);

--- a/FL/Fl_Widget.H
+++ b/FL/Fl_Widget.H
@@ -729,11 +729,13 @@ public:
   // -- Callback setters
   void callback(Fl_Callback* cb, void* p);
   void callback(Fl_Callback* cb, Fl_Callback_User_Data* p, bool auto_free);
+  void callback(Fl_Callback* cb, Fl_Callback_User_Data* p, Fl_Callback_User_Data_Dtor* dtor);
   void callback(Fl_Callback* cb);
   void callback(Fl_Callback0* cb);
   void callback(Fl_Callback1* cb, long p = 0);
   void user_data(void* v);
   void user_data(Fl_Callback_User_Data* v, bool auto_free);
+  void user_data(Fl_Callback_User_Data* v, Fl_Callback_User_Data_Dtor* dtor);
   void argument(long v);
   // -- Callback getters
   Fl_Callback_p callback() const;

--- a/FL/Fl_Widget.H
+++ b/FL/Fl_Widget.H
@@ -165,7 +165,7 @@ protected:
         NEEDS_KEYBOARD  = 1<<20,  ///< set on touch screen devices if a widget needs a keyboard when it gets the focus. Reserved, not yet used in 1.4.0. \see Fl_Widget::needs_keyboard()
         IMAGE_BOUND     = 1<<21,  ///< binding the image to the widget will transfer ownership, so that the widget will delete the image when it is no longer needed
         DEIMAGE_BOUND   = 1<<22,  ///< bind the inactive image to the widget, so the widget deletes the image when it is no longer needed
-        AUTO_DELETE_USER_DATA = 1<<23, ///< automatically call `delete` on the user_data pointer when destroying this widget; if set, user_data must point to a class derived from the class Fl_Callback_User_Data
+        CALLBACK_IS_STDF= 1<<23, ///< automatically call `delete` on the user_data pointer when destroying this widget; if set, user_data must point to a class derived from the class Fl_Callback_User_Data
         MAXIMIZED       = 1<<24,  ///< a maximized Fl_Window
         POPUP           = 1<<25,  ///< popup window (i.e., positioned relatively to another mapped window)
         // Note to devs: add new FLTK core flags above this line (up to 1<<28).
@@ -176,6 +176,17 @@ protected:
         USERFLAG2       = 1<<30,  ///< reserved for 3rd party extensions
         USERFLAG1       = 1<<31   ///< reserved for 3rd party extensions
   };
+public:
+  /** Returns whether the callback is a std::ffunction */
+  bool callback_is_stdf() const { return flags() & CALLBACK_IS_STDF; }
+
+  /** The callback entry is a std::function. */
+  void set_callback_stdf() { set_flag(CALLBACK_IS_STDF); }
+
+  /** The callback entry is a "C" style function pointer. */
+  void clear_callback_stdf() { clear_flag(CALLBACK_IS_STDF); }
+protected:
+
   void draw_box() const;
   void draw_box(Fl_Boxtype t, Fl_Color c) const;
   void draw_box(Fl_Boxtype t, int x,int y,int w,int h, Fl_Color c) const;

--- a/src/Fl_File_Chooser.cxx
+++ b/src/Fl_File_Chooser.cxx
@@ -107,8 +107,7 @@ void Fl_File_Chooser::cb_okButton_i(Fl_Return_Button*, void*) {
   hide();
 
   // Do any callback that is registered...
-  if (callback_)
-    (*callback_)(this, data_);
+  do_callback();
 }
 void Fl_File_Chooser::cb_okButton(Fl_Return_Button* o, void* v) {
   ((Fl_File_Chooser*)(o->parent()->parent()->parent()->user_data()))->cb_okButton_i(o,v);
@@ -170,23 +169,28 @@ Fl_File_Chooser::Fl_File_Chooser(const char *pathname, const char *pattern, int 
     prefs_ = new Fl_Preferences(Fl_Preferences::CORE_USER, "fltk.org", "filechooser");
   }
   Fl_Group *prev_current = Fl_Group::current();
-  { window = new Fl_Double_Window(490, 380, "Choose File");
+  { auto* o = window = new Fl_Double_Window(490, 380, "Choose File");
+    (void)o;
     window->callback((Fl_Callback*)cb_window, (void*)(this));
-    { Fl_Group* o = new Fl_Group(10, 10, 470, 25);
-      { showChoice = new Fl_Choice(65, 10, 215, 25, "Show:");
+    { auto* o = new Fl_Group(10, 10, 470, 25);
+      (void)o;
+      { auto* o = showChoice = new Fl_Choice(65, 10, 215, 25, "Show:");
+        (void)o;
         showChoice->down_box(FL_BORDER_BOX);
         showChoice->labelfont(1);
         showChoice->callback((Fl_Callback*)cb_showChoice);
         Fl_Group::current()->resizable(showChoice);
         showChoice->label(show_label);
       } // Fl_Choice* showChoice
-      { favoritesButton = new Fl_Menu_Button(290, 10, 155, 25, "Favorites");
+      { auto* o = favoritesButton = new Fl_Menu_Button(290, 10, 155, 25, "Favorites");
+        (void)o;
         favoritesButton->down_box(FL_BORDER_BOX);
         favoritesButton->callback((Fl_Callback*)cb_favoritesButton);
         favoritesButton->align(Fl_Align(FL_ALIGN_LEFT|FL_ALIGN_INSIDE));
         favoritesButton->label(favorites_label);
       } // Fl_Menu_Button* favoritesButton
-      { Fl_Button* o = newButton = new Fl_Button(455, 10, 25, 25);
+      { auto* o = newButton = new Fl_Button(455, 10, 25, 25);
+        (void)o;
         newButton->image( image_new() );
         newButton->labelsize(8);
         newButton->callback((Fl_Callback*)cb_newButton);
@@ -194,15 +198,18 @@ Fl_File_Chooser::Fl_File_Chooser(const char *pathname, const char *pattern, int 
       } // Fl_Button* newButton
       o->end();
     } // Fl_Group* o
-    { Fl_Tile* o = new Fl_Tile(10, 45, 470, 225);
+    { auto* o = new Fl_Tile(10, 45, 470, 225);
+      (void)o;
       o->callback((Fl_Callback*)cb_);
-      { fileList = new Fl_File_Browser(10, 45, 295, 225);
+      { auto* o = fileList = new Fl_File_Browser(10, 45, 295, 225);
+        (void)o;
         fileList->type(2);
         fileList->box(FL_DOWN_BOX);
         fileList->callback((Fl_Callback*)cb_fileList);
         fileList->window()->hotspot(fileList);
       } // Fl_File_Browser* fileList
-      { errorBox = new Fl_Box(10, 45, 295, 225, "dynamic error display");
+      { auto* o = errorBox = new Fl_Box(10, 45, 295, 225, "dynamic error display");
+        (void)o;
         errorBox->box(FL_DOWN_BOX);
         errorBox->color(FL_BACKGROUND2_COLOR);
         errorBox->labelsize(18);
@@ -210,7 +217,8 @@ Fl_File_Chooser::Fl_File_Chooser(const char *pathname, const char *pattern, int 
         errorBox->align(Fl_Align(133|FL_ALIGN_INSIDE));
         errorBox->hide();
       } // Fl_Box* errorBox
-      { previewBox = new Fl_Box(305, 45, 175, 225, "?");
+      { auto* o = previewBox = new Fl_Box(305, 45, 175, 225, "?");
+        (void)o;
         previewBox->box(FL_DOWN_BOX);
         previewBox->labelsize(100);
         previewBox->align(Fl_Align(FL_ALIGN_CLIP|FL_ALIGN_INSIDE));
@@ -218,47 +226,58 @@ Fl_File_Chooser::Fl_File_Chooser(const char *pathname, const char *pattern, int 
       o->end();
       Fl_Group::current()->resizable(o);
     } // Fl_Tile* o
-    { Fl_Group* o = new Fl_Group(10, 275, 470, 95);
-      { Fl_Group* o = new Fl_Group(10, 275, 470, 20);
-        { previewButton = new Fl_Check_Button(10, 275, 105, 20, "Preview");
+    { auto* o = new Fl_Group(10, 275, 470, 95);
+      (void)o;
+      { auto* o = new Fl_Group(10, 275, 470, 20);
+        (void)o;
+        { auto* o = previewButton = new Fl_Check_Button(10, 275, 105, 20, "Preview");
+          (void)o;
           previewButton->shortcut(FL_ALT|'p');
           previewButton->down_box(FL_DOWN_BOX);
           previewButton->value(1);
           previewButton->callback((Fl_Callback*)cb_previewButton);
           previewButton->label(preview_label);
         } // Fl_Check_Button* previewButton
-        { showHiddenButton = new Fl_Check_Button(115, 275, 140, 20, "Show hidden files");
+        { auto* o = showHiddenButton = new Fl_Check_Button(115, 275, 140, 20, "Show hidden files");
+          (void)o;
           showHiddenButton->down_box(FL_DOWN_BOX);
           showHiddenButton->callback((Fl_Callback*)cb_showHiddenButton);
           showHiddenButton->label(hidden_label);
         } // Fl_Check_Button* showHiddenButton
-        { Fl_Box* o = new Fl_Box(255, 275, 225, 20);
+        { auto* o = new Fl_Box(255, 275, 225, 20);
+          (void)o;
           Fl_Group::current()->resizable(o);
         } // Fl_Box* o
         o->end();
       } // Fl_Group* o
-      { fileName = new Fl_File_Input(115, 300, 365, 35);
+      { auto* o = fileName = new Fl_File_Input(115, 300, 365, 35);
+        (void)o;
         fileName->labelfont(1);
         fileName->callback((Fl_Callback*)cb_fileName);
         fileName->when(FL_WHEN_ENTER_KEY);
         Fl_Group::current()->resizable(fileName);
         fileName->when(FL_WHEN_CHANGED | FL_WHEN_ENTER_KEY_ALWAYS);
       } // Fl_File_Input* fileName
-      { Fl_Box* o = new Fl_Box(10, 310, 105, 25, "Filename:");
+      { auto* o = new Fl_Box(10, 310, 105, 25, "Filename:");
+        (void)o;
         o->labelfont(1);
         o->align(Fl_Align(FL_ALIGN_RIGHT|FL_ALIGN_INSIDE));
         o->label(filename_label);
       } // Fl_Box* o
-      { Fl_Group* o = new Fl_Group(10, 345, 470, 25);
-        { okButton = new Fl_Return_Button(313, 345, 85, 25, "OK");
+      { auto* o = new Fl_Group(10, 345, 470, 25);
+        (void)o;
+        { auto* o = okButton = new Fl_Return_Button(313, 345, 85, 25, "OK");
+          (void)o;
           okButton->callback((Fl_Callback*)cb_okButton);
           okButton->label(fl_ok);
         } // Fl_Return_Button* okButton
-        { Fl_Button* o = cancelButton = new Fl_Button(408, 345, 72, 25, "Cancel");
+        { auto* o = cancelButton = new Fl_Button(408, 345, 72, 25, "Cancel");
+          (void)o;
           cancelButton->callback((Fl_Callback*)cb_cancelButton);
           o->label(fl_cancel);
         } // Fl_Button* cancelButton
-        { Fl_Box* o = new Fl_Box(10, 345, 30, 25);
+        { auto* o = new Fl_Box(10, 345, 30, 25);
+          (void)o;
           Fl_Group::current()->resizable(o);
         } // Fl_Box* o
         o->end();
@@ -269,37 +288,47 @@ Fl_File_Chooser::Fl_File_Chooser(const char *pathname, const char *pattern, int 
     if (title) window->label(title);
     window->end();
   } // Fl_Double_Window* window
-  { favWindow = new Fl_Double_Window(355, 150, "Manage Favorites");
+  { auto* o = favWindow = new Fl_Double_Window(355, 150, "Manage Favorites");
+    (void)o;
     favWindow->user_data((void*)(this));
-    { favList = new Fl_File_Browser(10, 10, 300, 95);
+    { auto* o = favList = new Fl_File_Browser(10, 10, 300, 95);
+      (void)o;
       favList->type(2);
       favList->callback((Fl_Callback*)cb_favList);
       Fl_Group::current()->resizable(favList);
     } // Fl_File_Browser* favList
-    { Fl_Group* o = new Fl_Group(320, 10, 25, 95);
-      { favUpButton = new Fl_Button(320, 10, 25, 25, "@8>");
+    { auto* o = new Fl_Group(320, 10, 25, 95);
+      (void)o;
+      { auto* o = favUpButton = new Fl_Button(320, 10, 25, 25, "@8>");
+        (void)o;
         favUpButton->callback((Fl_Callback*)cb_favUpButton);
       } // Fl_Button* favUpButton
-      { favDeleteButton = new Fl_Button(320, 45, 25, 25, "X");
+      { auto* o = favDeleteButton = new Fl_Button(320, 45, 25, 25, "X");
+        (void)o;
         favDeleteButton->labelfont(1);
         favDeleteButton->callback((Fl_Callback*)cb_favDeleteButton);
         Fl_Group::current()->resizable(favDeleteButton);
       } // Fl_Button* favDeleteButton
-      { favDownButton = new Fl_Button(320, 80, 25, 25, "@2>");
+      { auto* o = favDownButton = new Fl_Button(320, 80, 25, 25, "@2>");
+        (void)o;
         favDownButton->callback((Fl_Callback*)cb_favDownButton);
       } // Fl_Button* favDownButton
       o->end();
     } // Fl_Group* o
-    { Fl_Group* o = new Fl_Group(10, 113, 335, 29);
-      { favCancelButton = new Fl_Button(273, 115, 72, 25, "Cancel");
+    { auto* o = new Fl_Group(10, 113, 335, 29);
+      (void)o;
+      { auto* o = favCancelButton = new Fl_Button(273, 115, 72, 25, "Cancel");
+        (void)o;
         favCancelButton->callback((Fl_Callback*)cb_favCancelButton);
         favCancelButton->label(fl_cancel);
       } // Fl_Button* favCancelButton
-      { favOkButton = new Fl_Return_Button(181, 115, 79, 25, "Save");
+      { auto* o = favOkButton = new Fl_Return_Button(181, 115, 79, 25, "Save");
+        (void)o;
         favOkButton->callback((Fl_Callback*)cb_favOkButton);
         favOkButton->label(save_label);
       } // Fl_Return_Button* favOkButton
-      { Fl_Box* o = new Fl_Box(10, 115, 161, 25);
+      { auto* o = new Fl_Box(10, 115, 161, 25);
+        (void)o;
         Fl_Group::current()->resizable(o);
       } // Fl_Box* o
       o->end();
@@ -309,8 +338,6 @@ Fl_File_Chooser::Fl_File_Chooser(const char *pathname, const char *pattern, int 
     favWindow->label(manage_favorites_label);
     favWindow->end();
   } // Fl_Double_Window* favWindow
-  callback_ = 0;
-  data_ = 0;
   directory_[0] = 0;
   window->size_range(window->w(), window->h());
   type(type_val);
@@ -330,11 +357,6 @@ Fl_File_Chooser::~Fl_File_Chooser() {
   if(ext_group)window->remove(ext_group);
   delete window;
   delete favWindow;
-}
-
-void Fl_File_Chooser::callback(void (*cb)(Fl_File_Chooser *, void *), void *d ) {
-  callback_ = cb;
-  data_     = d;
 }
 
 void Fl_File_Chooser::color(Fl_Color c) {
@@ -437,14 +459,6 @@ void Fl_File_Chooser::type(int t) {
 
 int Fl_File_Chooser::type() {
   return (type_);
-}
-
-void * Fl_File_Chooser::user_data() const {
-  return (data_);
-}
-
-void Fl_File_Chooser::user_data(void *d) {
-  data_ = d;
 }
 
 int Fl_File_Chooser::visible() {

--- a/src/Fl_File_Chooser.fl
+++ b/src/Fl_File_Chooser.fl
@@ -1,5 +1,5 @@
 # data file for the Fltk User Interface Designer (fluid)
-version 1.0500
+version 1.050020
 header_name {../FL/Fl_File_Chooser.H}
 code_name {.cxx}
 include_guard {}
@@ -28,10 +28,13 @@ comment {//
 } {in_source in_header
 }
 
+decl {\#include <FL/Fl_Callback_Interface.H>} {selected public global
+}
+
 decl {\#include <FL/fl_draw.H>} {private local
 }
 
-class FL_EXPORT Fl_File_Chooser {open
+class FL_EXPORT Fl_File_Chooser {open : {public Fl_Callback_Interface<Fl_File_Chooser>}
 } {
   decl {enum Type {
     SINGLE    = 0, ///< Select a single, existing file.
@@ -46,10 +49,6 @@ Determines the type of file chooser presented to the user.
 } public local
   }
   decl {static Fl_Preferences *prefs_;} {private local
-  }
-  decl {void (*callback_)(Fl_File_Chooser*, void *);} {private local
-  }
-  decl {void *data_;} {private local
   }
   decl {char directory_[FL_PATH_MAX];} {private local
   }
@@ -87,9 +86,9 @@ Determines the type of file chooser presented to the user.
       label {Choose File}
       callback {fileName->value("");
 fileList->deselect();
-hide();} open selected
+hide();} open
       private xywh {467 276 490 380} type Double resizable
-      code0 {if (title) window->label(title);} modal visible
+      code3 {if (title) window->label(title);} modal visible
     } {
       Fl_Group {} {open
         private xywh {10 10 470 25}
@@ -98,19 +97,19 @@ hide();} open selected
           label {Show:}
           callback {showChoiceCB();} open
           private xywh {65 10 215 25} down_box BORDER_BOX labelfont 1 resizable
-          code0 {showChoice->label(show_label);}
+          code3 {showChoice->label(show_label);}
         } {}
         Fl_Menu_Button favoritesButton {
           label Favorites
           callback {favoritesButtonCB();} open
           private xywh {290 10 155 25} down_box BORDER_BOX align 20
-          code0 {favoritesButton->label(favorites_label);}
+          code3 {favoritesButton->label(favorites_label);}
         } {}
         Fl_Button newButton {
           callback {newdir();}
           image {new.xbm} compress_image 0 xywh {455 10 25 25} labelsize 8
           code0 {\#include <FL/Fl_Preferences.H>}
-          code1 {o->tooltip(new_directory_tooltip);}
+          code3 {o->tooltip(new_directory_tooltip);}
         }
       }
       Fl_Tile {} {
@@ -141,13 +140,13 @@ hide();} open selected
             label Preview
             callback {preview(previewButton->value());}
             xywh {10 275 105 20} down_box DOWN_BOX shortcut 0x80070 value 1
-            code0 {previewButton->label(preview_label);}
+            code3 {previewButton->label(preview_label);}
           }
           Fl_Check_Button showHiddenButton {
             label {Show hidden files}
             callback {showHidden(showHiddenButton->value());}
             xywh {115 275 140 20} down_box DOWN_BOX
-            code0 {showHiddenButton->label(hidden_label);}
+            code3 {showHiddenButton->label(hidden_label);}
           }
           Fl_Box {} {
             private xywh {255 275 225 20} resizable
@@ -156,12 +155,12 @@ hide();} open selected
         Fl_File_Input fileName {
           callback {fileNameCB();}
           private xywh {115 300 365 35} labelfont 1 when 8 resizable
-          code0 {fileName->when(FL_WHEN_CHANGED | FL_WHEN_ENTER_KEY_ALWAYS);}
+          code3 {fileName->when(FL_WHEN_CHANGED | FL_WHEN_ENTER_KEY_ALWAYS);}
         }
         Fl_Box {} {
           label {Filename:}
           private xywh {10 310 105 25} labelfont 1 align 24
-          code0 {o->label(filename_label);}
+          code3 {o->label(filename_label);}
         }
         Fl_Group {} {open
           private xywh {10 345 470 25}
@@ -171,11 +170,10 @@ hide();} open selected
             callback {hide();
 
 // Do any callback that is registered...
-if (callback_)
-  (*callback_)(this, data_);}
+do_callback();}
             private xywh {313 345 85 25}
             code0 {\#include <FL/fl_ask.H>}
-            code1 {okButton->label(fl_ok);}
+            code3 {okButton->label(fl_ok);}
           }
           Fl_Button cancelButton {
             label Cancel
@@ -183,7 +181,7 @@ if (callback_)
 fileList->deselect();
 hide();}
             private xywh {408 345 72 25}
-            code0 {o->label(fl_cancel);}
+            code3 {o->label(fl_cancel);}
           }
           Fl_Box {} {
             private xywh {10 345 30 25} resizable
@@ -194,7 +192,7 @@ hide();}
     Fl_Window favWindow {
       label {Manage Favorites}
       private xywh {0 0 355 150} type Double hide resizable
-      code0 {favWindow->label(manage_favorites_label);} modal size_range {181 150 0 0}
+      code3 {favWindow->label(manage_favorites_label);} modal size_range {181 150 0 0}
     } {
       Fl_File_Browser favList {
         callback {favoritesCB(favList);}
@@ -226,23 +224,21 @@ hide();}
           label Cancel
           callback {favWindow->hide();}
           private xywh {273 115 72 25}
-          code0 {favCancelButton->label(fl_cancel);}
+          code3 {favCancelButton->label(fl_cancel);}
         }
         Fl_Return_Button favOkButton {
           label Save
           callback {favoritesCB(favOkButton);}
           private xywh {181 115 79 25}
           code0 {\#include <FL/fl_ask.H>}
-          code1 {favOkButton->label(save_label);}
+          code3 {favOkButton->label(save_label);}
         }
         Fl_Box {} {
           xywh {10 115 161 25} resizable
         }
       }
     }
-    code {callback_ = 0;
-data_ = 0;
-directory_[0] = 0;
+    code {directory_[0] = 0;
 window->size_range(window->w(), window->h());
 type(type_val);
 filter(pattern);
@@ -261,11 +257,6 @@ Fl_Group::current(prev_current);} {}
 if(ext_group)window->remove(ext_group);
 delete window;
 delete favWindow;} {}
-  }
-  Function {callback(void (*cb)(Fl_File_Chooser *, void *), void *d = 0)} {return_type void
-  } {
-    code {callback_ = cb;
-data_     = d;} {}
   }
   Function {color(Fl_Color c)} {} {
     code {fileList->color(c);} {}
@@ -389,14 +380,6 @@ else
   Function {type()} {return_type int
   } {
     code {return (type_);} {}
-  }
-  Function {user_data() const} {return_type {void *}
-  } {
-    code {return (data_);} {}
-  }
-  Function {user_data(void *d)} {return_type void
-  } {
-    code {data_ = d;} {}
   }
   decl {const char *value(int f = 1);} {public local
   }

--- a/src/Fl_File_Chooser.fl
+++ b/src/Fl_File_Chooser.fl
@@ -28,7 +28,7 @@ comment {//
 } {in_source in_header
 }
 
-decl {\#include <FL/Fl_Callback_Interface.H>} {selected public global
+decl {\#include <FL/Fl_Callback_Interface.H>} {public global
 }
 
 decl {\#include <FL/fl_draw.H>} {private local
@@ -75,6 +75,8 @@ Determines the type of file chooser presented to the user.
   decl {void update_favorites();} {private local
   }
   decl {void update_preview();} {private local
+  }
+  decl {bool callback_is_stdf_ = false;} {private local
   }
   Function {Fl_File_Chooser(const char *pathname, const char *pattern, int type_val, const char *title)} {open
   } {
@@ -258,6 +260,12 @@ if(ext_group)window->remove(ext_group);
 delete window;
 delete favWindow;} {}
   }
+  Function {callback_is_stdf() const { return callback_is_stdf_; }} {open selected return_type bool
+  } {}
+  Function {set_callback_stdf() { callback_is_stdf_ = true; }} {open
+  } {}
+  Function {clear_callback_stdf() { callback_is_stdf_ = false; }} {open
+  } {}
   Function {color(Fl_Color c)} {} {
     code {fileList->color(c);} {}
   }

--- a/src/Fl_File_Chooser2.cxx
+++ b/src/Fl_File_Chooser2.cxx
@@ -696,7 +696,7 @@ Fl_File_Chooser::fileListCB()
     {
       // Hide the window - picked the file...
       window->hide();
-      if (callback_) (*callback_)(this, data_);
+      do_callback();
     }
   }
   else
@@ -741,7 +741,7 @@ Fl_File_Chooser::fileListCB()
     Fl::add_timeout(1.0, (Fl_Timeout_Handler)previewCB, this);
 
     // Do any callback that is registered...
-    if (callback_) (*callback_)(this, data_);
+    do_callback();
 
     // Activate the OK button as needed...
     if (!Fl::system_driver()->filename_isdir_quick(pathname) || (type_ & DIRECTORY))
@@ -817,7 +817,7 @@ Fl_File_Chooser::fileNameCB()
         update_preview();
 
         // Do any callback that is registered...
-        if (callback_) (*callback_)(this, data_);
+        do_callback();
 
         // Hide the window to signal things are done...
         window->hide();

--- a/src/Fl_Widget.cxx
+++ b/src/Fl_Widget.cxx
@@ -212,8 +212,6 @@ Fl_Widget::Fl_Widget(int X, int Y, int W, int H, const char* L) {
   label_.h_margin_ = label_.v_margin_ = 0;
   label_.spacing   = 0;
   tooltip_         = 0;
-  callback_        = default_callback;
-  user_data_       = 0;
   type_            = 0;
   flags_           = VISIBLE_FOCUS;
   damage_          = 0;
@@ -223,6 +221,7 @@ Fl_Widget::Fl_Widget(int X, int Y, int W, int H, const char* L) {
   when_            = FL_WHEN_RELEASE;
 
   parent_ = nullptr;
+  callback(default_callback);
   if (Fl_Group::current()) Fl_Group::current()->add(this);
 }
 
@@ -271,9 +270,8 @@ Fl_Widget::~Fl_Widget() {
   parent_ = 0; // Don't throw focus to a parent widget.
   fl_throw_focus(this);
   // remove stale entries from default callback queue (Fl::readqueue())
-  if (callback_ == default_callback) cleanup_readqueue(this);
-  if ( (flags_ & AUTO_DELETE_USER_DATA) && user_data_)
-    delete (Fl_Callback_User_Data*)user_data_;
+  if (callback() == default_callback) cleanup_readqueue(this);
+  // Fl_Callback_Interface will clean up user_data if necessary.
 }
 
 /**
@@ -470,35 +468,128 @@ void Fl_Widget::bind_deimage(Fl_Image* img) {
  */
 void Fl_Widget::do_callback(Fl_Widget *widget, void *arg, Fl_Callback_Reason reason) {
   Fl::callback_reason_ = reason;
-  if (!callback_) return;
+  if (!callback()) return;
   Fl_Widget_Tracker wp(this);
-  callback_(widget, arg);
+  callback()(widget, arg);
   if (wp.deleted()) return;
-  if (callback_ != default_callback)
+  if (callback() != default_callback)
     clear_changed();
 }
 
-/*
- \brief Sets the user data for this widget.
- Sets the new user data (void *) argument that is passed to the callback function.
- \param[in] v new user data
- */
-void Fl_Widget::user_data(void* v) {
-  if ((flags_ & AUTO_DELETE_USER_DATA) && user_data_)
-    delete (Fl_Callback_User_Data*)user_data_;
-  clear_flag(AUTO_DELETE_USER_DATA);
-  user_data_ = v;
-}
+#ifdef FL_DOXYGEN
 
-/*
- \brief Sets the user data for this widget.
- Sets the new user data (void *) argument that is passed to the callback function.
- \param[in] v new user data
- \param[in] auto_free if set, the widget will free user data when destroyed; defaults to false
- */
-void Fl_Widget::user_data(Fl_Callback_User_Data* v, bool auto_free) {
-  user_data((void*)v);
-  if (auto_free)
-    set_flag(AUTO_DELETE_USER_DATA);
-}
+/**
+  \fn Fl_Callback_p Fl_Widget::callback() const
+  Gets the current callback function for the widget.
+  Each widget has a single callback.
+  \return current callback
+*/
 
+/**
+  \fn void Fl_Widget::callback(Fl_Callback* cb, void* p)
+  Sets the current callback function and data for the widget.
+  Each widget has a single callback.
+  \param[in] cb new callback
+  \param[in] p user data
+*/
+
+/**
+  \fn void Fl_Widget::callback(Fl_Callback* cb, Fl_Callback_User_Data* p, bool auto_free)
+  Sets the current callback function and managed user data for the widget.
+  Setting auto_free will transfer ownership of the callback user data to the
+  widget. Deleting the widget will then also delete the user data.
+  \param[in] cb new callback
+  \param[in] p user data
+  \param[in] auto_free if set, the widget will free user data when destroyed
+*/
+
+/**
+  \fn void Fl_Widget::callback(Fl_Callback* cb)
+  Sets the current callback function for the widget.
+  Each widget has a single callback.
+  \param[in] cb new callback
+*/
+
+/**
+  \fn void Fl_Widget::callback(Fl_Callback0* cb)
+  Sets the current callback function for the widget.
+  Each widget has a single callback.
+  \param[in] cb new callback
+*/
+
+/**
+  \fn void Fl_Widget::callback(Fl_Callback1* cb, long p = 0)
+  Sets the current callback function for the widget.
+  Each widget has a single callback.
+  \param[in] cb new callback
+  \param[in] p user data
+*/
+
+/**
+  \fn void* Fl_Widget::user_data() const
+  Gets the user data for this widget.
+  Gets the current user data (void *) argument that is passed to the callback function.
+  \return user data as a pointer
+*/
+
+/**
+  \fn void Fl_Widget::user_data(void* v)
+  \brief Sets the user data for this widget.
+  Sets the new user data (void *) argument that is passed to the callback function.
+  \param[in] v new user data
+*/
+
+/**
+  \fn void Fl_Widget::user_data(Fl_Callback_User_Data* v, bool auto_free)
+  \brief Sets the user data for this widget.
+  Sets the new user data (void *) argument that is passed to the callback function.
+  \param[in] v new user data
+  \param[in] auto_free if set, the widget will free user data when destroyed; defaults to false
+*/
+
+/**
+  \fn long Fl_Widget::argument() const
+  Gets the current user data (long) argument that is passed to the callback function.
+
+  \note On platforms with <tt>sizeof(long) \< sizeof(void*)</tt>, particularly
+        on Windows 64-bit platforms, this method can truncate stored addresses
+        \p (void*) to the size of a \p long value. Use with care and only
+        if you are sure that the stored user_data value fits in a \p long
+        value because it was stored with argument(long) or another method
+        using only \p long values. You may want to use user_data() instead.
+
+  \see user_data()
+*/
+
+/**
+  \fn void Fl_Widget::argument(long v)
+  Sets the current user data (long) argument that is passed to the callback function.
+  \see argument()
+*/
+
+/**
+   \fn void Fl_Widget::do_callback(Fl_Callback_Reason reason=FL_REASON_UNKNOWN)
+  Calls the widget callback function with default arguments.
+
+  This is the same as calling
+  \code
+  do_callback(this, user_data(), reason);
+  \endcode
+
+  \param[in] reason give a reason to why this callback was called, defaults to \ref FL_REASON_UNKNOWN
+
+  \see callback()
+  \see do_callback(Fl_Widget *widget, void *data, Fl_Callback_Reason reason), Fl_Callback_Reason
+*/
+
+/**
+  \fn void Fl_Widget::do_callback(Fl_Widget *widget, long arg, Fl_Callback_Reason reason=FL_REASON_UNKNOWN)
+  Calls the widget callback function with arbitrary arguments.
+  \param[in] widget call the callback with \p widget as the first argument
+  \param[in] arg call the callback with \p arg as the user data (second) argument
+  \param[in] reason give a reason to why this callback was called, defaults to \ref FL_REASON_UNKNOWN
+  \see callback()
+  \see do_callback(Fl_Widget *widget, void *data), Fl_Callback_Reason
+*/
+
+#endif // FL_DOXYGEN

--- a/src/Fl_Widget.cxx
+++ b/src/Fl_Widget.cxx
@@ -466,19 +466,10 @@ void Fl_Widget::bind_deimage(Fl_Image* img) {
  \see class Fl_Widget_Tracker
  \see Fl::callback_reason()
  */
-void Fl_Widget::do_callback(Fl_Widget *widget, void *arg, Fl_Callback_Reason reason) {
-  Fl::callback_reason_ = reason;
+void Fl_Widget::do_callback(Fl_Widget *widget, void *arg, Fl_Callback_Reason reason)
+{
   if (!callback()) return;
-
-    // if (static_cast<T*>(this)->callback_is_stdf()) {
-    //   if (!callback_interface_.stdf_callback_) return;
-    //   callback_interface_.stdf_callback_();
-    // } else {
-    //   if (!callback_interface_.callback_) return;
-    //   callback_interface_.callback_(widget, arg);
-    // }
-
-
+  Fl::callback_reason_ = reason;
   Fl_Widget_Tracker wp(this);
   if (callback_is_stdf()) {
     callback_interface_.stdf_callback_();
@@ -547,6 +538,13 @@ void Fl_Widget::do_callback(Fl_Widget *widget, void *arg, Fl_Callback_Reason rea
   Each widget has a single callback.
   \param[in] cb new callback
   \param[in] p user data
+*/
+
+/**
+  \fn void Fl_Widget::callback(std::function<void()> cb)
+  Sets the current callback function for the widget using a std::function.
+  Each widget has a single callback.
+  \param[in] cb new callback
 */
 
 /**

--- a/src/Fl_Widget.cxx
+++ b/src/Fl_Widget.cxx
@@ -504,6 +504,15 @@ void Fl_Widget::do_callback(Fl_Widget *widget, void *arg, Fl_Callback_Reason rea
 */
 
 /**
+  \fn void Fl_Widget::callback(Fl_Callback* cb, Fl_Callback_User_Data* p, Fl_Callback_User_Data_Dtor* dtor)
+  Sets the current callback function and managed user data for the widget.
+  The destructor callback is used to free the user data when the widget is deleted.
+  \param[in] cb new callback
+  \param[in] p user data
+  \param[in] dtor destructor callback for the user data
+*/
+
+/**
   \fn void Fl_Widget::callback(Fl_Callback* cb)
   Sets the current callback function for the widget.
   Each widget has a single callback.
@@ -545,6 +554,15 @@ void Fl_Widget::do_callback(Fl_Widget *widget, void *arg, Fl_Callback_Reason rea
   Sets the new user data (void *) argument that is passed to the callback function.
   \param[in] v new user data
   \param[in] auto_free if set, the widget will free user data when destroyed; defaults to false
+*/
+
+/**
+  \fn void Fl_Widget::user_data(Fl_Callback_User_Data* v, Fl_Callback_User_Data_Dtor* dtor)
+  \brief Sets the user data for this widget.
+  Sets the new user data to an object derived of the Fl_Callback_User_Data class.
+  The destructor callback is used to free the user data when the widget is deleted.
+  \param[in] v new user data
+  \param[in] dtor destructor callback for the user data
 */
 
 /**

--- a/src/Fl_Widget.cxx
+++ b/src/Fl_Widget.cxx
@@ -472,7 +472,7 @@ void Fl_Widget::do_callback(Fl_Widget *widget, void *arg, Fl_Callback_Reason rea
   Fl::callback_reason_ = reason;
   Fl_Widget_Tracker wp(this);
   if (callback_is_stdf()) {
-    callback_interface_.stdf_callback_();
+    callback_data_.stdf_callback_();
   } else {
     callback()(widget, arg);
   }

--- a/src/Fl_Widget.cxx
+++ b/src/Fl_Widget.cxx
@@ -486,11 +486,12 @@ void Fl_Widget::do_callback(Fl_Widget *widget, void *arg, Fl_Callback_Reason rea
 */
 
 /**
-  \fn void Fl_Widget::callback(Fl_Callback* cb, void* p)
+  \fn void Fl_Widget::callback(Fl_Callback* cb, void* p, Fl_Callback_Free* free_cb = nullptr)
   Sets the current callback function and data for the widget.
   Each widget has a single callback.
   \param[in] cb new callback
   \param[in] p user data
+  \param[in] free_cb optional free callback for the user data
 */
 
 /**
@@ -542,10 +543,11 @@ void Fl_Widget::do_callback(Fl_Widget *widget, void *arg, Fl_Callback_Reason rea
 */
 
 /**
-  \fn void Fl_Widget::user_data(void* v)
+  \fn void Fl_Widget::user_data(void* v, Fl_Callback_Free* free_cb = nullptr)
   \brief Sets the user data for this widget.
   Sets the new user data (void *) argument that is passed to the callback function.
   \param[in] v new user data
+  \param[in] free_cb optional free callback for the user data
 */
 
 /**

--- a/src/Fl_Widget.cxx
+++ b/src/Fl_Widget.cxx
@@ -469,8 +469,22 @@ void Fl_Widget::bind_deimage(Fl_Image* img) {
 void Fl_Widget::do_callback(Fl_Widget *widget, void *arg, Fl_Callback_Reason reason) {
   Fl::callback_reason_ = reason;
   if (!callback()) return;
+
+    // if (static_cast<T*>(this)->callback_is_stdf()) {
+    //   if (!callback_interface_.stdf_callback_) return;
+    //   callback_interface_.stdf_callback_();
+    // } else {
+    //   if (!callback_interface_.callback_) return;
+    //   callback_interface_.callback_(widget, arg);
+    // }
+
+
   Fl_Widget_Tracker wp(this);
-  callback()(widget, arg);
+  if (callback_is_stdf()) {
+    callback_interface_.stdf_callback_();
+  } else {
+    callback()(widget, arg);
+  }
   if (wp.deleted()) return;
   if (callback() != default_callback)
     clear_changed();


### PR DESCRIPTION
@Albrecht-S @ManoloFLTK @RokerHRO @erco77 

As discussed in #1442, this is another proposal for adding std::function as a callback option. It's type safe, convenient, and removes UB function pointer casting. Capturing lambdas are available since C++11.

This implementation uses a template class to create an interface that can be used with any class that needs a callback interface, and is not derived from Fl_Widget (Fl_File_Chooser, for example).

In phase 1, I implemented the basic idea without changing the API at all. Feedback is highly appreciated. Commit 1 is tested on macOS with all apps in test and Fluid and compiles without any new warnings.

In phase 2, I added the Fl_Callback_Interface to Fl_File_Chooser. This works well and is easy to implement, just as planned.

Phase 3 adds a user data destructor callback as discussed in #1442 for both Fl_Callback_User_Data and void* callbacks. Fl_Widget size increases from 2 words for old-style callback to 3 words by adding the second callback.

In phase 4, I added std::function as a new callback option without changing the logic of the old callback system. Fl_Widget size increase from 3 words to 4 words.This requires Fl_Widget to implement a simple on/off flag. If I don;t do that, alignment will require a 5th word in the worst case.

📍<- you are here

Phase 5 is optional because it may break the API, but fixes ambiguities and undefined behavior in our current code. For example, casting `void()(Fl_Widget*, long)` to `void()(Fl_Widget*, void*)` is UB 